### PR TITLE
mp/sim-rs: wave context — ships + rng plumbing (Phase 2.1)

### DIFF
--- a/server/src/sim/wave.rs
+++ b/server/src/sim/wave.rs
@@ -46,7 +46,7 @@
 
 use rand_pcg::Pcg64;
 
-use crate::protocol::{EnemyState, GameEvent};
+use crate::protocol::{EnemyState, GameEvent, ShipState};
 
 use super::state::WaveState;
 
@@ -150,14 +150,39 @@ impl Wave {
 /// Per-tick context for `update_wave`. Mirrors the JS
 /// `WaveUpdateContext` typedef (state.js:316–327).
 ///
-/// Fields on the JS side that are not yet consumed by `updateWave`
-/// (`ships`, `rng`) are intentionally omitted here — they will be
-/// added when randomized scheduling lands. Adding them now would be
-/// dead weight on every call site.
-#[derive(Debug, Clone, Copy)]
-pub struct WaveContext {
+/// **Currently unread fields** (`ships`, `rng`):
+///
+/// The JS `WaveUpdateContext` typedef declares both `ships` and `rng`
+/// — see `js/sim/wave.js` lines 98–102 and the corresponding state
+/// typedef — but the JS `updateWave` body **does not read either**.
+/// `wave-data.js` is fully deterministic (zero `Math.random` /
+/// `ctx.rng` references; no randomized branches in the campaign
+/// schedule).
+///
+/// We carry the fields in the Rust shape anyway so:
+///   1. The wrapper / call sites already have somewhere to plug in
+///      ship snapshots and a seeded `Pcg64` (no signature churn when
+///      randomized scheduling lands).
+///   2. The parity fixture can prove that populating these fields
+///      with non-default values does NOT alter the spawn sequence
+///      (`parity_wave::wave1_with_populated_context`).
+///
+/// When randomized scheduling is introduced (e.g., a future
+/// "substitute one Hunter with a Wasp on Pcg64::gen_bool(0.3)"
+/// branch), `update_wave` will start reading these fields and the
+/// `#[allow(dead_code)]` attribute will be removed.
+#[allow(dead_code)] // ships + rng reserved for future randomized scheduling — see doc comment.
+pub struct WaveContext<'a> {
     pub enemy_count: u32,
     pub dt: f32,
+    /// Ship snapshots for any future "spawn enemies near the player"
+    /// scheduling. Empty slice = no ships (e.g., between rounds).
+    /// **Unread by `update_wave` today.**
+    pub ships: &'a [ShipState],
+    /// Seeded RNG for any future randomized branch. `None` = no RNG
+    /// available (also acceptable — the current implementation never
+    /// touches it). **Unread by `update_wave` today.**
+    pub rng: Option<&'a mut Pcg64>,
 }
 
 /// Side-effect events emitted by `update_wave`. Mirrors the JS event
@@ -535,7 +560,14 @@ pub fn is_boss_wave(wave: u32) -> bool {
 /// Order of operations is **load-bearing for parity** — see the
 /// matching block comments in `js/sim/wave.js::updateWave()`. Do not
 /// reorder without a matching change on the JS side.
-pub fn update_wave(wave: &mut Wave, ctx: &WaveContext, events: &mut Vec<WaveEvent>) {
+///
+/// **Note**: `ctx.ships` and `ctx.rng` are part of the context shape
+/// for forward-compat (see `WaveContext` doc comment) but are not
+/// read by this implementation — the JS counterpart does not read
+/// them either. The fixture
+/// `parity_wave::wave1_with_populated_context` exercises this
+/// no-op-on-extras invariant.
+pub fn update_wave(wave: &mut Wave, ctx: &WaveContext<'_>, events: &mut Vec<WaveEvent>) {
     // ── 'intro' or 'complete' phases: nothing to do ──
     // 'intro' is a brief overlay phase; the wrapper transitions to
     // 'spawning' once it spawns sub-wave 0. 'complete' is terminal.

--- a/server/tests/parity_wave.rs
+++ b/server/tests/parity_wave.rs
@@ -49,9 +49,11 @@
 //!     phase flips Spawning → Complete (because 0 enemies on the
 //!     same tick), emits a WaveClear event. No further EnemySpawn.
 
-use rainboids_server::sim::wave::{
-    update_wave, EnemyType, Wave, WaveContext, WaveEvent, WavePhase,
+use rainboids_server::sim::{
+    rng,
+    wave::{update_wave, EnemyType, Wave, WaveContext, WaveEvent, WavePhase},
 };
+use rainboids_server::protocol::{PlayerId, ShipState};
 
 #[test]
 fn wave1_advance_at_two_enemies() {
@@ -68,6 +70,8 @@ fn wave1_advance_at_two_enemies() {
         let ctx = WaveContext {
             enemy_count,
             dt: 1.0_f32 / 60.0,
+            ships: &[],
+            rng: None,
         };
         let mut tick_events: Vec<WaveEvent> = Vec::new();
         update_wave(&mut wave, &ctx, &mut tick_events);
@@ -132,5 +136,122 @@ fn wave1_advance_at_two_enemies() {
             .iter()
             .any(|ev| matches!(ev, WaveEvent::WaveClear { wave } if *wave == 1)),
         "expected a WaveClear event for wave 1 by the final tick"
+    );
+}
+
+/// Same scenario as `wave1_advance_at_two_enemies` but with the new
+/// `ctx.ships` slice populated and a real `Pcg64` plugged into
+/// `ctx.rng`. The JS audit (see commit 2026-05-10 follow-up to PR #22)
+/// confirmed that `js/sim/wave.js::updateWave` does NOT read either of
+/// these fields; the JS `wave-data.js` campaign schedule is fully
+/// deterministic with no `Math.random` branches. This fixture proves
+/// the Rust port honors the same invariant: populating `ships` + `rng`
+/// must not affect the spawn sequence emitted on the same enemy_count
+/// vector.
+///
+/// If a future change adds randomized scheduling (e.g., enemy
+/// substitution gated on `rng.gen_bool(...)`), this test will start
+/// diverging from `wave1_advance_at_two_enemies` — that's the signal
+/// to capture a new JS golden + flip the docstring on `WaveContext`.
+#[test]
+fn wave1_with_populated_context() {
+    // Same wave-1 setup as the original fixture.
+    let mut wave = Wave::fresh(1);
+    wave.phase = WavePhase::Spawning;
+
+    // Non-default ships slice — a single ship at a fixed (non-zero)
+    // position with non-zero velocity / hp / shield. Using one entry
+    // exercises the slice-borrowing path (vs. the empty-slice fast
+    // path the original test takes).
+    let ships: [ShipState; 1] = [ShipState {
+        player: PlayerId(7),
+        x: 1234.5,
+        y: -678.25,
+        vx: 12.0,
+        vy: -3.5,
+        angle: 1.5707963, // ~π/2 — not load-bearing, just non-zero.
+        hp: 80.0,
+        shield: 25.0,
+    }];
+
+    // Seeded RNG. Seed 42 matches `parity_vectors::pcg64_seed_42`
+    // captures, so if a future randomized branch is added to
+    // `update_wave`, the resulting golden can be cross-checked
+    // against existing PCG64 trace fixtures.
+    let mut rng = rng::from_seed(42);
+
+    let enemy_counts: [u32; 4] = [0, 5, 2, 0];
+    let mut all_events: Vec<WaveEvent> = Vec::new();
+
+    for &enemy_count in &enemy_counts {
+        let ctx = WaveContext {
+            enemy_count,
+            dt: 1.0_f32 / 60.0,
+            ships: &ships,
+            rng: Some(&mut rng),
+        };
+        let mut tick_events: Vec<WaveEvent> = Vec::new();
+        update_wave(&mut wave, &ctx, &mut tick_events);
+        all_events.extend(tick_events);
+    }
+
+    let spawn_tuples: Vec<(EnemyType, u32, bool, u8)> = all_events
+        .iter()
+        .filter_map(|ev| match ev {
+            WaveEvent::EnemySpawn {
+                enemy_type,
+                count,
+                is_boss,
+                boss_tier,
+                ..
+            } => Some((*enemy_type, *count, *is_boss, *boss_tier)),
+            _ => None,
+        })
+        .collect();
+
+    eprintln!("RUST-EMITS (populated ctx): {:?}", spawn_tuples);
+
+    // Identical golden to `wave1_advance_at_two_enemies` — the new
+    // fields must not perturb the spawn sequence.
+    let expected: Vec<(EnemyType, u32, bool, u8)> = vec![
+        (EnemyType::Hunter, 3, false, 0),
+        (EnemyType::Hunter, 2, false, 0),
+        (EnemyType::Wasp, 2, false, 0),
+    ];
+
+    assert_eq!(
+        spawn_tuples, expected,
+        "EnemySpawn sequence must be identical to the empty-context \
+         baseline — populating ctx.ships / ctx.rng must not affect \
+         the (deterministic) wave schedule"
+    );
+
+    // Same terminal-state checks as the baseline.
+    assert_eq!(
+        wave.phase,
+        WavePhase::Complete,
+        "wave should be Complete after final tick (populated ctx)"
+    );
+    assert_eq!(
+        wave.sub_wave_index, 2,
+        "sub_wave_index should match wave 1's total sub-wave count (2)"
+    );
+    assert!(
+        all_events
+            .iter()
+            .any(|ev| matches!(ev, WaveEvent::WaveClear { wave } if *wave == 1)),
+        "expected a WaveClear event for wave 1 by the final tick"
+    );
+
+    // Sanity: the RNG must be untouched. If the implementation ever
+    // starts consuming it, this assertion will fail and the doc
+    // comment on `WaveContext::rng` will need updating to reflect the
+    // new "consumed by update_wave" semantics.
+    let mut control = rng::from_seed(42);
+    use rand::RngCore;
+    assert_eq!(
+        rng.next_u64(),
+        control.next_u64(),
+        "ctx.rng state must be unchanged — update_wave does not read it"
     );
 }


### PR DESCRIPTION
## Summary
Audit-driven plumbing PR. JS `updateWave` does **NOT** consume `ctx.ships` or `ctx.rng` today — both are on the typedef but never read (verified by reading `js/sim/wave.js` lines 111–202; zero `Math.random` calls in `wave-data.js` either; the 20-wave campaign is fully deterministic).

This PR adds the field plumbing for future randomized scheduling without changing behavior, satisfying PR #22's deferred work item.

## `WaveContext` now carries
- `ships: &[ShipState]` — reserved for future ship-aware spawning
- `rng: Option<&mut Pcg64>` — reserved for randomized branches

Both guarded with `#[allow(dead_code)]` + per-field doc comments. `update_wave`'s body is byte-for-byte identical; only the signature gained a lifetime.

## New parity fixture
`server/tests/parity_wave.rs::wave1_with_populated_context`:
- Same wave-1 setup, same `[0, 5, 2, 0]` enemy_count vector, same expected golden as `wave1_advance_at_two_enemies`.
- But populates `ships` (PlayerId(7) at (1234.5, -678.25) with non-zero velocity/hp/shield) AND `rng = Some(&mut from_seed(42))`.
- Asserts spawn sequence is byte-identical → proves no-op semantics.
- **Bonus canary**: asserts `rng.next_u64()` matches a fresh `from_seed(42)` afterward — proves `update_wave` didn't consume any RNG state. Fires if a future randomized branch is added without updating doc comments.

## When randomized scheduling actually lands
1. Remove `#[allow(dead_code)]` + "unread today" notes
2. Update `update_wave` doc comment
3. Replace `wave1_with_populated_context`'s identity assertion with a real captured JS golden (capture via node with seeded `Pcg64`)
4. The `next_u64()` canary will start failing — that's the trigger to update test intent

## Test plan
- [x] `cargo test --test parity_wave` — 2 passed (1 existing + 1 new)
- [x] All other workspace tests still green
- [x] `cargo build --tests` — clean, no warnings (`#[allow(dead_code)]` covers the unread fields)

## Phase 2.1 progress (task #45)
- ✓ drops magnet + tractor + expiry (PR #25)
- ✓ asteroid bounce + death-flash (PR #26)
- ✓ bullet helix + homing (PR #27)
- ✓ wave context plumbing (this PR)
- ⬜ enemy hunter_arc + 9 remaining kinds (blocked on PR #23 merging)
- ⏳ enemy bullet patterns (sibling PR coming next, ran in parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)