### PR TITLE
mp/sim: extract asteroid + bullet ballistics (Phase 1, agent E)

### DIFF
--- a/js/modules/enemy/enemy-bullet.js
+++ b/js/modules/enemy/enemy-bullet.js
@@ -2,6 +2,12 @@
 import { GameDimensions, bakedBulletSpriteCache } from '../core/utils.js';
 import { ENEMY_BULLET_CONFIG, GAME_CONFIG } from '../core/constants.js';
 import { frameClock } from '../core/frame-clock.js';
+// Phase-1 multiplayer engine refactor: enemy-bullet ballistics extracted
+// to `js/sim/bullet.js`. The wrapper in `update()` below builds a
+// plain-data `BulletState` from `this`, calls `updateEnemyBullet`, and
+// writes the result back. Behavior is byte-for-byte equivalent to the
+// legacy inline code (per-shape velocity, lifetime, despawn).
+import { updateEnemyBullet } from '../../sim/bullet.js';
 
 // 5.79.2 — Map enemy-bullet shape names to bullet-atlas slot names.
 //   When a shape has an entry here, the WebGL bullet renderer takes
@@ -97,10 +103,9 @@ export class EnemyBullet {
     update() {
         if (!this.active) return;
 
-        // OPT: ring buffer trail insert — O(1).
-        // 5.79.4 — Reuse the slot's {x,y} object instead of allocating
-        //   one per frame per bullet. ~6 000 obj/sec saved at heavy
-        //   density.
+        // ── Trail ring-buffer (presentation; runs BEFORE physics so
+        // the trail captures the pre-move position). Reuses the slot's
+        // {x,y} object — no allocation.
         let slot = this.trail[this.trailHead];
         if (!slot) {
             slot = { x: 0, y: 0 };
@@ -110,68 +115,123 @@ export class EnemyBullet {
         slot.y = this.y;
         this.trailHead = (this.trailHead + 1) % this.trailLength;
         if (this.trailCount < this.trailLength) this.trailCount++;
-        
-        // Apply movement pattern
-        this.applyMovementPattern();
-        
-        // Update position (scaled for tick rate)
-        const ts = GAME_CONFIG.TICK_SCALE;
-        this.x += this.vel.x * ts;
-        this.y += this.vel.y * ts;
 
-        // Update rotation
-        this.rotation += this.rotationSpeed * ts;
-
-        // Update pattern timer
-        this.patternTimer += GAME_CONFIG.LOGIC_TICK_MS / 1000;
-        
-        // Homing mine health-based death
-        if (this.shape === 'mine' && this.health !== undefined && this.health <= 0) {
-            this.active = false;
-            return;
+        // ── Pure-sim physics step (extracted to js/sim/bullet.js) ──
+        // Reusable scratch state — avoid per-tick allocation.
+        if (!this._eBulletScratch) {
+            this._eBulletScratch = {
+                id: 0, kind: 'enemy', shape: null, movementPattern: 'aimed',
+                x: 0, y: 0, vx: 0, vy: 0,
+                startX: 0, startY: 0, baseVx: 0, baseVy: 0,
+                angle: 0, rotation: 0, rotationSpeed: 0,
+                life: 1.0, maxLife: 0, fadeFactor: 1.0,
+                damage: 0, radius: 0, baseRadius: 0,
+                maxRange: 0, rangeMultiplier: 1.0,
+                active: true, owner: null,
+                homing: false, homingStrength: 0,
+                helixActive: false, helixFreq: 0, helixPhase: 0, helixAmplitude: 0,
+                piercing: 0, piercedEnemies: 0,
+                explosive: false, explosionRadius: 0,
+                patternTimer: 0, patternPhase: 0,
+                isPersistent: false, maxLifetimeOverride: undefined,
+                creationTime: 0, targetPlayer: null, bossRageHoming: false,
+                sinePhase: 0, sineFreq: 0, sineAmp: 0, sinePerpX: 0, sinePerpY: 0,
+                health: undefined, maxHealth: undefined,
+                rocketSpeed: undefined, maxDistance: undefined, distanceTraveled: undefined,
+                deceleration: undefined, minSpeed: undefined, slashProgress: 0,
+                expiredByRange: false, expiredByBounds: false, expiredByDistance: false,
+            };
         }
-
-        // Persistent bullets (mines, lightning orbs) use time-based lifetime
-        if (this.isPersistent) {
-            const maxLife = this.maxLifetimeOverride || 15000;
-            const age = frameClock.now - this.creationTime;
-            if (age > maxLife) {
-                this.active = false;
-                return;
-            }
-            // Mines stay full opacity; other persistent bullets fade over final 40%
-            if (this.shape === 'mine') {
-                this.life = 1.0;
-            } else {
-                const progress = age / maxLife;
-                this.life = progress < 0.6 ? 1.0 : 1.0 - (progress - 0.6) / 0.4;
-            }
+        if (!this._eBulletCtx) {
+            this._eBulletCtx = {
+                tickScale: GAME_CONFIG.TICK_SCALE,
+                logicTickSeconds: GAME_CONFIG.LOGIC_TICK_MS / 1000,
+                bulletSpeed: GAME_CONFIG.BULLET_SPEED,
+                boundaryWidth: 0, boundaryHeight: 0,
+                now: 0,
+                targetPlayer: null, homingTarget: null,
+                rngFloat: Math.random,
+            };
+        }
+        const sb = this._eBulletScratch;
+        sb.shape = this.shape || null;
+        sb.movementPattern = this.movementPattern;
+        sb.x = this.x; sb.y = this.y;
+        sb.vx = this.vel.x; sb.vy = this.vel.y;
+        sb.startX = this.startX; sb.startY = this.startY;
+        sb.baseVx = this.baseVel ? this.baseVel.x : 0;
+        sb.baseVy = this.baseVel ? this.baseVel.y : 0;
+        sb.rotation = this.rotation;
+        sb.rotationSpeed = this.rotationSpeed;
+        sb.life = this.life;
+        sb.damage = this.damage;
+        sb.radius = this.radius;
+        sb.maxRange = this.maxRange;
+        sb.active = this.active;
+        sb.patternTimer = this.patternTimer;
+        sb.patternPhase = this.patternPhase;
+        sb.isPersistent = this.isPersistent;
+        sb.maxLifetimeOverride = this.maxLifetimeOverride;
+        sb.creationTime = this.creationTime;
+        sb.targetPlayer = this.targetPlayer;
+        sb.bossRageHoming = this.bossRageHoming;
+        sb.sinePhase = this.sinePhase;
+        sb.sineFreq = this.sineFreq;
+        sb.sineAmp = this.sineAmp;
+        sb.sinePerpX = this.sinePerpX;
+        sb.sinePerpY = this.sinePerpY;
+        sb.health = this.health;
+        sb.maxHealth = this.maxHealth;
+        sb.rocketSpeed = this.rocketSpeed;
+        sb.maxDistance = this.maxDistance;
+        sb.distanceTraveled = this.distanceTraveled;
+        // Resolve missile_decelerate constants from PROWLER_PIKE config
+        // (the legacy code did this lazily inside applyMovementPattern).
+        if (this.movementPattern === 'missile_decelerate') {
+            const cfg = ENEMY_BULLET_CONFIG.MISSILE && ENEMY_BULLET_CONFIG.MISSILE.PROWLER_PIKE;
+            sb.deceleration = this.deceleration !== undefined
+                ? this.deceleration
+                : (cfg ? cfg.DECELERATION : undefined);
+            sb.minSpeed = cfg ? cfg.MIN_SPEED : undefined;
         } else {
-            // Distance-based range — bullet fades and dies after traveling maxRange
-            const dist = Math.hypot(this.x - this.startX, this.y - this.startY);
-            const progress = dist / this.maxRange; // 0 → 1
-
-            if (progress >= 1.0) {
-                this.createDisappearEffect();
-                this.active = false;
-                return;
-            }
-
-            // life stays 1.0 for first 65%, then fades 1.0→0.5 over final 35%
-            this.life = progress < 0.65
-                ? 1.0
-                : 1.0 - (progress - 0.65) / 0.35 * 0.5; // 1.0 → 0.5
+            sb.deceleration = this.deceleration;
+            sb.minSpeed = this.minSpeed;
         }
-        
-        // Check bounds - recycle if off screen (use gameField dimensions)
-        const margin = 50;
-        const fieldWidth = GameDimensions.width;
-        const fieldHeight = GameDimensions.height;
-        
-        if (this.x < -margin || this.x > fieldWidth + margin ||
-            this.y < -margin || this.y > fieldHeight + margin) {
-            // Don't create disappear effect for off-screen bullets (too far away to see)
-            this.active = false; // Will be recycled by pool manager
+        sb.slashProgress = this.slashProgress || 0;
+        sb.expiredByRange = false;
+        sb.expiredByBounds = false;
+        sb.expiredByDistance = false;
+
+        const ctx = this._eBulletCtx;
+        ctx.boundaryWidth = GameDimensions.width;
+        ctx.boundaryHeight = GameDimensions.height;
+        ctx.now = frameClock.now;
+        ctx.targetPlayer = this.targetPlayer;
+
+        updateEnemyBullet(sb, ctx, null);
+
+        // Write outputs back.
+        this.x = sb.x; this.y = sb.y;
+        this.vel.x = sb.vx; this.vel.y = sb.vy;
+        this.rotation = sb.rotation;
+        this.life = sb.life;
+        this.damage = sb.damage;
+        this.radius = sb.radius;
+        this.patternTimer = sb.patternTimer;
+        this.sinePhase = sb.sinePhase;
+        this.distanceTraveled = sb.distanceTraveled;
+
+        if (!sb.active) {
+            this.active = false;
+            // Translate sim-emitted despawn flags into legacy FX calls.
+            // expiredByRange spawns the disappear puff; expiredByDistance
+            // (titan_rocket / missile_decelerate) spawns an explosion;
+            // expiredByBounds is silent (too far away to see).
+            if (sb.expiredByRange) {
+                this.createDisappearEffect();
+            } else if (sb.expiredByDistance) {
+                this.createExplosionEffect();
+            }
         }
     }
     

--- a/js/modules/player/bullet.js
+++ b/js/modules/player/bullet.js
@@ -1,6 +1,12 @@
 // Bullet projectile entity
 import { GAME_CONFIG } from '../core/constants.js';
 import { wrap, random, bakedBulletSpriteCache } from '../core/utils.js';
+// Phase-1 multiplayer engine refactor: bullet ballistics extracted to
+// `js/sim/bullet.js`. The wrapper in `update()` below builds a plain-
+// data `BulletState` from `this`, calls `updatePlayerBullet`, and
+// writes the result back. Behavior is byte-for-byte equivalent to the
+// legacy inline code.
+import { updatePlayerBullet } from '../../sim/bullet.js';
 
 export class Bullet {
     constructor() {
@@ -76,34 +82,9 @@ export class Bullet {
     update(particlePool, asteroidPool, enemyPool = null, gameEngine = null, gameField = null) {
         if (!this.active) return;
 
-        this.life++;
-
-        // Lifetime expiry — shrink + puff when range is exhausted
-        const effectiveMaxLife = Math.round(this.maxLife * this.rangeMultiplier);
-        if (this.life >= effectiveMaxLife) {
-            this.createDisappearPuff(gameEngine);
-            this.active = false;
-            if (this.onOffScreen) this.onOffScreen();
-            return;
-        }
-
-        // Compute fade factor for final 35% of life (used by draw)
-        const remaining = 1 - this.life / effectiveMaxLife;
-        this.fadeFactor = remaining < 0.35 ? remaining / 0.35 : 1.0;
-        // Shrink radius during fade
-        this.radius = this.baseRadius * (0.3 + 0.7 * this.fadeFactor);
-
-        // Homing behavior - can target both enemies and asteroids
-        if (this.homing) {
-            this.applyHoming(enemyPool, asteroidPool, gameEngine);
-        }
-
-        // OPT: ring buffer trail — O(1) insert, no shifting.
-        // 5.79.4 — Reuse the existing slot's {x, y} object instead of
-        //   allocating a fresh one each frame. With ~150 player bullets
-        //   on heavy fights this saves ~9 000 short-lived objects/sec
-        //   off the GC's young generation. Same data layout downstream
-        //   (drawTrail still reads .x / .y).
+        // ── Trail ring-buffer (presentation; runs BEFORE physics so
+        // the trail captures the pre-move position, matching legacy
+        // ordering). Reuses the existing slot's {x,y} object.
         let slot = this.trail[this.trailHead];
         if (!slot) {
             slot = { x: 0, y: 0 };
@@ -114,37 +95,135 @@ export class Bullet {
         this.trailHead = (this.trailHead + 1) % this.maxTrailLength;
         if (this.trailCount < this.maxTrailLength) this.trailCount++;
 
-        // Movement
-        this.x += this.vel.x;
-        this.y += this.vel.y;
-
-        // Helix offset — Rail Driver double-helix bullets oscillate
-        // perpendicular to their rail axis. We apply the *delta* of the
-        // sine each frame so the underlying rail position still advances
-        // by `vel` exactly. A pair of bullets fired with phases 0 and π
-        // crosses over every half period.
-        if (this.helixActive) {
-            const speed = Math.hypot(this.vel.x, this.vel.y) || 1;
-            // Perpendicular unit vector (rotate vel by +90°).
-            const ux = -this.vel.y / speed;
-            const uy =  this.vel.x / speed;
-            const t = this.life;
-            const sNow  = Math.sin(t       * this.helixFreq + this.helixPhase);
-            const sPrev = Math.sin((t - 1) * this.helixFreq + this.helixPhase);
-            const delta = (sNow - sPrev) * this.helixAmplitude;
-            this.x += ux * delta;
-            this.y += uy * delta;
+        // ── Pre-physics homing-target pick (presentation-adjacent —
+        // it reads from entity pools and the input-handler cursor).
+        // Done in the wrapper so the pure sim stays free of pool /
+        // input-handler imports.
+        let homingTarget = null;
+        if (this.homing) {
+            homingTarget = this._pickHomingTarget(enemyPool, asteroidPool, gameEngine);
         }
 
-        // Boundary check (bullets disappear when off game field or screen)
-        const boundaryWidth = gameField ? gameField.width : this.width;
-        const boundaryHeight = gameField ? gameField.height : this.height;
+        // ── Pure-sim physics step (extracted to js/sim/bullet.js) ──
+        // Reusable scratch state — avoid per-tick allocation.
+        if (!this._bulletScratch) {
+            this._bulletScratch = {
+                id: 0, kind: 'player', shape: null, movementPattern: 'aimed',
+                x: 0, y: 0, vx: 0, vy: 0,
+                startX: 0, startY: 0, baseVx: 0, baseVy: 0,
+                angle: 0, rotation: 0, rotationSpeed: 0,
+                life: 0, maxLife: 0, fadeFactor: 1.0,
+                damage: 1, radius: 0, baseRadius: 0,
+                maxRange: 0, rangeMultiplier: 1.0,
+                active: true, owner: null,
+                homing: false, homingStrength: 0,
+                helixActive: false, helixFreq: 0, helixPhase: 0, helixAmplitude: 0,
+                piercing: 0, piercedEnemies: 0,
+                explosive: false, explosionRadius: 0,
+                expiredByRange: false, expiredByBounds: false, expiredByDistance: false,
+            };
+        }
+        if (!this._bulletCtx) {
+            this._bulletCtx = {
+                tickScale: GAME_CONFIG.TICK_SCALE,
+                logicTickSeconds: GAME_CONFIG.LOGIC_TICK_MS / 1000,
+                bulletSpeed: GAME_CONFIG.BULLET_SPEED,
+                boundaryWidth: 0, boundaryHeight: 0,
+                now: 0,
+                targetPlayer: null, homingTarget: null,
+                rngFloat: Math.random,
+            };
+        }
+        const sb = this._bulletScratch;
+        sb.x = this.x; sb.y = this.y;
+        sb.vx = this.vel.x; sb.vy = this.vel.y;
+        sb.life = this.life;
+        sb.maxLife = this.maxLife;
+        sb.fadeFactor = this.fadeFactor;
+        sb.radius = this.radius;
+        sb.baseRadius = this.baseRadius;
+        sb.rangeMultiplier = this.rangeMultiplier;
+        sb.active = this.active;
+        sb.homing = !!this.homing;
+        sb.homingStrength = this.homingStrength || 0;
+        sb.helixActive = !!this.helixActive;
+        sb.helixFreq = this.helixFreq || 0;
+        sb.helixPhase = this.helixPhase || 0;
+        sb.helixAmplitude = this.helixAmplitude || 0;
+        sb.expiredByRange = false;
+        sb.expiredByBounds = false;
 
-        if (this.x < -50 || this.x > boundaryWidth + 50 ||
-            this.y < -50 || this.y > boundaryHeight + 50) {
+        const ctx = this._bulletCtx;
+        ctx.boundaryWidth = gameField ? gameField.width : this.width;
+        ctx.boundaryHeight = gameField ? gameField.height : this.height;
+        ctx.homingTarget = homingTarget;
+
+        updatePlayerBullet(sb, ctx, null);
+
+        // Write outputs back.
+        this.x = sb.x; this.y = sb.y;
+        this.vel.x = sb.vx; this.vel.y = sb.vy;
+        this.life = sb.life;
+        this.fadeFactor = sb.fadeFactor;
+        this.radius = sb.radius;
+        if (!sb.active) {
             this.active = false;
+            // Translate sim-emitted despawn flags into legacy FX calls.
+            if (sb.expiredByRange) {
+                this.createDisappearPuff(gameEngine);
+            }
             if (this.onOffScreen) this.onOffScreen();
         }
+    }
+
+    /**
+     * Wrapper-side homing-target picker. Lifted out of the legacy
+     * `applyHoming()` so the pure sim takes only the chosen target,
+     * not the live pools.
+     */
+    _pickHomingTarget(enemyPool, asteroidPool, gameEngine) {
+        let bestTarget = null;
+        let bestDistance = Infinity;
+        let cursorX = null, cursorY = null;
+
+        if (gameEngine && gameEngine.inputHandler) {
+            cursorX = gameEngine.inputHandler.input.aimX;
+            cursorY = gameEngine.inputHandler.input.aimY;
+        }
+
+        const checkTargets = (targets, filter = null) => {
+            if (!targets) return;
+            for (const target of targets.activeObjects) {
+                if (!target.active) continue;
+                if (filter && !filter(target)) continue;
+
+                const dx = target.x - this.x;
+                const dy = target.y - this.y;
+                const bulletDistance = Math.hypot(dx, dy);
+                if (bulletDistance > 400) continue;
+
+                let priority = bulletDistance;
+                if (cursorX !== null && cursorY !== null) {
+                    const cdx = target.x - cursorX;
+                    const cdy = target.y - cursorY;
+                    priority = Math.hypot(cdx, cdy);
+                }
+                if (priority < bestDistance) {
+                    bestDistance = priority;
+                    bestTarget = target;
+                }
+            }
+        };
+
+        if (enemyPool) checkTargets(enemyPool);
+        // 5.73.0 — also home toward enemy mines (proximity bombs); not
+        // toward ordinary projectiles.
+        if (!bestTarget && gameEngine && gameEngine.enemyBulletPool) {
+            checkTargets(gameEngine.enemyBulletPool, t => t.shape === 'mine');
+        }
+        if (!bestTarget && asteroidPool) checkTargets(asteroidPool);
+
+        return bestTarget;
     }
     
     applyHoming(enemyPool, asteroidPool = null, gameEngine = null) {

--- a/js/modules/world/asteroid.js
+++ b/js/modules/world/asteroid.js
@@ -3,6 +3,12 @@ import { GAME_CONFIG } from '../core/constants.js';
 import { random, GameDimensions, glowSpriteCache } from '../core/utils.js';
 import { frameClock } from '../core/frame-clock.js';
 import { hsl } from '../core/color-cache.js';
+// Phase-1 multiplayer engine refactor: asteroid drift / boundary /
+// rotation extracted to `js/sim/asteroid.js`. The wrapper in `update()`
+// below builds a plain-data `AsteroidState` from `this`, calls
+// `updateAsteroid`, and writes the result back. Behavior is byte-for-
+// byte equivalent to the legacy inline code.
+import { updateAsteroid } from '../../sim/asteroid.js';
 const DEBRIS_COUNT = 5;
 
 // ── Shared sin/cos lookup table ──────────────────────────────────────────
@@ -325,69 +331,71 @@ export class Asteroid {
     update(gameField = null) {
         if (!this.active) return;
 
-        // Warp-in entry — skip motion / boundary logic until warp completes.
+        // Warp-in entry — presentation-side animation. Stays in the
+        // wrapper because it touches projection dirtiness and uses a
+        // 1.5x rotation multiplier specific to the warp-in feel.
         if (this.warping) {
             this.updateWarpIn();
             return;
         }
 
-        // Death flash countdown
-        if (this._deathFlash > 0) {
-            this._deathFlash--;
-            if (this._deathFlash <= 0) {
-                this.active = false;
-            }
+        // ── Pure-sim physics step (extracted to js/sim/asteroid.js) ──
+        // Reusable scratch object — avoid per-tick allocation.
+        if (!this._astScratch) {
+            this._astScratch = {
+                id: 0, size: 0,
+                x: 0, y: 0, vx: 0, vy: 0, radius: 0,
+                rotX: 0, rotY: 0, rotZ: 0,
+                rotVelX: 0, rotVelY: 0, rotVelZ: 0,
+                hp: 0, maxHp: 0, level: 1,
+                active: true, warping: false, deathFlash: 0,
+            };
+        }
+        if (!this._astCtx) {
+            this._astCtx = {
+                field: null,
+                tickScale: GAME_CONFIG.TICK_SCALE,
+                wrapWidth: 0, wrapHeight: 0,
+            };
+        }
+        const ast = this._astScratch;
+        ast.x = this.x;
+        ast.y = this.y;
+        ast.vx = this.vel.x;
+        ast.vy = this.vel.y;
+        ast.radius = this.radius;
+        ast.rotX = this.rot3D.x;
+        ast.rotY = this.rot3D.y;
+        ast.rotZ = this.rot3D.z;
+        ast.rotVelX = this.rotVel3D.x;
+        ast.rotVelY = this.rotVel3D.y;
+        ast.rotVelZ = this.rotVel3D.z;
+        ast.active = this.active;
+        ast.warping = false;
+        ast.deathFlash = this._deathFlash || 0;
+
+        const ctx = this._astCtx;
+        ctx.field = gameField || null;
+        ctx.wrapWidth = GameDimensions.width;
+        ctx.wrapHeight = GameDimensions.height;
+
+        updateAsteroid(ast, ctx, null);
+
+        // Write outputs back.
+        this.x = ast.x;
+        this.y = ast.y;
+        this.vel.x = ast.vx;
+        this.vel.y = ast.vy;
+        this.rot3D.x = ast.rotX;
+        this.rot3D.y = ast.rotY;
+        this.rot3D.z = ast.rotZ;
+        this._deathFlash = ast.deathFlash;
+        if (!ast.active) {
+            this.active = false;
             return;
         }
 
-        // Cap asteroid speed to keep them manageable to hit
-        const maxSpeed = 2.0; // Maximum speed for asteroids
-        const currentSpeed = Math.hypot(this.vel.x, this.vel.y);
-        if (currentSpeed > maxSpeed) {
-            this.vel.x = (this.vel.x / currentSpeed) * maxSpeed;
-            this.vel.y = (this.vel.y / currentSpeed) * maxSpeed;
-        }
-
-        this.x += this.vel.x * GAME_CONFIG.TICK_SCALE;
-        this.y += this.vel.y * GAME_CONFIG.TICK_SCALE;
-
-        // Boundary bouncing instead of wrapping
-        if (gameField) {
-            // Bounce off left/right boundaries
-            if (this.x - this.radius < 0) {
-                this.x = this.radius;
-                this.vel.x = Math.abs(this.vel.x) * 0.9; // Bounce with slight energy loss
-            } else if (this.x + this.radius > gameField.width) {
-                this.x = gameField.width - this.radius;
-                this.vel.x = -Math.abs(this.vel.x) * 0.9;
-            }
-
-            // Bounce off top/bottom boundaries
-            if (this.y - this.radius < 0) {
-                this.y = this.radius;
-                this.vel.y = Math.abs(this.vel.y) * 0.9;
-            } else if (this.y + this.radius > gameField.height) {
-                this.y = gameField.height - this.radius;
-                this.vel.y = -Math.abs(this.vel.y) * 0.9;
-            }
-        } else {
-            // Fallback to old wrapping if no game field provided
-            const wrapBuffer = this.radius * 2;
-            if (this.x < -wrapBuffer) this.x = GameDimensions.width + wrapBuffer;
-            if (this.x > GameDimensions.width + wrapBuffer) this.x = -wrapBuffer;
-            if (this.y < -wrapBuffer) this.y = GameDimensions.height + wrapBuffer;
-            if (this.y > GameDimensions.height + wrapBuffer) this.y = -wrapBuffer;
-        }
-
-        // Update rotation angles (always, for consistency)
-        this.rot3D.x += this.rotVel3D.x;
-        this.rot3D.y += this.rotVel3D.y;
-        this.rot3D.z += this.rotVel3D.z;
-
-        // Defer projection to draw — and stagger across frames so only
-        // half the field re-projects per tick. Cuts total projection cost
-        // in half. Rotations still advance every frame; the projected
-        // vertices just lag by at most one frame (16ms at 60fps).
+        // Presentation-only: stagger projection re-bake across frames.
         if (((frameClock.tick & 1) === this._projOffset) || this.warping) {
             this._projectionDirty = true;
         }

--- a/js/sim/asteroid.js
+++ b/js/sim/asteroid.js
@@ -1,0 +1,156 @@
+// Pure asteroid-update step.
+//
+// Extracted from `js/modules/world/asteroid.js`'s `update()` method as
+// part of the Phase-1 multiplayer engine refactor (see
+// `docs/Multiplayer Rust Client Engine – 2026-05-07.md`, §"Phase 1:
+// Engine refactor"). Mirrors the agent-A pattern that landed for ship
+// physics in `js/sim/ship.js`.
+//
+// This module is **byte-for-byte equivalent** to the existing solo
+// asteroid-update behavior — same speed cap, same per-tick position
+// delta (scaled by TICK_SCALE), same boundary-bounce 0.9 damping, same
+// 3D-rotation accumulation. No tuning happens here.
+//
+// What lives here:
+//   - Speed-cap clamp (currentSpeed > 2.0 → renormalize to 2.0)
+//   - Position update (x += vx * TICK_SCALE)
+//   - Boundary bounce (with 0.9 damp) OR wraparound fallback
+//   - 3D rotation accumulation (rotX += rotVelX, etc.)
+//   - Death-flash countdown (tick down, deactivate at 0)
+//
+// What does NOT live here (stays on `Asteroid` for now):
+//   - Warp-in entry animation (presentation; wrapper handles)
+//   - 3D vertex projection (drawing concern)
+//   - Hit-flash visual timer (presentation)
+//   - Sprite/health-bar rendering
+//   - Audio events / particle FX
+//
+// Split logic (1 large → N fragments) is NOT here because the live
+// game does it from `js/modules/combat/collision-system.js` when a
+// bullet hit destroys a parent asteroid. Once collision moves into
+// the sim layer (separate session), it will produce a "split" event
+// that the engine driver drains — for now this update step never
+// emits events.
+
+// Asteroid drift cap (px per logic tick, post-scale). Mirrors the
+// `maxSpeed = 2.0` literal in the legacy `Asteroid.update()`.
+const ASTEROID_MAX_SPEED = 2.0;
+
+// Boundary-bounce energy retention. Mirrors the `0.9` factor in the
+// legacy code (slightly more elastic than the ship's 0.8).
+const ASTEROID_BOUNCE_DAMP = 0.9;
+
+/**
+ * Pure asteroid-update step.
+ *
+ * Reads the current asteroid state, integrates one tick of motion,
+ * advances rotation, and **mutates `asteroid` in place** (no allocation
+ * per tick). Pushes side-effect events onto `events` — currently never
+ * emits anything, but the slot reserves space for the upcoming split
+ * migration.
+ *
+ * @param {import('./state.js').AsteroidState} asteroid
+ * @param {import('./state.js').AsteroidUpdateContext} ctx
+ * @param {Array<*>} events            out-buffer for split / despawn events
+ * @returns {import('./state.js').AsteroidState} the (mutated) asteroid
+ */
+export function updateAsteroid(asteroid, ctx, events) {
+    if (!asteroid.active) return asteroid;
+
+    // ── Warp-in: skip motion / boundary while phasing in ──
+    // The wrapper handles the warp animation itself (it touches projection
+    // dirtiness which is a presentation concern). We just early-exit so
+    // the rotation & position don't double-advance.
+    if (asteroid.warping) return asteroid;
+
+    // ── Death flash: tick down, deactivate at zero ──
+    // Mirrors the original `if (this._deathFlash > 0) { … return; }`
+    // block at the top of update(). We early-return so motion doesn't
+    // continue once the rock is mid-explosion.
+    if (asteroid.deathFlash > 0) {
+        asteroid.deathFlash--;
+        if (asteroid.deathFlash <= 0) {
+            asteroid.active = false;
+        }
+        return asteroid;
+    }
+
+    // ── Speed cap ──
+    // Mirrors `Asteroid.update()` line 343-349. Renormalizes velocity
+    // when |v| > 2.0 so split fragments (which can spawn with 4.5–7.5
+    // initial speed) settle into a manageable drift instead of streaking
+    // off-screen.
+    const speed = Math.hypot(asteroid.vx, asteroid.vy);
+    if (speed > ASTEROID_MAX_SPEED) {
+        asteroid.vx = (asteroid.vx / speed) * ASTEROID_MAX_SPEED;
+        asteroid.vy = (asteroid.vy / speed) * ASTEROID_MAX_SPEED;
+    }
+
+    // ── Position update ──
+    // Mirrors lines 351-352. Note the `* TICK_SCALE` factor; legacy
+    // `vel` is stored as 30Hz units and scaled per render frame.
+    asteroid.x += asteroid.vx * ctx.tickScale;
+    asteroid.y += asteroid.vy * ctx.tickScale;
+
+    // ── Boundary handling ──
+    // Mirrors lines 354-380. With a field, bounce with 0.9 damp; without
+    // a field, fall back to torus wraparound at radius * 2 buffer.
+    const field = ctx.field;
+    if (field) {
+        const r = asteroid.radius;
+        if (asteroid.x - r < 0) {
+            asteroid.x = r;
+            asteroid.vx = Math.abs(asteroid.vx) * ASTEROID_BOUNCE_DAMP;
+        } else if (asteroid.x + r > field.width) {
+            asteroid.x = field.width - r;
+            asteroid.vx = -Math.abs(asteroid.vx) * ASTEROID_BOUNCE_DAMP;
+        }
+        if (asteroid.y - r < 0) {
+            asteroid.y = r;
+            asteroid.vy = Math.abs(asteroid.vy) * ASTEROID_BOUNCE_DAMP;
+        } else if (asteroid.y + r > field.height) {
+            asteroid.y = field.height - r;
+            asteroid.vy = -Math.abs(asteroid.vy) * ASTEROID_BOUNCE_DAMP;
+        }
+    } else {
+        // Wraparound fallback — only used when no field is supplied.
+        // Live engine call sites always pass a field, so this branch
+        // is effectively dead in solo play; kept for robustness.
+        const wrapW = ctx.wrapWidth;
+        const wrapH = ctx.wrapHeight;
+        const buf = asteroid.radius * 2;
+        if (asteroid.x < -buf) asteroid.x = wrapW + buf;
+        if (asteroid.x > wrapW + buf) asteroid.x = -buf;
+        if (asteroid.y < -buf) asteroid.y = wrapH + buf;
+        if (asteroid.y > wrapH + buf) asteroid.y = -buf;
+    }
+
+    // ── 3D rotation ──
+    // Mirrors lines 382-385. The actual projection is presentation work
+    // (it lives in the wrapper / draw path); here we just advance the
+    // rotation angles each tick. Always runs, even if motion is clamped,
+    // matching the original "for consistency" comment.
+    asteroid.rotX += asteroid.rotVelX;
+    asteroid.rotY += asteroid.rotVelY;
+    asteroid.rotZ += asteroid.rotVelZ;
+
+    return asteroid;
+}
+
+/**
+ * Loop helper. Calls `updateAsteroid()` over an array of asteroids,
+ * passing the same context to each.
+ *
+ * @param {import('./state.js').AsteroidState[]} asteroids
+ * @param {import('./state.js').AsteroidUpdateContext} ctx
+ * @param {Array<*>} events
+ */
+export function updateAsteroids(asteroids, ctx, events) {
+    for (const asteroid of asteroids) {
+        updateAsteroid(asteroid, ctx, events);
+    }
+}
+
+// Re-export the constants so the wrapper / tests can compare without
+// duplicating the literals.
+export { ASTEROID_MAX_SPEED, ASTEROID_BOUNCE_DAMP };

--- a/js/sim/bullet.js
+++ b/js/sim/bullet.js
@@ -1,0 +1,624 @@
+// Pure bullet-update step.
+//
+// Handles BOTH player and enemy bullets — they have different shapes
+// (player bullets carry weapon-upgrade flags; enemy bullets carry a
+// firing-pattern + per-shape state), so the per-tick step is split
+// internally into `updatePlayerBullet` + `updateEnemyBullet`. The
+// `updateBullet` dispatcher picks based on `bullet.kind`.
+//
+// Extracted from `js/modules/player/bullet.js` and
+// `js/modules/enemy/enemy-bullet.js`'s `update()` methods as part of
+// the Phase-1 multiplayer engine refactor (see
+// `docs/Multiplayer Rust Client Engine – 2026-05-07.md`, §"Phase 1:
+// Engine refactor"). Mirrors the agent-A pattern that landed for ship
+// physics in `js/sim/ship.js`.
+//
+// This module is **byte-for-byte equivalent** to the existing solo
+// bullet-update behavior — same lifetime ticks, same homing turn rates,
+// same per-shape velocity adjustments, same despawn rules. No tuning
+// happens here.
+//
+// What lives here:
+//   - Position integration (x += vx [* tickScale]).
+//   - Lifetime decay (frames-elapsed for player bullets; distance-from-
+//     start for enemy bullets; time-elapsed for persistent bullets).
+//   - Homing logic (player: predictive lead-time; enemy: per-pattern).
+//   - Per-shape velocity adjustments (sine, spiral, missile, mine, …).
+//   - Despawn rules (out-of-bounds, expired lifetime, hit consumed).
+//   - Helix offset (player Rail-Driver bullets).
+//
+// What does NOT live here (stays on `Bullet` / `EnemyBullet`):
+//   - Sprite/shape rendering (drawTriangleBullet, drawMineBullet, …).
+//   - Hit-flash / fade-in visual timers (presentation only).
+//   - Particle FX on spawn / despawn.
+//   - Audio events.
+//   - Trail ring-buffer (presentation; lives on the entity).
+//   - Anything talking to `gameEngine` directly (collision detection,
+//     particle pools, etc. — the wrapper translates events into those
+//     calls).
+//   - Hit-detection (collision.js's job in a future session).
+
+// ── Despawn-event marker (reserved for future collision migration) ────
+// `updateBullet` doesn't currently emit despawn events because the
+// caller can read `bullet.active` directly. Kept as a constant so the
+// wrapper can pre-allocate an event buffer of the right shape.
+export const BULLET_EVENT_DESPAWN = 'despawn';
+
+// ── Player bullet ─────────────────────────────────────────────────────
+
+/**
+ * Per-tick player-bullet update. Mutates `bullet` in place.
+ *
+ * @param {import('./state.js').BulletState} bullet
+ * @param {import('./state.js').BulletUpdateContext} ctx
+ * @param {Array<*>} _events
+ */
+export function updatePlayerBullet(bullet, ctx, _events) {
+    if (!bullet.active) return bullet;
+
+    bullet.life++;
+
+    // Lifetime expiry — extended by LONG_RANGE upgrades. The original
+    // code rounds at the call site; we mirror that exactly.
+    const effectiveMaxLife = Math.round(bullet.maxLife * bullet.rangeMultiplier);
+    if (bullet.life >= effectiveMaxLife) {
+        bullet.active = false;
+        bullet.expiredByRange = true; // wrapper triggers disappear-puff
+        return bullet;
+    }
+
+    // Fade factor for the final 35% of life — drawn-side only, but the
+    // entity's `radius` is also derived from it (visual shrink).
+    const remaining = 1 - bullet.life / effectiveMaxLife;
+    bullet.fadeFactor = remaining < 0.35 ? remaining / 0.35 : 1.0;
+    bullet.radius = bullet.baseRadius * (0.3 + 0.7 * bullet.fadeFactor);
+
+    // Homing — adjust velocity toward best target. The actual target
+    // pick is presentation-adjacent (it reaches into entity pools), so
+    // the wrapper supplies the chosen target via `ctx.homingTarget`.
+    if (bullet.homing && ctx.homingTarget) {
+        applyPlayerHoming(bullet, ctx.homingTarget, ctx.bulletSpeed);
+    }
+
+    // Movement.
+    bullet.x += bullet.vx;
+    bullet.y += bullet.vy;
+
+    // Helix offset — Rail Driver double-helix bullets oscillate
+    // perpendicular to the rail axis. We apply the *delta* of the sine
+    // each frame so the underlying rail position still advances by
+    // `vel` exactly. Two bullets with phases 0 and π cross every half
+    // period.
+    if (bullet.helixActive) {
+        const speed = Math.hypot(bullet.vx, bullet.vy) || 1;
+        const ux = -bullet.vy / speed;
+        const uy =  bullet.vx / speed;
+        const t = bullet.life;
+        const sNow  = Math.sin(t       * bullet.helixFreq + bullet.helixPhase);
+        const sPrev = Math.sin((t - 1) * bullet.helixFreq + bullet.helixPhase);
+        const delta = (sNow - sPrev) * bullet.helixAmplitude;
+        bullet.x += ux * delta;
+        bullet.y += uy * delta;
+    }
+
+    // Boundary check (bullet disappears off-field). The original used
+    // a 50px margin and checked field OR window dimensions; the
+    // wrapper passes whichever is in scope.
+    const w = ctx.boundaryWidth;
+    const h = ctx.boundaryHeight;
+    if (bullet.x < -50 || bullet.x > w + 50 ||
+        bullet.y < -50 || bullet.y > h + 50) {
+        bullet.active = false;
+        bullet.expiredByBounds = true;
+    }
+
+    return bullet;
+}
+
+/**
+ * Predictive-lead homing — adjust velocity toward the chosen target's
+ * predicted position 8 frames ahead.
+ *
+ * Mirrors `Bullet.applyHoming()` from `js/modules/player/bullet.js`.
+ * @param {import('./state.js').BulletState} bullet
+ * @param {{x:number, y:number, vel?:{x:number,y:number}}} target
+ * @param {number} bulletSpeed
+ */
+function applyPlayerHoming(bullet, target, bulletSpeed) {
+    const leadTime = 8;
+    const predictedX = target.x + (target.vel ? target.vel.x * leadTime : 0);
+    const predictedY = target.y + (target.vel ? target.vel.y * leadTime : 0);
+
+    const dx = predictedX - bullet.x;
+    const dy = predictedY - bullet.y;
+    const distance = Math.hypot(dx, dy);
+    if (distance <= 0) return;
+
+    const desiredVelX = (dx / distance) * bulletSpeed;
+    const desiredVelY = (dy / distance) * bulletSpeed;
+
+    const maxTurnRate = 0.15;
+    const currentAngle = Math.atan2(bullet.vy, bullet.vx);
+    const desiredAngle = Math.atan2(desiredVelY, desiredVelX);
+
+    let angleDiff = desiredAngle - currentAngle;
+    if (angleDiff > Math.PI) angleDiff -= 2 * Math.PI;
+    if (angleDiff < -Math.PI) angleDiff += 2 * Math.PI;
+    const actualTurn = Math.sign(angleDiff) * Math.min(Math.abs(angleDiff), maxTurnRate);
+    const newAngle = currentAngle + actualTurn;
+
+    // Distance-based homing strength (stronger when closer).
+    const homingStrength = bullet.homingStrength * (1 + (200 - Math.min(distance, 200)) / 200);
+
+    const currentSpeed = Math.hypot(bullet.vx, bullet.vy);
+    const targetVelX = Math.cos(newAngle) * currentSpeed;
+    const targetVelY = Math.sin(newAngle) * currentSpeed;
+
+    bullet.vx = bullet.vx * (1 - homingStrength) + targetVelX * homingStrength;
+    bullet.vy = bullet.vy * (1 - homingStrength) + targetVelY * homingStrength;
+
+    // Maintain consistent speed with slight boost when homing.
+    const speedAfter = Math.hypot(bullet.vx, bullet.vy);
+    const targetSpeed = bulletSpeed * 1.1;
+    if (speedAfter > 0) {
+        bullet.vx = (bullet.vx / speedAfter) * targetSpeed;
+        bullet.vy = (bullet.vy / speedAfter) * targetSpeed;
+    }
+}
+
+// ── Enemy bullet ──────────────────────────────────────────────────────
+
+/**
+ * Per-tick enemy-bullet update. Mutates `bullet` in place.
+ *
+ * The enemy bullet is identified by `movementPattern` + `shape`. The
+ * pattern drives velocity (per-frame); the shape drives despawn rules
+ * (mines and persistent bullets use time-based lifetime; everything
+ * else uses distance-from-start).
+ *
+ * @param {import('./state.js').BulletState} bullet
+ * @param {import('./state.js').BulletUpdateContext} ctx
+ * @param {Array<*>} _events
+ */
+export function updateEnemyBullet(bullet, ctx, _events) {
+    if (!bullet.active) return bullet;
+
+    // ── Apply movement pattern (mutates bullet.vel in place) ──
+    applyEnemyMovementPattern(bullet, ctx);
+
+    // ── Position update — scaled for tick rate ──
+    bullet.x += bullet.vx * ctx.tickScale;
+    bullet.y += bullet.vy * ctx.tickScale;
+
+    // ── Rotation accumulator (cosmetic, but kept here so the wrapper
+    // can render in lockstep). Some patterns above set `rotation`
+    // directly to align with velocity; this `+=` only contributes when
+    // the pattern leaves it alone.
+    bullet.rotation += bullet.rotationSpeed * ctx.tickScale;
+
+    // ── Pattern timer (seconds) ──
+    bullet.patternTimer += ctx.logicTickSeconds;
+
+    // ── Mine HP-based death (proximity bombs lose HP via collision
+    // damage and despawn at 0). collision-system writes bullet.health;
+    // we just observe.
+    if (bullet.shape === 'mine' && bullet.health !== undefined && bullet.health <= 0) {
+        bullet.active = false;
+        return bullet;
+    }
+
+    // ── Lifetime / fade ──
+    if (bullet.isPersistent) {
+        // Time-based lifetime (mines, lightning orbs).
+        const maxLife = bullet.maxLifetimeOverride || 15000;
+        const age = ctx.now - bullet.creationTime;
+        if (age > maxLife) {
+            bullet.active = false;
+            return bullet;
+        }
+        if (bullet.shape === 'mine') {
+            bullet.life = 1.0;
+        } else {
+            const progress = age / maxLife;
+            bullet.life = progress < 0.6 ? 1.0 : 1.0 - (progress - 0.6) / 0.4;
+        }
+    } else {
+        // Distance-based lifetime — fades / despawns once the bullet
+        // has traveled `maxRange` from its origin.
+        const dist = Math.hypot(bullet.x - bullet.startX, bullet.y - bullet.startY);
+        const progress = dist / bullet.maxRange;
+        if (progress >= 1.0) {
+            bullet.active = false;
+            bullet.expiredByRange = true; // wrapper triggers disappear-effect
+            return bullet;
+        }
+        bullet.life = progress < 0.65
+            ? 1.0
+            : 1.0 - (progress - 0.65) / 0.35 * 0.5; // 1.0 → 0.5
+    }
+
+    // ── Out-of-bounds despawn (no FX — too far to see) ──
+    const margin = 50;
+    if (bullet.x < -margin || bullet.x > ctx.boundaryWidth + margin ||
+        bullet.y < -margin || bullet.y > ctx.boundaryHeight + margin) {
+        bullet.active = false;
+        bullet.expiredByBounds = true;
+    }
+
+    return bullet;
+}
+
+/**
+ * Per-pattern velocity adjustment for enemy bullets. Mutates
+ * `bullet.vx` / `bullet.vy` in place. Mirrors
+ * `EnemyBullet.applyMovementPattern()` byte-for-byte.
+ *
+ * @param {import('./state.js').BulletState} bullet
+ * @param {import('./state.js').BulletUpdateContext} ctx
+ */
+function applyEnemyMovementPattern(bullet, ctx) {
+    if (!bullet.baseVx && !bullet.baseVy && bullet.movementPattern !== 'mine') {
+        // Safety: legacy code early-returned when baseVel was missing.
+        return;
+    }
+
+    const speed = Math.hypot(bullet.baseVx, bullet.baseVy);
+    const baseAngle = Math.atan2(bullet.baseVy, bullet.baseVx);
+    const target = ctx.targetPlayer;
+
+    switch (bullet.movementPattern) {
+        case 'aimed':
+            // Standard straight movement — no modification.
+            break;
+
+        case 'mine':
+            // Stationary proximity mine.
+            bullet.vx = 0;
+            bullet.vy = 0;
+            break;
+
+        case 'homing_mine': {
+            if (target && target.active !== false) {
+                const dx = target.x - bullet.x;
+                const dy = target.y - bullet.y;
+                const dist = Math.hypot(dx, dy);
+                if (dist > 5) {
+                    bullet.vx += (dx / dist) * 0.09;
+                    bullet.vy += (dy / dist) * 0.09;
+                    const maxSpeed = 1.8;
+                    const spd = Math.hypot(bullet.vx, bullet.vy);
+                    if (spd > maxSpeed) {
+                        bullet.vx = (bullet.vx / spd) * maxSpeed;
+                        bullet.vy = (bullet.vy / spd) * maxSpeed;
+                    }
+                }
+            }
+            break;
+        }
+
+        case 'spread': {
+            const waveFreq = 3;
+            const waveAmp = 0.5;
+            const perpAngle = baseAngle + Math.PI / 2;
+            const waveOffset = Math.sin(bullet.patternTimer * waveFreq + bullet.patternPhase) * waveAmp;
+            bullet.vx = bullet.baseVx + Math.cos(perpAngle) * waveOffset;
+            bullet.vy = bullet.baseVy + Math.sin(perpAngle) * waveOffset;
+            break;
+        }
+
+        case 'rapid': {
+            const jitterStrength = 0.3;
+            const jitterX = (ctx.rngFloat() - 0.5) * jitterStrength;
+            const jitterY = (ctx.rngFloat() - 0.5) * jitterStrength;
+            bullet.vx = bullet.baseVx + jitterX;
+            bullet.vy = bullet.baseVy + jitterY;
+            break;
+        }
+
+        case 'spiral': {
+            const spiralRate = 2;
+            const spiralRadius = bullet.patternTimer * 0.5;
+            const spiralAngle = baseAngle + bullet.patternTimer * spiralRate;
+            bullet.vx = Math.cos(spiralAngle) * speed + Math.cos(spiralAngle + Math.PI / 2) * spiralRadius * 0.1;
+            bullet.vy = Math.sin(spiralAngle) * speed + Math.sin(spiralAngle + Math.PI / 2) * spiralRadius * 0.1;
+            break;
+        }
+
+        case 'burst': {
+            const accelFactor = 1 + bullet.patternTimer * 0.5;
+            bullet.vx = bullet.baseVx * accelFactor;
+            bullet.vy = bullet.baseVy * accelFactor;
+            break;
+        }
+
+        case 'explosive': {
+            let explosiveFactor;
+            if (bullet.patternTimer < 0.5) {
+                explosiveFactor = 0.3;
+            } else {
+                explosiveFactor = 1.5 + (bullet.patternTimer - 0.5) * 2;
+            }
+            bullet.vx = bullet.baseVx * explosiveFactor;
+            bullet.vy = bullet.baseVy * explosiveFactor;
+            break;
+        }
+
+        case 'laser': {
+            const laserSpeed = Math.hypot(bullet.baseVx, bullet.baseVy) * 2;
+            const laserAngle = Math.atan2(bullet.baseVy, bullet.baseVx);
+            bullet.vx = Math.cos(laserAngle) * laserSpeed;
+            bullet.vy = Math.sin(laserAngle) * laserSpeed;
+            break;
+        }
+
+        case 'laser_beam': {
+            const beamSpeed = Math.hypot(bullet.baseVx, bullet.baseVy) * 3;
+            const beamAngle = Math.atan2(bullet.baseVy, bullet.baseVx);
+            bullet.vx = Math.cos(beamAngle) * beamSpeed;
+            bullet.vy = Math.sin(beamAngle) * beamSpeed;
+            // Reduced damage for balance — was (damage || 15) * 1.5.
+            bullet.damage = (bullet.damage || 3) * 1.0;
+            bullet.radius = Math.max(bullet.radius, 8);
+            break;
+        }
+
+        case 'missile': {
+            if (target) {
+                const dx = target.x - bullet.x;
+                const dy = target.y - bullet.y;
+                const distance = Math.hypot(dx, dy);
+                if (distance > 0) {
+                    const homingStrength = 0.05;
+                    const currentSpeed = Math.hypot(bullet.vx, bullet.vy);
+                    bullet.vx += (dx / distance) * homingStrength;
+                    bullet.vy += (dy / distance) * homingStrength;
+                    const newSpeed = Math.hypot(bullet.vx, bullet.vy);
+                    if (newSpeed > 0) {
+                        bullet.vx = (bullet.vx / newSpeed) * currentSpeed;
+                        bullet.vy = (bullet.vy / newSpeed) * currentSpeed;
+                    }
+                }
+            }
+            if (bullet.vx !== 0 || bullet.vy !== 0) {
+                bullet.rotation = Math.atan2(bullet.vy, bullet.vx);
+            }
+            break;
+        }
+
+        case 'homing': {
+            if (target) {
+                const dx = target.x - bullet.x;
+                const dy = target.y - bullet.y;
+                const distance = Math.hypot(dx, dy);
+                if (distance > 0) {
+                    const homingStrength = 0.03; // Slower than missile.
+                    const currentSpeed = Math.hypot(bullet.vx, bullet.vy);
+                    bullet.vx += (dx / distance) * homingStrength;
+                    bullet.vy += (dy / distance) * homingStrength;
+                    const newSpeed = Math.hypot(bullet.vx, bullet.vy);
+                    if (newSpeed > 0) {
+                        bullet.vx = (bullet.vx / newSpeed) * currentSpeed;
+                        bullet.vy = (bullet.vy / newSpeed) * currentSpeed;
+                    }
+                }
+            }
+            break;
+        }
+
+        case 'titan_homing': {
+            if (target) {
+                const dx = target.x - bullet.x;
+                const dy = target.y - bullet.y;
+                const distance = Math.hypot(dx, dy);
+                if (distance > 0) {
+                    const homingStrength = 0.02;
+                    const currentSpeed = Math.hypot(bullet.vx, bullet.vy);
+                    bullet.vx += (dx / distance) * homingStrength;
+                    bullet.vy += (dy / distance) * homingStrength;
+                    const newSpeed = Math.hypot(bullet.vx, bullet.vy);
+                    if (newSpeed > 0) {
+                        bullet.vx = (bullet.vx / newSpeed) * currentSpeed;
+                        bullet.vy = (bullet.vy / newSpeed) * currentSpeed;
+                    }
+                }
+            }
+            break;
+        }
+
+        case 'titan_rocket': {
+            const rocketSpeed = bullet.rocketSpeed;
+            const currentSpeed = Math.hypot(bullet.vx, bullet.vy);
+            if (rocketSpeed && currentSpeed !== rocketSpeed) {
+                const direction = Math.atan2(bullet.vy, bullet.vx);
+                bullet.vx = Math.cos(direction) * rocketSpeed;
+                bullet.vy = Math.sin(direction) * rocketSpeed;
+            }
+            // Track distance traveled — mutate `distanceTraveled` so the
+            // wrapper can read it for explosion side-effects.
+            if (bullet.distanceTraveled !== undefined) {
+                const dx = bullet.x - bullet.startX;
+                const dy = bullet.y - bullet.startY;
+                bullet.distanceTraveled = Math.hypot(dx, dy);
+                if (bullet.maxDistance && bullet.distanceTraveled >= bullet.maxDistance) {
+                    bullet.active = false;
+                    bullet.expiredByDistance = true; // wrapper triggers explosion FX
+                }
+            }
+            break;
+        }
+
+        case 'missile_decelerate': {
+            const deceleration = bullet.deceleration;
+            const minSpeed = bullet.minSpeed; // wrapper sets these from constants
+            if (deceleration === undefined || minSpeed === undefined) break;
+            const currentSpeedDeccel = Math.hypot(bullet.vx, bullet.vy);
+            if (currentSpeedDeccel > minSpeed) {
+                const direction = Math.atan2(bullet.vy, bullet.vx);
+                const newSpeed = Math.max(currentSpeedDeccel - deceleration, minSpeed);
+                bullet.vx = Math.cos(direction) * newSpeed;
+                bullet.vy = Math.sin(direction) * newSpeed;
+            } else {
+                bullet.active = false;
+                bullet.expiredByDistance = true; // wrapper triggers explosion FX
+            }
+            // Max-distance check.
+            if (bullet.maxDistance && bullet.startX !== undefined && bullet.startY !== undefined) {
+                const dx = bullet.x - bullet.startX;
+                const dy = bullet.y - bullet.startY;
+                const distanceTraveled = Math.hypot(dx, dy);
+                if (distanceTraveled >= bullet.maxDistance) {
+                    bullet.active = false;
+                    bullet.expiredByDistance = true;
+                }
+            }
+            break;
+        }
+
+        case 'pulse': {
+            const pulseAccel = 1 + bullet.patternTimer * 0.8;
+            bullet.vx = bullet.baseVx * pulseAccel;
+            bullet.vy = bullet.baseVy * pulseAccel;
+            break;
+        }
+
+        case 'shield_burst': {
+            const wobble = Math.sin(bullet.patternTimer * 8) * 0.2;
+            const shieldPerpAngle = Math.atan2(bullet.baseVy, bullet.baseVx) + Math.PI / 2;
+            bullet.vx = bullet.baseVx + Math.cos(shieldPerpAngle) * wobble;
+            bullet.vy = bullet.baseVy + Math.sin(shieldPerpAngle) * wobble;
+            break;
+        }
+
+        case 'wave_energy': {
+            const waveFrequency = 3;
+            const waveAmplitude = 15;
+            const baseDirection = Math.atan2(bullet.baseVy, bullet.baseVx);
+            const perpDirection = baseDirection + Math.PI / 2;
+            const energyWaveOffset = Math.sin(bullet.patternTimer * waveFrequency) * waveAmplitude;
+            const waveVelX = Math.cos(perpDirection) * energyWaveOffset * 0.1;
+            const waveVelY = Math.sin(perpDirection) * energyWaveOffset * 0.1;
+            bullet.vx = bullet.baseVx + waveVelX;
+            bullet.vy = bullet.baseVy + waveVelY;
+            break;
+        }
+
+        case 'energy_slash': {
+            const slashDirection = Math.atan2(bullet.baseVy, bullet.baseVx);
+            const curveIntensity = 0.3;
+            const slashProgress = bullet.slashProgress || 0;
+            const curveOffset = Math.sin(slashProgress * Math.PI) * curveIntensity;
+            const perpSlashDirection = slashDirection + Math.PI / 2;
+            const curveVelX = Math.cos(perpSlashDirection) * curveOffset;
+            const curveVelY = Math.sin(perpSlashDirection) * curveOffset;
+            bullet.vx = bullet.baseVx + curveVelX;
+            bullet.vy = bullet.baseVy + curveVelY;
+            const pulseIntensity = 1 + Math.sin(bullet.patternTimer * 8) * 0.1;
+            bullet.vx *= pulseIntensity;
+            bullet.vy *= pulseIntensity;
+            break;
+        }
+
+        case 'crescent_beam':
+        case 'crescent_slice':
+            // Straight movement — no modification.
+            break;
+
+        case 'sine_wave': {
+            bullet.sinePhase += bullet.sineFreq;
+            const sineDisp = Math.sin(bullet.sinePhase) * bullet.sineAmp;
+            bullet.vx = bullet.baseVx + bullet.sinePerpX * sineDisp;
+            bullet.vy = bullet.baseVy + bullet.sinePerpY * sineDisp;
+            // Keep needle oriented in actual travel direction.
+            bullet.rotation = Math.atan2(bullet.vy, bullet.vx);
+            break;
+        }
+
+        case 'sine_wave_nospin': {
+            bullet.sinePhase += bullet.sineFreq;
+            const snDisp = Math.sin(bullet.sinePhase) * bullet.sineAmp;
+            bullet.vx = bullet.baseVx + bullet.sinePerpX * snDisp;
+            bullet.vy = bullet.baseVy + bullet.sinePerpY * snDisp;
+            // rotation NOT touched — outer update() ticks rotationSpeed.
+            break;
+        }
+
+        case 'missile_fast_slow': {
+            if (target) {
+                const mDx = target.x - bullet.x;
+                const mDy = target.y - bullet.y;
+                const mDist = Math.hypot(mDx, mDy);
+                if (mDist > 0) {
+                    bullet.vx += (mDx / mDist) * 0.18;
+                    bullet.vy += (mDy / mDist) * 0.18;
+                }
+            }
+            const mSpd = Math.hypot(bullet.vx, bullet.vy);
+            const mMaxSpd = bullet.patternTimer < 0.95 ? 14 : 5;
+            if (mSpd > mMaxSpd && mSpd > 0) {
+                bullet.vx = (bullet.vx / mSpd) * mMaxSpd;
+                bullet.vy = (bullet.vy / mSpd) * mMaxSpd;
+            }
+            const mMinSpd = 2.5;
+            if (mSpd > 0 && mSpd < mMinSpd) {
+                bullet.vx = (bullet.vx / mSpd) * mMinSpd;
+                bullet.vy = (bullet.vy / mSpd) * mMinSpd;
+            }
+            if (bullet.vx !== 0 || bullet.vy !== 0) {
+                bullet.rotation = Math.atan2(bullet.vy, bullet.vx);
+            }
+            break;
+        }
+    }
+
+    // ── Boss-rage homing nudge ──
+    // Applied AFTER the per-pattern adjustment so it composes naturally
+    // over straight, burst, spread, missile, etc. Gentle turn rate so
+    // the player can still dodge.
+    if (bullet.bossRageHoming && target) {
+        const dx = target.x - bullet.x;
+        const dy = target.y - bullet.y;
+        const distance = Math.hypot(dx, dy);
+        if (distance > 0) {
+            const turn = 0.04;
+            const currentSpeed = Math.hypot(bullet.vx, bullet.vy);
+            bullet.vx += (dx / distance) * turn;
+            bullet.vy += (dy / distance) * turn;
+            const newSpeed = Math.hypot(bullet.vx, bullet.vy);
+            if (newSpeed > 0 && currentSpeed > 0) {
+                bullet.vx = (bullet.vx / newSpeed) * currentSpeed;
+                bullet.vy = (bullet.vy / newSpeed) * currentSpeed;
+            }
+        }
+    }
+}
+
+// ── Dispatcher / loop helpers ─────────────────────────────────────────
+
+/**
+ * Pure bullet-update step. Dispatches to player or enemy logic based
+ * on `bullet.kind`. Mutates `bullet` in place.
+ *
+ * Hit detection is NOT here — that's collision.js's job (future
+ * session).
+ *
+ * @param {import('./state.js').BulletState} bullet
+ * @param {import('./state.js').BulletUpdateContext} ctx
+ * @param {Array<*>} events
+ */
+export function updateBullet(bullet, ctx, events) {
+    if (bullet.kind === 'enemy') return updateEnemyBullet(bullet, ctx, events);
+    return updatePlayerBullet(bullet, ctx, events);
+}
+
+/**
+ * Loop helper. Calls `updateBullet()` over an array of bullets.
+ *
+ * @param {import('./state.js').BulletState[]} bullets
+ * @param {import('./state.js').BulletUpdateContext} ctx
+ * @param {Array<*>} events
+ */
+export function updateBullets(bullets, ctx, events) {
+    for (const bullet of bullets) {
+        updateBullet(bullet, ctx, events);
+    }
+}

--- a/js/sim/index.js
+++ b/js/sim/index.js
@@ -70,4 +70,6 @@ export {
     BTN_AB1,
     BTN_AB2,
 } from './input.js';
-export { freshGameState } from './state.js';
+export { freshGameState, freshAsteroidState, freshBulletState } from './state.js';
+export { updateAsteroid, updateAsteroids, ASTEROID_MAX_SPEED, ASTEROID_BOUNCE_DAMP } from './asteroid.js';
+export { updateBullet, updateBullets, updatePlayerBullet, updateEnemyBullet, BULLET_EVENT_DESPAWN } from './bullet.js';

--- a/js/sim/state.js
+++ b/js/sim/state.js
@@ -146,3 +146,215 @@ export function freshGameState(seed) {
         rng: new Pcg64(typeof seed === 'bigint' ? seed : BigInt(seed >>> 0)),
     };
 }
+
+// ── Round-2 agent E (sim/projectile-extract) additions ───────────────
+//
+// Working AsteroidState + BulletState used by the f32 sims
+// (`js/sim/asteroid.js`, `js/sim/bullet.js`). Distinct from the
+// `Asteroid` / `Bullet` typedefs above (those are the eventual fixed-
+// point design). Plain-f32 shapes mirror the wire types in
+// `js/sim/protocol-generated.js` for the prediction-relevant subset,
+// with extras for the per-tick step. The wrappers in `Asteroid.update`
+// / `Bullet.update` / `EnemyBullet.update` populate these structs from
+// `this` each tick, call the pure functions, and write the result back.
+
+/**
+ * @typedef {Object} AsteroidState
+ * @property {AsteroidId|number} id
+ * @property {number} size
+ * @property {number} x
+ * @property {number} y
+ * @property {number} vx
+ * @property {number} vy
+ * @property {number} radius
+ * @property {number} rotX
+ * @property {number} rotY
+ * @property {number} rotZ
+ * @property {number} rotVelX
+ * @property {number} rotVelY
+ * @property {number} rotVelZ
+ * @property {number} hp
+ * @property {number} maxHp
+ * @property {number} level
+ * @property {boolean} active
+ * @property {boolean} warping
+ * @property {number} deathFlash
+ */
+
+/**
+ * @typedef {Object} AsteroidUpdateContext
+ * @property {Field|null} field
+ * @property {number} tickScale
+ * @property {number} wrapWidth
+ * @property {number} wrapHeight
+ */
+
+/**
+ * Bullet state for player AND enemy projectiles.
+ * @typedef {Object} BulletState
+ * @property {BulletId|number} id
+ * @property {string} kind                       'player' | 'enemy'
+ * @property {string|null} shape
+ * @property {string} [movementPattern]          enemy-only
+ * @property {number} x
+ * @property {number} y
+ * @property {number} vx
+ * @property {number} vy
+ * @property {number} startX
+ * @property {number} startY
+ * @property {number} baseVx                     enemy-only pre-pattern velocity
+ * @property {number} baseVy
+ * @property {number} angle
+ * @property {number} rotation
+ * @property {number} rotationSpeed
+ * @property {number} life                       0..1 (enemy) | int frames (player)
+ * @property {number} maxLife                    player frames before expiry
+ * @property {number} fadeFactor                 player final-stretch shrink
+ * @property {number} damage
+ * @property {number} radius
+ * @property {number} baseRadius                 player radius at full life
+ * @property {number} maxRange                   px before despawn
+ * @property {number} rangeMultiplier            player LONG_RANGE upgrade
+ * @property {boolean} active
+ * @property {PlayerId|number|null} owner
+ * @property {boolean} homing                    player powerup
+ * @property {number} homingStrength
+ * @property {boolean} helixActive               Rail-Driver helix mode
+ * @property {number} helixFreq
+ * @property {number} helixPhase
+ * @property {number} helixAmplitude
+ * @property {number} piercing
+ * @property {number} piercedEnemies
+ * @property {boolean} explosive
+ * @property {number} explosionRadius
+ * @property {number} patternTimer               enemy seconds-since-spawn
+ * @property {number} patternPhase
+ * @property {boolean} isPersistent              time-based lifetime (mines)
+ * @property {number} maxLifetimeOverride
+ * @property {number} creationTime               ms
+ * @property {object|null} targetPlayer          for homing patterns
+ * @property {boolean} bossRageHoming
+ * @property {number} sinePhase
+ * @property {number} sineFreq
+ * @property {number} sineAmp
+ * @property {number} sinePerpX
+ * @property {number} sinePerpY
+ * @property {number} health                     mine HP
+ * @property {number} maxHealth                  mine HP cap
+ * @property {number} rocketSpeed                titan_rocket
+ * @property {number} maxDistance
+ * @property {number} distanceTraveled
+ * @property {number} deceleration               missile_decelerate
+ * @property {number} minSpeed
+ * @property {number} slashProgress              energy_slash
+ * @property {boolean} expiredByRange            despawn flags — wrapper FX
+ * @property {boolean} expiredByBounds
+ * @property {boolean} expiredByDistance
+ */
+
+/**
+ * @typedef {Object} BulletUpdateContext
+ * @property {number} tickScale
+ * @property {number} logicTickSeconds
+ * @property {number} bulletSpeed                GAME_CONFIG.BULLET_SPEED
+ * @property {number} boundaryWidth
+ * @property {number} boundaryHeight
+ * @property {number} now                        frameClock.now (ms)
+ * @property {object|null} targetPlayer          for enemy homing
+ * @property {object|null} homingTarget          for player homing
+ * @property {Function} rngFloat                 [0,1) for jitter
+ */
+
+const ASTEROID_DEFAULT_RADIUS = 30;
+
+/**
+ * Construct a fresh AsteroidState.
+ * @param {AsteroidId|number} id
+ * @param {Partial<AsteroidState>} [overrides]
+ * @returns {AsteroidState}
+ */
+export function freshAsteroidState(id, overrides = {}) {
+    return {
+        id,
+        size: overrides.size !== undefined ? overrides.size : ASTEROID_DEFAULT_RADIUS,
+        x: overrides.x !== undefined ? overrides.x : 0,
+        y: overrides.y !== undefined ? overrides.y : 0,
+        vx: overrides.vx !== undefined ? overrides.vx : 0,
+        vy: overrides.vy !== undefined ? overrides.vy : 0,
+        radius: overrides.radius !== undefined ? overrides.radius : ASTEROID_DEFAULT_RADIUS,
+        rotX: overrides.rotX !== undefined ? overrides.rotX : 0,
+        rotY: overrides.rotY !== undefined ? overrides.rotY : 0,
+        rotZ: overrides.rotZ !== undefined ? overrides.rotZ : 0,
+        rotVelX: overrides.rotVelX !== undefined ? overrides.rotVelX : 0,
+        rotVelY: overrides.rotVelY !== undefined ? overrides.rotVelY : 0,
+        rotVelZ: overrides.rotVelZ !== undefined ? overrides.rotVelZ : 0,
+        hp: overrides.hp !== undefined ? overrides.hp : 1,
+        maxHp: overrides.maxHp !== undefined ? overrides.maxHp : 1,
+        level: overrides.level !== undefined ? overrides.level : 1,
+        active: overrides.active !== undefined ? overrides.active : true,
+        warping: overrides.warping !== undefined ? overrides.warping : false,
+        deathFlash: overrides.deathFlash !== undefined ? overrides.deathFlash : 0,
+    };
+}
+
+/**
+ * Construct a fresh BulletState. `kind` selects the per-tick step.
+ * @param {BulletId|number} id
+ * @param {string} kind                          'player' | 'enemy'
+ * @param {Partial<BulletState>} [overrides]
+ * @returns {BulletState}
+ */
+export function freshBulletState(id, kind, overrides = {}) {
+    return {
+        id,
+        kind,
+        shape: overrides.shape !== undefined ? overrides.shape : null,
+        movementPattern: overrides.movementPattern !== undefined ? overrides.movementPattern : 'aimed',
+        x: overrides.x !== undefined ? overrides.x : 0,
+        y: overrides.y !== undefined ? overrides.y : 0,
+        vx: overrides.vx !== undefined ? overrides.vx : 0,
+        vy: overrides.vy !== undefined ? overrides.vy : 0,
+        startX: overrides.startX !== undefined ? overrides.startX : 0,
+        startY: overrides.startY !== undefined ? overrides.startY : 0,
+        baseVx: overrides.baseVx !== undefined ? overrides.baseVx : 0,
+        baseVy: overrides.baseVy !== undefined ? overrides.baseVy : 0,
+        angle: overrides.angle !== undefined ? overrides.angle : 0,
+        rotation: overrides.rotation !== undefined ? overrides.rotation : 0,
+        rotationSpeed: overrides.rotationSpeed !== undefined ? overrides.rotationSpeed : 0,
+        life: overrides.life !== undefined ? overrides.life : (kind === 'player' ? 0 : 1.0),
+        maxLife: overrides.maxLife !== undefined ? overrides.maxLife : 60,
+        fadeFactor: overrides.fadeFactor !== undefined ? overrides.fadeFactor : 1.0,
+        damage: overrides.damage !== undefined ? overrides.damage : 1,
+        radius: overrides.radius !== undefined ? overrides.radius : 4,
+        baseRadius: overrides.baseRadius !== undefined ? overrides.baseRadius : 4,
+        maxRange: overrides.maxRange !== undefined ? overrides.maxRange : 600,
+        rangeMultiplier: overrides.rangeMultiplier !== undefined ? overrides.rangeMultiplier : 1.0,
+        active: overrides.active !== undefined ? overrides.active : true,
+        owner: overrides.owner !== undefined ? overrides.owner : null,
+        homing: overrides.homing !== undefined ? overrides.homing : false,
+        homingStrength: overrides.homingStrength !== undefined ? overrides.homingStrength : 0,
+        helixActive: overrides.helixActive !== undefined ? overrides.helixActive : false,
+        helixFreq: overrides.helixFreq !== undefined ? overrides.helixFreq : 0,
+        helixPhase: overrides.helixPhase !== undefined ? overrides.helixPhase : 0,
+        helixAmplitude: overrides.helixAmplitude !== undefined ? overrides.helixAmplitude : 0,
+        piercing: overrides.piercing !== undefined ? overrides.piercing : 0,
+        piercedEnemies: overrides.piercedEnemies !== undefined ? overrides.piercedEnemies : 0,
+        explosive: overrides.explosive !== undefined ? overrides.explosive : false,
+        explosionRadius: overrides.explosionRadius !== undefined ? overrides.explosionRadius : 30,
+        patternTimer: overrides.patternTimer !== undefined ? overrides.patternTimer : 0,
+        patternPhase: overrides.patternPhase !== undefined ? overrides.patternPhase : 0,
+        isPersistent: overrides.isPersistent !== undefined ? overrides.isPersistent : false,
+        maxLifetimeOverride: overrides.maxLifetimeOverride,
+        creationTime: overrides.creationTime !== undefined ? overrides.creationTime : 0,
+        targetPlayer: overrides.targetPlayer !== undefined ? overrides.targetPlayer : null,
+        bossRageHoming: overrides.bossRageHoming !== undefined ? overrides.bossRageHoming : false,
+        sinePhase: overrides.sinePhase !== undefined ? overrides.sinePhase : 0,
+        sineFreq: overrides.sineFreq !== undefined ? overrides.sineFreq : 0,
+        sineAmp: overrides.sineAmp !== undefined ? overrides.sineAmp : 0,
+        sinePerpX: overrides.sinePerpX !== undefined ? overrides.sinePerpX : 0,
+        sinePerpY: overrides.sinePerpY !== undefined ? overrides.sinePerpY : 0,
+        expiredByRange: false,
+        expiredByBounds: false,
+        expiredByDistance: false,
+    };
+}

--- a/tests/unit/sim/asteroid.test.js
+++ b/tests/unit/sim/asteroid.test.js
@@ -1,0 +1,110 @@
+// Pure asteroid-update unit tests.
+//
+// `updateAsteroid` was extracted from `js/modules/world/asteroid.js` in
+// the Phase-1 multiplayer engine refactor. These tests pin the behavior
+// the wrapper depends on: speed cap, position update with TICK_SCALE,
+// boundary bounce damping, rotation accumulation, death-flash gate.
+
+import { describe, test, expect } from '@jest/globals';
+import {
+    updateAsteroid,
+    ASTEROID_MAX_SPEED,
+    ASTEROID_BOUNCE_DAMP,
+} from '../../../js/sim/asteroid.js';
+import { freshAsteroidState } from '../../../js/sim/state.js';
+
+const TICK_SCALE = 30 / 60; // 0.5
+
+function freshCtx(overrides = {}) {
+    return {
+        field: { width: 1920, height: 1080 },
+        tickScale: TICK_SCALE,
+        wrapWidth: 1920,
+        wrapHeight: 1080,
+        ...overrides,
+    };
+}
+
+describe('updateAsteroid — early exits', () => {
+    test('inactive asteroid is not mutated', () => {
+        const a = freshAsteroidState(0, { active: false, x: 100, y: 100, vx: 5, vy: 5 });
+        const before = JSON.stringify({ x: a.x, y: a.y, vx: a.vx, vy: a.vy });
+        updateAsteroid(a, freshCtx(), []);
+        expect(JSON.stringify({ x: a.x, y: a.y, vx: a.vx, vy: a.vy })).toBe(before);
+    });
+    test('warping asteroid is not mutated by the sim', () => {
+        const a = freshAsteroidState(0, { warping: true, x: 50, y: 50, vx: 1, vy: 0 });
+        updateAsteroid(a, freshCtx(), []);
+        expect(a.x).toBe(50);
+        expect(a.y).toBe(50);
+    });
+    test('death flash counts down and deactivates at zero', () => {
+        const a = freshAsteroidState(0, { deathFlash: 1, x: 100, y: 100 });
+        updateAsteroid(a, freshCtx(), []);
+        expect(a.deathFlash).toBe(0);
+        expect(a.active).toBe(false);
+    });
+    test('death flash > 0 returns early (no motion)', () => {
+        const a = freshAsteroidState(0, { deathFlash: 3, x: 100, y: 100, vx: 5, vy: 5 });
+        updateAsteroid(a, freshCtx(), []);
+        expect(a.deathFlash).toBe(2);
+        expect(a.x).toBe(100);
+        expect(a.y).toBe(100);
+        expect(a.active).toBe(true);
+    });
+});
+
+describe('updateAsteroid — speed cap', () => {
+    test('|v| > 2.0 is renormalized to 2.0', () => {
+        const a = freshAsteroidState(0, { x: 100, y: 100, vx: 6, vy: 8 });
+        updateAsteroid(a, freshCtx(), []);
+        // hypot(6, 8) = 10 → renormalize to (1.2, 1.6).
+        // Position += (1.2, 1.6) * 0.5 = (0.6, 0.8).
+        expect(Math.hypot(a.vx, a.vy)).toBeCloseTo(ASTEROID_MAX_SPEED, 10);
+        expect(a.x).toBeCloseTo(100 + 0.6, 10);
+        expect(a.y).toBeCloseTo(100 + 0.8, 10);
+    });
+    test('|v| <= 2.0 is left alone', () => {
+        const a = freshAsteroidState(0, { x: 100, y: 100, vx: 1.0, vy: 1.0 });
+        updateAsteroid(a, freshCtx(), []);
+        expect(a.vx).toBeCloseTo(1.0, 10);
+        expect(a.vy).toBeCloseTo(1.0, 10);
+    });
+});
+
+describe('updateAsteroid — position update', () => {
+    test('x += vx * TICK_SCALE', () => {
+        const a = freshAsteroidState(0, { x: 500, y: 500, vx: 1.5, vy: 0 });
+        updateAsteroid(a, freshCtx(), []);
+        expect(a.x).toBeCloseTo(500.75, 10);
+        expect(a.y).toBeCloseTo(500, 10);
+    });
+});
+
+describe('updateAsteroid — boundary bounce', () => {
+    test('left wall bounces vx with 0.9 damp', () => {
+        const a = freshAsteroidState(0, { x: 5, y: 500, vx: -1.0, vy: 0, radius: 30 });
+        updateAsteroid(a, freshCtx(), []);
+        expect(a.x).toBe(30);
+        expect(a.vx).toBeCloseTo(1.0 * ASTEROID_BOUNCE_DAMP, 10);
+    });
+    test('right wall reverses vx with 0.9 damp', () => {
+        const a = freshAsteroidState(0, { x: 1900, y: 500, vx: 1.0, vy: 0, radius: 30 });
+        updateAsteroid(a, freshCtx(), []);
+        expect(a.x).toBe(1920 - 30);
+        expect(a.vx).toBeCloseTo(-1.0 * ASTEROID_BOUNCE_DAMP, 10);
+    });
+});
+
+describe('updateAsteroid — rotation', () => {
+    test('rot accumulates rotVel each tick', () => {
+        const a = freshAsteroidState(0, {
+            x: 500, y: 500,
+            rotVelX: 0.01, rotVelY: 0.02, rotVelZ: 0.03,
+        });
+        updateAsteroid(a, freshCtx(), []);
+        expect(a.rotX).toBeCloseTo(0.01, 10);
+        expect(a.rotY).toBeCloseTo(0.02, 10);
+        expect(a.rotZ).toBeCloseTo(0.03, 10);
+    });
+});

--- a/tests/unit/sim/bullet.test.js
+++ b/tests/unit/sim/bullet.test.js
@@ -1,0 +1,137 @@
+// Pure bullet-update unit tests.
+//
+// `updatePlayerBullet` and `updateEnemyBullet` were extracted from
+// `js/modules/player/bullet.js` and `js/modules/enemy/enemy-bullet.js`
+// in the Phase-1 multiplayer engine refactor. These tests pin the
+// behavior the wrappers depend on: lifetime decay, position
+// integration, helix offset, per-pattern velocity, despawn flags.
+
+import { describe, test, expect } from '@jest/globals';
+import {
+    updateBullet,
+    updatePlayerBullet,
+    updateEnemyBullet,
+} from '../../../js/sim/bullet.js';
+import { freshBulletState } from '../../../js/sim/state.js';
+
+const TICK_SCALE = 30 / 60; // 0.5
+const LOGIC_TICK_SECONDS = (1000 / 60) / 1000;
+
+function freshCtx(overrides = {}) {
+    return {
+        tickScale: TICK_SCALE,
+        logicTickSeconds: LOGIC_TICK_SECONDS,
+        bulletSpeed: 8,
+        boundaryWidth: 1920,
+        boundaryHeight: 1080,
+        now: 0,
+        targetPlayer: null,
+        homingTarget: null,
+        rngFloat: () => 0.5, // deterministic for jitter tests
+        ...overrides,
+    };
+}
+
+describe('updatePlayerBullet — early exit + lifetime', () => {
+    test('inactive bullet is not mutated', () => {
+        const b = freshBulletState(0, 'player', { active: false, x: 100, y: 100, vx: 5, vy: 0 });
+        const before = JSON.stringify({ x: b.x, y: b.y, life: b.life });
+        updatePlayerBullet(b, freshCtx(), []);
+        expect(JSON.stringify({ x: b.x, y: b.y, life: b.life })).toBe(before);
+    });
+    test('life increments by 1 each tick', () => {
+        const b = freshBulletState(0, 'player', { x: 500, y: 500, vx: 1, vy: 0, maxLife: 100 });
+        updatePlayerBullet(b, freshCtx(), []);
+        expect(b.life).toBe(1);
+    });
+    test('expiry sets active=false and expiredByRange=true', () => {
+        const b = freshBulletState(0, 'player', {
+            x: 500, y: 500, vx: 1, vy: 0,
+            life: 99, maxLife: 100, rangeMultiplier: 1.0,
+        });
+        updatePlayerBullet(b, freshCtx(), []);
+        expect(b.active).toBe(false);
+        expect(b.expiredByRange).toBe(true);
+    });
+});
+
+describe('updatePlayerBullet — movement', () => {
+    test('x += vx (NOT scaled by TICK_SCALE for player bullets)', () => {
+        const b = freshBulletState(0, 'player', { x: 500, y: 500, vx: 8, vy: 0, maxLife: 100 });
+        updatePlayerBullet(b, freshCtx(), []);
+        expect(b.x).toBe(508);
+        expect(b.y).toBe(500);
+    });
+});
+
+describe('updatePlayerBullet — out-of-bounds despawn', () => {
+    test('off-field x triggers expiredByBounds', () => {
+        const b = freshBulletState(0, 'player', { x: 2000, y: 500, vx: 8, vy: 0, maxLife: 100 });
+        updatePlayerBullet(b, freshCtx(), []);
+        expect(b.active).toBe(false);
+        expect(b.expiredByBounds).toBe(true);
+    });
+});
+
+describe('updateEnemyBullet — aimed pattern', () => {
+    test('straight movement scaled by TICK_SCALE', () => {
+        const b = freshBulletState(0, 'enemy', {
+            x: 500, y: 500,
+            vx: 4, vy: 0, baseVx: 4, baseVy: 0,
+            startX: 500, startY: 500, maxRange: 600,
+            movementPattern: 'aimed',
+        });
+        updateEnemyBullet(b, freshCtx(), []);
+        expect(b.x).toBe(500 + 4 * TICK_SCALE);
+    });
+});
+
+describe('updateEnemyBullet — distance-based lifetime', () => {
+    test('progress >= 1.0 sets expiredByRange', () => {
+        const b = freshBulletState(0, 'enemy', {
+            x: 1100, y: 500,
+            vx: 4, vy: 0, baseVx: 4, baseVy: 0,
+            startX: 500, startY: 500, maxRange: 600,
+            movementPattern: 'aimed',
+        });
+        updateEnemyBullet(b, freshCtx(), []);
+        expect(b.active).toBe(false);
+        expect(b.expiredByRange).toBe(true);
+    });
+});
+
+describe('updateBullet — dispatcher', () => {
+    test('dispatches to player when kind=player', () => {
+        const b = freshBulletState(0, 'player', { x: 500, y: 500, vx: 8, vy: 0, maxLife: 100 });
+        updateBullet(b, freshCtx(), []);
+        expect(b.x).toBe(508); // player bullets are unscaled
+        expect(b.life).toBe(1);
+    });
+    test('dispatches to enemy when kind=enemy', () => {
+        const b = freshBulletState(0, 'enemy', {
+            x: 500, y: 500, vx: 4, vy: 0, baseVx: 4, baseVy: 0,
+            startX: 500, startY: 500, maxRange: 600,
+            movementPattern: 'aimed',
+        });
+        updateBullet(b, freshCtx(), []);
+        expect(b.x).toBe(500 + 4 * TICK_SCALE); // enemy bullets are scaled
+    });
+});
+
+describe('updateEnemyBullet — mine pattern (stationary)', () => {
+    test('mine pattern zeroes velocity', () => {
+        const b = freshBulletState(0, 'enemy', {
+            x: 500, y: 500, vx: 5, vy: 5,
+            baseVx: 5, baseVy: 5,
+            startX: 500, startY: 500, maxRange: 600,
+            movementPattern: 'mine', shape: 'mine',
+            isPersistent: true, creationTime: 0,
+        });
+        updateEnemyBullet(b, freshCtx({ now: 100 }), []);
+        // Mine pattern sets vel to 0,0 so x/y unchanged.
+        expect(b.vx).toBe(0);
+        expect(b.vy).toBe(0);
+        expect(b.x).toBe(500);
+        expect(b.y).toBe(500);
+    });
+});


### PR DESCRIPTION
Round-2 Phase-1 engine refactor. Extracts asteroid drift/rotation/boundary and player+enemy bullet ballistics into pure-function modules under `js/sim/`, mirroring agent A's `mp/sim-ship-extract` pattern.

## What's in here

- new: `js/sim/asteroid.js` (156 lines) — pure asteroid drift / boundary / rotation
- new: `js/sim/bullet.js` (624 lines) — pure player + enemy ballistics; split into `updatePlayerBullet` + `updateEnemyBullet` because state shapes diverged enough that a unified path was uglier
- expanded: `js/sim/state.js` — adds `AsteroidState`, `BulletState`, `AsteroidUpdateContext`, `BulletUpdateContext` typedefs + `freshAsteroidState`, `freshBulletState` factories
- expanded: `js/sim/index.js` — re-exports the new helpers
- modified: `js/modules/world/asteroid.js` — wraps `updateAsteroid`
- modified: `js/modules/player/bullet.js` — wraps `updateBullet` + new `_pickHomingTarget`
- modified: `js/modules/enemy/enemy-bullet.js` — wraps `updateEnemyBullet`
- new: `tests/unit/sim/asteroid.test.js` (9 tests pinning constants)
- new: `tests/unit/sim/bullet.test.js` (11 tests pinning per-shape behaviors)

## Trickiest preserved behaviors

- `missile_decelerate` PROWLER_PIKE constants resolved by the wrapper (pure sim doesn't import constants)
- `homing_mine` carries `targetPlayer` ref through the context bag
- `titan_rocket` / `missile_decelerate` set `expiredByDistance` so the wrapper plays explosion FX vs disappear-puff for `expiredByRange`
- helix offset applies the **delta** of the sine each frame to preserve phase-0/π crossover
- `sine_wave` / `sine_wave_nospin` carry `sinePhase` across so oscillation doesn't reset

## Verification

- `npm run test:unit` → 244/244 (224 baseline + 20 new)
- `npm run build` → green (665 KB)
- `npm run codegen:check`, `npm run schema:check` → both green

## Coordination

- Round-2 sibling of #13 (mp/sim-enemy-extract, agent D) and mp/sim-wave-drops-extract (agent F).
- Pattern matches PR #10 (mp/sim-ship-extract, agent A): pure functions in `js/sim/`, wrappers in existing modules, no `game-engine.js` touch.
- Asteroid split-on-hit logic (1 large → N fragments) lives in `js/modules/combat/collision-system.js` — out of scope; will move when collision migrates.
- Rust mirror (`server/src/sim/asteroid.rs` + `server/src/sim/bullet.rs`) follows agent B's pattern in a future session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)