### PR TITLE
mp/sim-rs: drops magnet + tractor + expiry parity fixtures (Phase 2.1)

### DIFF
--- a/server/tests/parity_drops.rs
+++ b/server/tests/parity_drops.rs
@@ -146,3 +146,230 @@ fn drop_basic_drift_friction() {
         drop.opacity
     );
 }
+
+// ─── Helpers reused across the magnet / tractor / expiry tests ─────────
+
+fn close(actual: f32, expected: f32, what: &str) {
+    let delta = (actual - expected).abs();
+    assert!(
+        delta < 0.01,
+        "{} diverged: rust={}, js={}, |Δ|={}",
+        what,
+        actual,
+        expected,
+        delta,
+    );
+}
+
+fn make_ship(x: f32, y: f32) -> ShipState {
+    ShipState {
+        player: PlayerId(1),
+        x,
+        y,
+        vx: 0.0,
+        vy: 0.0,
+        angle: 0.0,
+        hp: 100.0,
+        shield: 0.0,
+    }
+}
+
+#[test]
+fn drop_health_magnet_gentle_pull() {
+    // Health orb at (400, 200), ship at (200, 200) — distance 200 px,
+    // inside the 320 px FAR radius but outside the 120 px NEAR radius.
+    // Only the gentle pull fires (force 8). 5 ticks captured pre-overshoot
+    // — long enough to validate the magnet-pull formula but short enough
+    // that f32↔f64 drift stays under tolerance (the drop oscillates
+    // around the ship at higher tick counts, amplifying drift past
+    // 0.01 px).
+    //
+    // JS reference values captured 2026-05-10 from `js/sim/drops.js`
+    // (5 ticks):
+    //
+    //   {"x":373.61871165268,"y":200,"vx":-14.037653316002999,"vy":0}
+    let mut drop = Drop {
+        id: 1,
+        kind: DropKind::Health,
+        x: 400.0,
+        y: 200.0,
+        vx: 0.0,
+        vy: 0.0,
+        ..Drop::default()
+    };
+    let ships = vec![make_ship(200.0, 200.0)];
+    let ctx = DropContext {
+        ships: &ships,
+        field: Field { width: 1920.0, height: 1080.0 },
+        dt: 1.0_f32 / 60.0,
+        tractor_engaged: false,
+        tractor_attraction: 0.0,
+        tractor_range: 0.0,
+    };
+
+    let mut events: Vec<DropEvent> = Vec::new();
+    for _ in 0..5 {
+        update_drop(&mut drop, &ctx, &mut events);
+    }
+
+    eprintln!(
+        "RUST-EMITS gentle_magnet: {{\"x\":{},\"y\":{},\"vx\":{},\"vy\":{}}}",
+        drop.x, drop.y, drop.vx, drop.vy
+    );
+
+    close(drop.x, 373.618_72, "drop.x");
+    close(drop.y, 200.0, "drop.y");
+    close(drop.vx, -14.037_653, "drop.vx");
+    close(drop.vy, 0.0, "drop.vy");
+    assert!(drop.active);
+}
+
+#[test]
+fn drop_health_magnet_snap_pull() {
+    // Health orb at (300, 200), ship at (200, 200) — distance 100 px,
+    // inside both 320 (FAR) and 120 (NEAR) radii. Both gentle (force 8)
+    // AND snap (force 22) pulls fire together — total per-tick force is
+    // ~30. 3 ticks captured pre-overshoot — both pulls active but the
+    // orb hasn't crossed the ship yet (no oscillation yet, so f32↔f64
+    // drift stays well under tolerance).
+    //
+    // JS reference values captured 2026-05-10 from `js/sim/drops.js`
+    // (3 ticks):
+    //
+    //   {"x":273.7582777777778,"y":200,"vx":-32.442081018518515,"vy":0}
+    let mut drop = Drop {
+        id: 2,
+        kind: DropKind::Health,
+        x: 300.0,
+        y: 200.0,
+        vx: 0.0,
+        vy: 0.0,
+        ..Drop::default()
+    };
+    let ships = vec![make_ship(200.0, 200.0)];
+    let ctx = DropContext {
+        ships: &ships,
+        field: Field { width: 1920.0, height: 1080.0 },
+        dt: 1.0_f32 / 60.0,
+        tractor_engaged: false,
+        tractor_attraction: 0.0,
+        tractor_range: 0.0,
+    };
+
+    let mut events: Vec<DropEvent> = Vec::new();
+    for _ in 0..3 {
+        update_drop(&mut drop, &ctx, &mut events);
+    }
+
+    eprintln!(
+        "RUST-EMITS snap_magnet: {{\"x\":{},\"y\":{},\"vx\":{},\"vy\":{}}}",
+        drop.x, drop.y, drop.vx, drop.vy
+    );
+
+    close(drop.x, 273.758_28, "drop.x");
+    close(drop.y, 200.0, "drop.y");
+    close(drop.vx, -32.442_08, "drop.vx");
+    close(drop.vy, 0.0, "drop.vy");
+    assert!(drop.active);
+}
+
+#[test]
+fn drop_money_pixel_tractor_pull() {
+    // Money-pixel orb (NOT health — magnet is OFF for non-health drops)
+    // at (400, 400), ship at (300, 300) — distance ≈ 141 px. Tractor beam
+    // engaged with attraction=0.05, range=500 px. Drop is pulled along
+    // the diagonal toward the ship; the lighter 0.985 friction (vs 0.92
+    // health) keeps the velocity from settling as fast.
+    //
+    // The tractor formula is: f = attraction * (1 - dist/range), then
+    // applied per-tick along the unit vector toward the ship, scaled by
+    // the orb's z (default 2.0 for collectibles). Net: a soft fall-off
+    // pull that grows as the orb approaches.
+    //
+    // JS reference values captured 2026-05-10 from `js/sim/drops.js`:
+    //
+    //   {"x":380.7627814276665,"y":380.7627814276665,
+    //    "vx":-1.2692646293803131,"vy":-1.2692646293803131}
+    let mut drop = Drop {
+        id: 3,
+        kind: DropKind::MoneyPixel,
+        x: 400.0,
+        y: 400.0,
+        vx: 0.0,
+        vy: 0.0,
+        ..Drop::default()
+    };
+    let ships = vec![make_ship(300.0, 300.0)];
+    let ctx = DropContext {
+        ships: &ships,
+        field: Field { width: 1920.0, height: 1080.0 },
+        dt: 1.0_f32 / 60.0,
+        tractor_engaged: true,
+        tractor_attraction: 0.05,
+        tractor_range: 500.0,
+    };
+
+    let mut events: Vec<DropEvent> = Vec::new();
+    for _ in 0..30 {
+        update_drop(&mut drop, &ctx, &mut events);
+    }
+
+    eprintln!(
+        "RUST-EMITS tractor: {{\"x\":{},\"y\":{},\"vx\":{},\"vy\":{}}}",
+        drop.x, drop.y, drop.vx, drop.vy
+    );
+
+    close(drop.x, 380.762_78, "drop.x");
+    close(drop.y, 380.762_78, "drop.y");
+    close(drop.vx, -1.269_264_6, "drop.vx");
+    close(drop.vy, -1.269_264_6, "drop.vy");
+    assert!(drop.active);
+}
+
+#[test]
+fn drop_lifetime_expiry_deactivates() {
+    // Health orb with life=10 at (500, 500), ship far away (no magnet).
+    // Drift at vx=0.5. Run 15 ticks — the lifetime tick decrements life
+    // by 1 each call; on tick 11 life reaches 0 and `active` flips to
+    // false. Once inactive, subsequent calls early-return without
+    // touching position, so the final x is just the friction-attenuated
+    // drift across exactly 10 active ticks.
+    //
+    // JS reference values captured 2026-05-10 from `js/sim/drops.js`:
+    //
+    //   {"x":503.03507216110233,"y":500,"active":false,"life":0}
+    let mut drop = Drop {
+        id: 4,
+        kind: DropKind::Health,
+        x: 500.0,
+        y: 500.0,
+        vx: 0.5,
+        vy: 0.0,
+        life: 10,
+        ..Drop::default()
+    };
+    let ships = vec![make_ship(5000.0, 5000.0)];
+    let ctx = DropContext {
+        ships: &ships,
+        field: Field { width: 1920.0, height: 1080.0 },
+        dt: 1.0_f32 / 60.0,
+        tractor_engaged: false,
+        tractor_attraction: 0.0,
+        tractor_range: 0.0,
+    };
+
+    let mut events: Vec<DropEvent> = Vec::new();
+    for _ in 0..15 {
+        update_drop(&mut drop, &ctx, &mut events);
+    }
+
+    eprintln!(
+        "RUST-EMITS expiry: {{\"x\":{},\"y\":{},\"active\":{},\"life\":{}}}",
+        drop.x, drop.y, drop.active, drop.life
+    );
+
+    close(drop.x, 503.035_07, "drop.x");
+    close(drop.y, 500.0, "drop.y");
+    assert!(!drop.active, "drop should be deactivated after lifetime expiry");
+    assert_eq!(drop.life, 0, "life should be exactly 0 at expiry");
+}


### PR DESCRIPTION
## Summary
Validates the previously-coded but untested branches of `server/src/sim/drops.rs`. **No changes to `drops.rs` itself** — pure parity-test coverage.

| Fixture | Scenario | Tolerance |
|---|---|---|
| `drop_health_magnet_gentle_pull` | Health orb 200 px from ship (FAR=320, NEAR=120 — gentle only fires) | 0.01 px @ 5 ticks |
| `drop_health_magnet_snap_pull` | Health orb 100 px from ship (both gentle + snap fire, total ~30 force) | 0.01 px @ 3 ticks |
| `drop_money_pixel_tractor_pull` | Gold-pixel orb (no magnet) with tractor_engaged=true, range=500, attraction=0.05 | 0.01 px @ 30 ticks |
| `drop_lifetime_expiry_deactivates` | Health orb life=10, run 15 ticks → active=false at tick 11 | exact-match on active+life |

## Why short tick counts on magnet tests
The orb oscillates around the ship at high velocity post-overshoot. f32↔f64 drift accumulates rapidly through that chaotic regime. 5/3-tick pre-overshoot scenarios cleanly validate the magnet formulas without numerical chaos.

This is a real-world consideration for Phase 3 prediction: the chaotic regime is a bigger threat than steady-state physics. Mitigation strategies (fixed-point math, quantized snapshot anchoring) deferred until prediction wiring makes it load-bearing.

The tractor test uses 30 ticks because the soft fall-off `(1 - dist/range)` keeps the orb's trajectory monotonic (no oscillation).

## Test plan
- [x] `cargo test --test parity_drops` — 5 passed (1 original + 4 new)
- [x] All other workspace tests still green

## Phase 2.1 progress (task #45)
- ✓ drops magnet + tractor + expiry (this PR)
- ⏳ asteroid bounce + death-flash (sibling PR coming next, subagent ran in parallel)
- ⬜ enemy hunter_arc + 9 remaining kinds (blocked on PR #23 merging)
- ⬜ bullet helix + homing + piercing + explosive
- ⬜ enemy bullets (17 movement patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)