### PR TITLE
mp/sim-rs: port asteroid physics to Rust + parity fixture (Phase 2)

### DIFF
--- a/server/src/sim/asteroid.rs
+++ b/server/src/sim/asteroid.rs
@@ -1,5 +1,246 @@
-//! Asteroid spawn + split. Stub. Wave cap is 12 (see CLAUDE.md memory).
+//! Asteroid physics — authoritative, mirroring `js/sim/asteroid.js::updateAsteroid()`.
+//!
+//! Tick model: `update_asteroid` advances one asteroid by exactly one logic
+//! tick. Position deltas are scaled by `ctx.tick_scale` (matching the JS
+//! `30/60 = 0.5` used in solo gameplay). The constants `ASTEROID_MAX_SPEED`
+//! and `ASTEROID_BOUNCE_DAMP` are copied verbatim from `js/sim/asteroid.js`
+//! and are the binding contract with the JS pure step.
+//!
+//! The `Asteroid` struct here is the SIM-LEVEL working state — distinct
+//! from the wire-level `crate::protocol::AsteroidState` (which is just
+//! `id`/`size`/`x`/`y` for snapshots). The wire type and the sim type
+//! converge in Phase 3 when client prediction wires through.
+//!
+//! What lives here:
+//!   - Speed-cap clamp (currentSpeed > 2.0 → renormalize to 2.0)
+//!   - Position update (x += vx * tick_scale)
+//!   - Boundary bounce (with 0.9 damp) OR wraparound fallback
+//!   - 3D rotation accumulation (rot_x += rot_vel_x, etc.)
+//!   - Death-flash countdown (tick down, deactivate at 0)
+//!
+//! Out of scope (deferred to later sessions):
+//!   - Warp-in entry animation (presentation; wrapper handles)
+//!   - 3D vertex projection (drawing concern)
+//!   - Hit-flash visual timer (presentation)
+//!   - Split logic — the live game does it from the collision system,
+//!     which will move into `sim/collision.rs` in a later session.
+//!
+//! Parity fixture: `server/tests/parity_asteroid.rs::asteroid_basic_drift`
+//! drives 60 ticks of pure linear drift with field 1920×1080 and asserts
+//! agreement with JS within f32 tolerance (0.01 px / 0.001 rad).
+//!
+//! The existing `update_all` stub at the bottom of this file is a
+//! placeholder for the wire-state integration that gets wired in Phase 3
+//! (snapshot diff). It is intentionally left untouched here; the new
+//! `update_asteroid` is the parity-tested function.
 
 use crate::protocol::{AsteroidState, GameEvent};
 
+use super::state::Field;
+
+// ── Constants copied verbatim from js/sim/asteroid.js ───────────────────
+//
+// JS: `const ASTEROID_MAX_SPEED = 2.0;` (asteroid.js:37)
+// Drift cap (px per logic tick, post-scale). Split fragments may spawn
+// at 4.5–7.5 initial speed and renormalize to this on the next tick.
+pub const ASTEROID_MAX_SPEED: f32 = 2.0;
+
+// JS: `const ASTEROID_BOUNCE_DAMP = 0.9;` (asteroid.js:41)
+// Boundary-bounce energy retention — slightly more elastic than the
+// ship's 0.8 (intentional gameplay feel difference).
+pub const ASTEROID_BOUNCE_DAMP: f32 = 0.9;
+
+/// Sim-level asteroid state. Mirrors the JS `AsteroidState` typedef
+/// in `js/sim/state.js` (lines 387–407, agent E's round-2 addition).
+///
+/// `f32` throughout for parity with the JS f64 → f32 boundary at the
+/// snapshot wire layer. `bool` for `active` / `warping`. `u32` for the
+/// death-flash countdown (frames remaining, decremented per tick).
+#[derive(Debug, Clone, Copy)]
+pub struct Asteroid {
+    pub id: u32,
+    pub size: f32,
+    pub x: f32,
+    pub y: f32,
+    pub vx: f32,
+    pub vy: f32,
+    pub radius: f32,
+    pub rot_x: f32,
+    pub rot_y: f32,
+    pub rot_z: f32,
+    pub rot_vel_x: f32,
+    pub rot_vel_y: f32,
+    pub rot_vel_z: f32,
+    pub hp: f32,
+    pub max_hp: f32,
+    pub level: u32,
+    pub active: bool,
+    pub warping: bool,
+    pub death_flash: u32,
+}
+
+impl Asteroid {
+    /// Construct a fresh asteroid with the JS `freshAsteroidState`
+    /// defaults (state.js:501–523). Override fields by mutating after
+    /// construction or via struct-update syntax.
+    pub fn fresh(id: u32) -> Self {
+        Self {
+            id,
+            size: 30.0,
+            x: 0.0,
+            y: 0.0,
+            vx: 0.0,
+            vy: 0.0,
+            radius: 30.0,
+            rot_x: 0.0,
+            rot_y: 0.0,
+            rot_z: 0.0,
+            rot_vel_x: 0.0,
+            rot_vel_y: 0.0,
+            rot_vel_z: 0.0,
+            hp: 1.0,
+            max_hp: 1.0,
+            level: 1,
+            active: true,
+            warping: false,
+            death_flash: 0,
+        }
+    }
+}
+
+/// Per-tick context for `update_asteroid`. Mirrors the JS
+/// `AsteroidUpdateContext` typedef (state.js:410–415).
+///
+/// `field: None` selects the wraparound branch (effectively dead in
+/// solo play; kept for robustness — see `update_asteroid` for details).
+#[derive(Debug, Clone)]
+pub struct AsteroidContext {
+    pub field: Option<Field>,
+    pub tick_scale: f32,
+    pub wrap_width: f32,
+    pub wrap_height: f32,
+}
+
+/// Pure asteroid-update step. One tick of motion + rotation.
+///
+/// Order of operations is **load-bearing for parity** — see the
+/// matching block comments in `js/sim/asteroid.js::updateAsteroid()`.
+/// Do not reorder without a matching change on the JS side.
+///
+/// The `events` out-buffer is currently never written to; the slot
+/// reserves space for the upcoming split migration when collision
+/// moves into the sim layer.
+pub fn update_asteroid(
+    asteroid: &mut Asteroid,
+    ctx: &AsteroidContext,
+    _events: &mut Vec<AsteroidEvent>,
+) {
+    if !asteroid.active {
+        return;
+    }
+
+    // ── Warp-in: skip motion / boundary while phasing in ──
+    // The wrapper handles the warp animation (presentation concern).
+    // Early-exit so rotation & position don't double-advance.
+    if asteroid.warping {
+        return;
+    }
+
+    // ── Death flash: tick down, deactivate at zero ──
+    // JS asteroid.js:70–76. Motion stops once mid-explosion.
+    if asteroid.death_flash > 0 {
+        asteroid.death_flash -= 1;
+        if asteroid.death_flash == 0 {
+            asteroid.active = false;
+        }
+        return;
+    }
+
+    // ── Speed cap ──
+    // JS asteroid.js:83–87. Renormalize when |v| > 2.0.
+    let speed = (asteroid.vx * asteroid.vx + asteroid.vy * asteroid.vy).sqrt();
+    if speed > ASTEROID_MAX_SPEED {
+        asteroid.vx = (asteroid.vx / speed) * ASTEROID_MAX_SPEED;
+        asteroid.vy = (asteroid.vy / speed) * ASTEROID_MAX_SPEED;
+    }
+
+    // ── Position update ──
+    // JS asteroid.js:92–93. The `* tick_scale` factor matches the
+    // 30 Hz logical units the JS engine stores velocities in.
+    asteroid.x += asteroid.vx * ctx.tick_scale;
+    asteroid.y += asteroid.vy * ctx.tick_scale;
+
+    // ── Boundary handling ──
+    // JS asteroid.js:98–126. With a field, bounce with 0.9 damp;
+    // without a field, fall back to torus wraparound at radius * 2 buffer.
+    if let Some(field) = &ctx.field {
+        let r = asteroid.radius;
+        if asteroid.x - r < 0.0 {
+            asteroid.x = r;
+            asteroid.vx = asteroid.vx.abs() * ASTEROID_BOUNCE_DAMP;
+        } else if asteroid.x + r > field.width {
+            asteroid.x = field.width - r;
+            asteroid.vx = -asteroid.vx.abs() * ASTEROID_BOUNCE_DAMP;
+        }
+        if asteroid.y - r < 0.0 {
+            asteroid.y = r;
+            asteroid.vy = asteroid.vy.abs() * ASTEROID_BOUNCE_DAMP;
+        } else if asteroid.y + r > field.height {
+            asteroid.y = field.height - r;
+            asteroid.vy = -asteroid.vy.abs() * ASTEROID_BOUNCE_DAMP;
+        }
+    } else {
+        // Wraparound — only used when no field is supplied. Live engine
+        // call sites always pass a field; kept for robustness.
+        let buf = asteroid.radius * 2.0;
+        if asteroid.x < -buf {
+            asteroid.x = ctx.wrap_width + buf;
+        }
+        if asteroid.x > ctx.wrap_width + buf {
+            asteroid.x = -buf;
+        }
+        if asteroid.y < -buf {
+            asteroid.y = ctx.wrap_height + buf;
+        }
+        if asteroid.y > ctx.wrap_height + buf {
+            asteroid.y = -buf;
+        }
+    }
+
+    // ── 3D rotation ──
+    // JS asteroid.js:133–135. Always runs (even if motion is clamped)
+    // matching the original "for consistency" comment.
+    asteroid.rot_x += asteroid.rot_vel_x;
+    asteroid.rot_y += asteroid.rot_vel_y;
+    asteroid.rot_z += asteroid.rot_vel_z;
+}
+
+/// Loop helper. Calls `update_asteroid` over a slice with the same context.
+pub fn update_asteroids(
+    asteroids: &mut [Asteroid],
+    ctx: &AsteroidContext,
+    events: &mut Vec<AsteroidEvent>,
+) {
+    for asteroid in asteroids.iter_mut() {
+        update_asteroid(asteroid, ctx, events);
+    }
+}
+
+/// Side-effect events emitted by `update_asteroid`. Currently empty;
+/// reserved for the upcoming split migration when collision moves
+/// into the sim layer (the split happens on bullet-hit, not on tick,
+/// so the variant set here is conservative).
+#[derive(Debug, Clone, Copy)]
+pub enum AsteroidEvent {
+    /// Reserved. The split event will land here when collision moves
+    /// into the sim layer — `parent_id` plus the spawned fragment count
+    /// will let the engine driver materialize the children pool entries.
+    Split { parent_id: u32, fragments: u8 },
+}
+
+// ── Wire-state integration stub (Phase 3) ───────────────────────────────
+//
+// Existing entry point called from `simulate_tick` in `mod.rs`. The
+// real wire ↔ sim bridging will land when client prediction wires up;
+// for now this is a no-op that satisfies the existing call site.
 pub fn update_all(_asteroids: &mut Vec<AsteroidState>, _dt: f32, _events: &mut Vec<GameEvent>) {}

--- a/server/tests/parity_asteroid.rs
+++ b/server/tests/parity_asteroid.rs
@@ -1,0 +1,109 @@
+//! Cross-language parity vector for asteroid physics.
+//!
+//! Drives the Rust `update_asteroid` step over 60 ticks of pure linear
+//! drift (no boundary hit, no speed-cap clamp, no death-flash) and
+//! asserts agreement with the JS pure step in `js/sim/asteroid.js`
+//! within an f32 tolerance.
+//!
+//! The reference values were captured 2026-05-10 with:
+//!
+//! ```bash
+//! node --input-type=module -e "
+//!   import { updateAsteroid } from './js/sim/asteroid.js';
+//!   import { freshAsteroidState } from './js/sim/state.js';
+//!   const a = freshAsteroidState(1, {
+//!     x: 200, y: 200, vx: 1.5, vy: 0.8,
+//!     radius: 30, rotVelX: 0.01, rotVelY: 0.02, rotVelZ: 0.005,
+//!   });
+//!   const ctx = { field: { width: 1920, height: 1080 }, tickScale: 0.5,
+//!                 wrapWidth: 1920, wrapHeight: 1080 };
+//!   for (let i = 0; i < 60; i++) updateAsteroid(a, ctx, []);
+//!   console.log(JSON.stringify({
+//!     x: a.x, y: a.y, vx: a.vx, vy: a.vy,
+//!     rotX: a.rotX, rotY: a.rotY, rotZ: a.rotZ, active: a.active,
+//!   }));
+//! "
+//! # → {"x":245,"y":224.00000000000034,"vx":1.5,"vy":0.8,
+//! #    "rotX":0.6000000000000003,"rotY":1.2000000000000006,"rotZ":0.30000000000000016,
+//! #    "active":true}
+//! ```
+//!
+//! Tolerance: f64 (JS) ↔ f32 (Rust) drift over 60 ticks of linear drift
+//! is tiny (no accumulated multiplication — just `vx * tick_scale * 60`).
+//! Position tolerance 0.01 px / rotation tolerance 0.001 rad would suffice;
+//! we use 0.01 throughout for symmetry with `ship_basic_movement`.
+
+use rainboids_server::sim::asteroid::{
+    update_asteroid, Asteroid, AsteroidContext, AsteroidEvent,
+};
+use rainboids_server::sim::state::Field;
+
+#[test]
+fn asteroid_basic_drift() {
+    // Setup: asteroid at (200, 200), velocity (1.5, 0.8), inside the
+    // field (1920×1080) — well clear of all boundaries for 60 ticks at
+    // tick_scale=0.5. Rotation velocities are non-zero so the rotation
+    // accumulator gets exercised. Speed (hypot ≈ 1.7) is below the 2.0
+    // cap so no clamp fires.
+    let mut a = Asteroid::fresh(1);
+    a.x = 200.0;
+    a.y = 200.0;
+    a.vx = 1.5;
+    a.vy = 0.8;
+    a.radius = 30.0;
+    a.rot_vel_x = 0.01;
+    a.rot_vel_y = 0.02;
+    a.rot_vel_z = 0.005;
+
+    let ctx = AsteroidContext {
+        field: Some(Field {
+            width: 1920.0,
+            height: 1080.0,
+        }),
+        tick_scale: 0.5,
+        wrap_width: 1920.0,
+        wrap_height: 1080.0,
+    };
+
+    let mut events: Vec<AsteroidEvent> = Vec::new();
+    for _ in 0..60 {
+        update_asteroid(&mut a, &ctx, &mut events);
+    }
+
+    eprintln!(
+        "RUST-EMITS: {{\"x\":{},\"y\":{},\"vx\":{},\"vy\":{},\"rotX\":{},\"rotY\":{},\"rotZ\":{},\"active\":{}}}",
+        a.x, a.y, a.vx, a.vy, a.rot_x, a.rot_y, a.rot_z, a.active
+    );
+
+    // JS reference values captured 2026-05-10 (see header docstring).
+    let expected_x: f32 = 245.0;
+    let expected_y: f32 = 224.0;
+    let expected_vx: f32 = 1.5;
+    let expected_vy: f32 = 0.8;
+    let expected_rot_x: f32 = 0.6;
+    let expected_rot_y: f32 = 1.2;
+    let expected_rot_z: f32 = 0.3;
+
+    let close = |actual: f32, expected: f32, what: &str| {
+        let delta = (actual - expected).abs();
+        assert!(
+            delta < 0.01,
+            "{} diverged: rust={}, js={}, |Δ|={}",
+            what,
+            actual,
+            expected,
+            delta,
+        );
+    };
+
+    close(a.x, expected_x, "asteroid.x");
+    close(a.y, expected_y, "asteroid.y");
+    close(a.vx, expected_vx, "asteroid.vx");
+    close(a.vy, expected_vy, "asteroid.vy");
+    close(a.rot_x, expected_rot_x, "asteroid.rotX");
+    close(a.rot_y, expected_rot_y, "asteroid.rotY");
+    close(a.rot_z, expected_rot_z, "asteroid.rotZ");
+    assert!(a.active, "asteroid.active should remain true");
+    // events buffer untouched — split is reserved for collision-system port.
+    assert!(events.is_empty(), "no events expected on basic-drift path");
+}


### PR DESCRIPTION
## Summary
First Rust mirror of the Phase-1 pure-step pipeline (task #30). Mirrors `js/sim/asteroid.js::updateAsteroid` byte-for-byte:

- `Asteroid` struct (sim-level working state, distinct from the wire `AsteroidState` which is just `id`/`size`/`x`/`y` for snapshots).
- `AsteroidContext` (field, tick_scale, wrap_width, wrap_height).
- `update_asteroid(asteroid, ctx, events)` pure step.
- `update_asteroids` loop helper.
- `AsteroidEvent` enum (currently only `Split`, reserved for the collision-system port; never emitted today).

## Constants extracted (with JS line-number anchors)
- `ASTEROID_MAX_SPEED = 2.0` (asteroid.js:37)
- `ASTEROID_BOUNCE_DAMP = 0.9` (asteroid.js:41)

## Order of operations
Matches JS exactly: warp gate → death-flash countdown → speed cap → position update → boundary handling (bounce-with-damp OR wraparound fallback) → 3D rotation accumulation. Each block has a JS line-number comment for cross-reference.

## Parity fixture
`server/tests/parity_asteroid.rs::asteroid_basic_drift`:
- Asteroid at (200, 200), v=(1.5, 0.8), radius 30, rotVel set.
- Field 1920×1080, tick_scale 0.5.
- 60 ticks of pure linear drift (no boundary, no clamp, no flash).
- Asserts (x, y, vx, vy, rot_x, rot_y, rot_z) within 0.01 tolerance.
- JS goldens captured via node one-liner (in test docstring).

JS reference: `{"x":245,"y":224,"vx":1.5,"vy":0.8,"rotX":0.6,"rotY":1.2,"rotZ":0.3,"active":true}` — Rust emits identical values within tolerance.

## Test plan
- [x] `cargo test --test parity_asteroid` — 1 passed
- [x] `cargo build` — clean, no warnings
- [x] Existing `update_all` stub preserved unchanged (still satisfies `simulate_tick` call site in `mod.rs`)
- [ ] Sibling Phase-2 ports (bullet, wave, drops, enemy) coming in subsequent PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)