### PR TITLE
mp/sim-rs: enemy bullet 3 patterns — straight, sine, decelerate (Phase 2.1)

### DIFF
--- a/server/src/sim/bullet.rs
+++ b/server/src/sim/bullet.rs
@@ -13,9 +13,20 @@
 //!   - Predictive-lead homing — js bullet.js:79–81 + applyPlayerHoming
 //!   - Piercing / piercedEnemies counter — collision-side, not in step()
 //!   - Explosive / explosionRadius — collision-side, not in step()
-//!   - Enemy bullets (movementPattern dispatch + per-pattern velocity, mine
-//!     HP, persistent timed lifetime, distance-based fade, boss-rage homing)
-//!     — js bullet.js:183–593. See `update_enemy_bullet` stub below.
+//!
+//! Enemy bullets: 3 of ~17 movement patterns implemented (Phase 2.1):
+//!
+//!   - `Straight` — js `aimed`/`crescent_beam`/`crescent_slice` (no-mod path).
+//!   - `Sine` — js `sine_wave_nospin` (perpendicular sine offset).
+//!   - `Decelerate` — js `missile_decelerate` (subtractive speed decay).
+//!
+//! Deferred enemy patterns (14+ remaining, js bullet.js:259–593):
+//! `mine`, `homing_mine`, `spread`, `rapid`, `spiral`, `burst`, `explosive`,
+//! `laser`, `laser_beam`, `missile`, `homing`, `titan_homing`, `titan_rocket`,
+//! `pulse`, `shield_burst`, `wave_energy`, `energy_slash`, `sine_wave` (with
+//! rotation), `missile_fast_slow`, plus boss-rage homing composition,
+//! mine HP-death, persistent timed lifetime (mines / lightning orbs),
+//! and `targetPlayer` lookups.
 //!
 //! Order of operations is **load-bearing for parity** — exactly mirrors the
 //! JS `updatePlayerBullet` body:
@@ -260,20 +271,328 @@ pub fn update_player_bullets(
     }
 }
 
-// ── Phase 2.1+: enemy-bullet step ───────────────────────────────────────
+// ── ENEMY BULLETS ───────────────────────────────────────────────────────
 //
 // `js/sim/bullet.js::updateEnemyBullet` switches on `movementPattern` and
-// has 17 distinct cases (aimed, mine, homing_mine, spread, rapid, spiral,
-// burst, explosive, laser, laser_beam, missile, homing, titan_homing,
-// titan_rocket, missile_decelerate, pulse, shield_burst, wave_energy,
-// energy_slash, crescent_*, sine_wave, sine_wave_nospin, missile_fast_slow)
-// plus boss-rage homing composition, mine HP-death, persistent timed
-// lifetime (mines / lightning orbs), and distance-based fade. That's a
-// session of its own — leaving an unimplemented marker so the wiring agent
-// gets a clear "not yet" instead of silent fallthrough.
-#[allow(dead_code)]
-pub fn update_enemy_bullet() {
-    // TODO Phase 2.1+: port js/sim/bullet.js::updateEnemyBullet.
-    // See module docstring for the full deferred-branches list.
-    unimplemented!("enemy bullets not yet ported — see module docstring");
+// has ~17 distinct cases. Phase 2.1 implements the 3 simplest:
+//
+//   - `Straight` (aimed / crescent_beam / crescent_slice — no-mod path).
+//   - `Sine` (sine_wave_nospin — perpendicular sin(phase)*amp offset).
+//   - `Decelerate` (missile_decelerate — subtract decel each tick, clamp
+//     at min_speed; expire when at floor).
+//
+// The remaining patterns are TODO; see module docstring for the full list.
+//
+// Order of operations is **load-bearing for parity** — exactly mirrors the
+// JS `updateEnemyBullet` body (js bullet.js:183–249):
+//
+//   1. Active-guard (early return if !active).
+//   2. `applyEnemyMovementPattern(b, ctx)` — pattern-specific velocity
+//      mutation. May set `active=false` + `expired_by_distance=true`
+//      (decelerate at min-speed floor).
+//   3. Position update: `x += vx * tick_scale; y += vy * tick_scale`.
+//      NOTE: enemy-bullet path **does** scale by tick_scale; player does not.
+//   4. Rotation tick — skipped here (cosmetic; not modeled).
+//   5. `pattern_timer += logic_tick_seconds`.
+//   6. Mine HP death — skipped (mine pattern not yet ported).
+//   7. Lifetime / fade:
+//        - Persistent (mines, lightning) — TODO; not implemented.
+//        - Distance-based: dist from (start_x, start_y); if progress >=
+//          1.0 → deactivate + `expired_by_range`; else fade `life`.
+//   8. Out-of-bounds despawn (50 px margin).
+
+// JS bullet.js:228 — distance-based lifetime fade knee (life is held at 1.0
+// until 65% of max_range is traveled, then ramps 1.0 → 0.5 over the final
+// 35%).
+const DISTANCE_FADE_KNEE: f32 = 0.65;
+const DISTANCE_FADE_RANGE: f32 = 0.35;
+const DISTANCE_FADE_FINAL: f32 = 0.5;
+
+/// Enemy-bullet movement pattern. Phase 2.1 covers the 3 simplest cases
+/// only. The full JS dispatcher has ~17 — see module docstring for the
+/// deferred list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BulletPattern {
+    /// JS `aimed` / `crescent_beam` / `crescent_slice` — straight-line drift,
+    /// no per-tick velocity adjustment.
+    Straight,
+    /// JS `sine_wave_nospin` — drift along base velocity plus perpendicular
+    /// `sin(sine_phase) * sine_amp` offset; advances `sine_phase` by
+    /// `sine_freq` each tick. (The `sine_wave` variant additionally aligns
+    /// rotation to travel direction; not modeled here.)
+    Sine,
+    /// JS `missile_decelerate` — subtractive speed decay each tick. When the
+    /// speed reaches `min_speed`, the bullet expires (`expired_by_distance`).
+    Decelerate,
+    // TODO Phase 2.1+: Helix, Homing, Ricochet, Rocket, Mine, Spiral,
+    // EnergySlash, Bezier, Charge, Spread, Rapid, Burst, Explosive, Laser,
+    // LaserBeam, Missile, TitanHoming, TitanRocket, Pulse, ShieldBurst,
+    // WaveEnergy, SineWave (with rotation), MissileFastSlow, HomingMine.
+}
+
+/// Minimal enemy-bullet state for the 3 patterns above.
+///
+/// Skips fields used only by deferred patterns (`shape`, `health`,
+/// `is_persistent`, `creation_time`, `target_player`, `boss_rage_homing`,
+/// `helix_*`, `rocket_speed`, `slash_progress`, etc.). See module docstring.
+#[derive(Debug, Clone, Copy)]
+pub struct EnemyBullet {
+    /// Stable identity for despawn events.
+    pub id: u32,
+    /// Dispatches per-tick velocity logic.
+    pub pattern: BulletPattern,
+
+    // ── Position / velocity (px / px-per-tick) ─────────────────────────
+    pub x: f32,
+    pub y: f32,
+    pub vx: f32,
+    pub vy: f32,
+
+    /// Origin — used for distance-based lifetime + fade. JS bullet.js:228.
+    pub start_x: f32,
+    pub start_y: f32,
+
+    /// Pre-pattern velocity baseline for Sine. JS state.js:430.
+    pub base_vx: f32,
+    pub base_vy: f32,
+
+    // ── Lifetime ───────────────────────────────────────────────────────
+    /// Distance-fade ratio (1.0 → DISTANCE_FADE_FINAL near max_range).
+    /// JS state.js:435 — **enemy** life is a 0..1 fade, not an int frame
+    /// counter (player path uses int frames).
+    pub life: f32,
+    /// Player-style frame cap (unused by these 3 patterns but kept for
+    /// parity with the JS struct). TODO Phase 2.1+ when persistent bullets
+    /// land.
+    #[allow(dead_code)]
+    pub max_life: u32,
+
+    // ── Combat (informational) ────────────────────────────────────────
+    pub damage: f32,
+    pub radius: f32,
+    pub base_radius: f32,
+
+    // ── Range / distance (px) ─────────────────────────────────────────
+    /// JS bullet.js:229 — distance-based fade horizon.
+    pub max_range: f32,
+    /// JS state.js:585 — LONG_RANGE upgrade (player only; enemy
+    /// bullets typically pass 1.0 here).
+    pub range_multiplier: f32,
+
+    // ── Pattern timing (seconds since spawn) ──────────────────────────
+    /// JS bullet.js:200 — incremented each tick by `logic_tick_seconds`.
+    pub pattern_timer: f32,
+    /// JS state.js:456 — pattern-specific phase offset (used by spread,
+    /// energy_slash, etc.). Reserved; not consumed by the 3 ported
+    /// patterns but kept on the struct for parity.
+    #[allow(dead_code)]
+    pub pattern_phase: f32,
+
+    // ── Sine pattern state ────────────────────────────────────────────
+    /// JS state.js:462. Advanced by `sine_freq` each tick.
+    pub sine_phase: f32,
+    pub sine_freq: f32,
+    pub sine_amp: f32,
+    /// Perpendicular axis (unit vector) along which the sine displaces
+    /// velocity. JS state.js:465–466.
+    pub sine_perp_x: f32,
+    pub sine_perp_y: f32,
+
+    // ── Decelerate pattern state ──────────────────────────────────────
+    /// JS state.js:472 — speed subtracted per tick (NOT a multiplier).
+    pub deceleration: f32,
+    /// JS state.js:473 — floor for the speed clamp.
+    pub min_speed: f32,
+
+    // ── Lifecycle flags ───────────────────────────────────────────────
+    pub active: bool,
+    /// JS state.js:475 — wrapper triggers disappear-puff FX.
+    pub expired_by_range: bool,
+    /// JS state.js:476 — wrapper skips FX (offscreen).
+    pub expired_by_bounds: bool,
+    /// JS state.js:477 — wrapper triggers explosion FX (decelerate hits
+    /// floor; titan_rocket out-of-distance).
+    pub expired_by_distance: bool,
+
+    // TODO Phase 2.1+: shape (mine vs needle vs ...) — drives mine HP
+    //   death + persistent-vs-distance lifetime branch.
+    // TODO Phase 2.1+: health, max_health (mine HP).
+    // TODO Phase 2.1+: is_persistent, max_lifetime_override, creation_time
+    //   (time-based lifetime for mines / lightning orbs).
+    // TODO Phase 2.1+: target_player (homing patterns).
+    // TODO Phase 2.1+: boss_rage_homing.
+    // TODO Phase 2.1+: rocket_speed, max_distance, distance_traveled
+    //   (titan_rocket).
+    // TODO Phase 2.1+: slash_progress (energy_slash).
+    // TODO Phase 2.1+: rotation, rotation_speed (sprite orientation).
+}
+
+/// Per-tick context for enemy-bullet updates. Mirrors the relevant subset
+/// of `BulletUpdateContext` in `js/sim/state.js`.
+#[derive(Debug, Clone, Copy)]
+pub struct EnemyBulletContext {
+    /// Render-rate scaler (`30 / 60 = 0.5`). JS bullet.js:190–191 — enemy
+    /// position update **does** consume this (player does not).
+    pub tick_scale: f32,
+    /// Seconds-per-logic-tick. JS bullet.js:200 — adds to `pattern_timer`.
+    pub logic_tick_seconds: f32,
+    /// World boundaries (px). JS bullet.js:242–243.
+    pub boundary_width: f32,
+    pub boundary_height: f32,
+    // TODO Phase 2.1+: now_ms (persistent bullet age — mines, lightning).
+    // TODO Phase 2.1+: bullet_speed (homing target velocity).
+    // TODO Phase 2.1+: target_player (homing patterns).
+    // TODO Phase 2.1+: rng (rapid-pattern jitter).
+}
+
+/// Pattern-specific velocity adjustment. Mirrors
+/// `applyEnemyMovementPattern` in js/sim/bullet.js, restricted to the 3
+/// patterns this module implements.
+fn apply_enemy_movement_pattern(b: &mut EnemyBullet, _ctx: &EnemyBulletContext) {
+    // JS bullet.js:260–263 — guard: when both base velocities are zero AND
+    // pattern is not `mine`, the legacy code early-returned. None of our 3
+    // patterns are `mine`, so we mirror the early-return. (`Straight` with
+    // base_vx/base_vy=0 means "stationary"; matches JS behavior.)
+    if b.base_vx == 0.0 && b.base_vy == 0.0 {
+        return;
+    }
+
+    match b.pattern {
+        // JS bullet.js:270–272 — `aimed` (and crescent_*): no velocity
+        // modification; the bullet drifts straight.
+        BulletPattern::Straight => {}
+
+        // JS bullet.js:536–543 — `sine_wave_nospin`. The `sine_wave` variant
+        // additionally aligns `rotation` with travel direction; we don't
+        // model rotation here.
+        BulletPattern::Sine => {
+            b.sine_phase += b.sine_freq;
+            let displacement = b.sine_phase.sin() * b.sine_amp;
+            b.vx = b.base_vx + b.sine_perp_x * displacement;
+            b.vy = b.base_vy + b.sine_perp_y * displacement;
+        }
+
+        // JS bullet.js:450–475 — `missile_decelerate`. Subtractive decay,
+        // clamped at min_speed. When the bullet is already at the floor, it
+        // expires with `expired_by_distance` set. The JS branch also has a
+        // max-distance check (lines 465–473); the wrapper sets
+        // `bullet.maxDistance` from constants — we don't model that field
+        // yet (it's a TODO above), so the deceleration-floor exit is the
+        // only despawn route from this case.
+        BulletPattern::Decelerate => {
+            let current_speed = (b.vx * b.vx + b.vy * b.vy).sqrt();
+            if current_speed > b.min_speed {
+                let direction = b.vy.atan2(b.vx);
+                let new_speed = (current_speed - b.deceleration).max(b.min_speed);
+                b.vx = direction.cos() * new_speed;
+                b.vy = direction.sin() * new_speed;
+            } else {
+                b.active = false;
+                b.expired_by_distance = true;
+            }
+        }
+    }
+}
+
+/// Single enemy-bullet step. Mirrors `js/sim/bullet.js::updateEnemyBullet`,
+/// restricted to the 3 patterns above.
+///
+/// Mutates `b` in place; appends despawn events to `events`.
+pub fn update_enemy_bullet(
+    b: &mut EnemyBullet,
+    ctx: &EnemyBulletContext,
+    events: &mut Vec<BulletEvent>,
+) {
+    // 1. Active-guard (JS bullet.js:184).
+    if !b.active {
+        return;
+    }
+
+    // 2. Apply movement pattern (JS bullet.js:187). May deactivate the bullet
+    //    (decelerate floor); the JS code does NOT early-return after this,
+    //    so the post-processing below still runs — including position update
+    //    and despawn-event emission via the lifetime branches.
+    apply_enemy_movement_pattern(b, ctx);
+
+    // 3. Position update — scaled for tick rate (JS bullet.js:190–191).
+    b.x += b.vx * ctx.tick_scale;
+    b.y += b.vy * ctx.tick_scale;
+
+    // 4. Rotation accumulator — skipped (cosmetic; not modeled).
+
+    // 5. Pattern timer (JS bullet.js:200).
+    b.pattern_timer += ctx.logic_tick_seconds;
+
+    // 6. Mine HP death — skipped (mine pattern is TODO).
+
+    // 7. Lifetime / fade. We only handle the distance-based branch here
+    //    (persistent bullets are TODO).
+    //
+    //    JS bullet.js:228–238: dist = hypot(x - startX, y - startY);
+    //    progress = dist / maxRange. If progress >= 1.0, deactivate +
+    //    `expiredByRange`. Otherwise life ramps 1.0 → 0.5 over the final
+    //    35% (held at 1.0 during the first 65%).
+    //
+    //    NOTE: `range_multiplier` is a player-bullet upgrade (LONG_RANGE);
+    //    enemy bullets typically pass 1.0. We multiply for parity in case
+    //    a future enemy-side modifier wants to use it.
+    let dx = b.x - b.start_x;
+    let dy = b.y - b.start_y;
+    let dist = (dx * dx + dy * dy).sqrt();
+    let effective_range = b.max_range * b.range_multiplier;
+    let progress = if effective_range > 0.0 {
+        dist / effective_range
+    } else {
+        0.0
+    };
+    if progress >= 1.0 {
+        // Only emit a single despawn event per bullet — if the pattern step
+        // already deactivated us (decelerate floor), don't double-emit.
+        if b.active {
+            events.push(BulletEvent::Despawn { bullet_id: b.id });
+        }
+        b.active = false;
+        b.expired_by_range = true;
+        return;
+    }
+    b.life = if progress < DISTANCE_FADE_KNEE {
+        1.0
+    } else {
+        1.0 - (progress - DISTANCE_FADE_KNEE) / DISTANCE_FADE_RANGE * DISTANCE_FADE_FINAL
+    };
+
+    // 8. Out-of-bounds despawn (JS bullet.js:241–246). 50 px margin.
+    let w = ctx.boundary_width;
+    let h = ctx.boundary_height;
+    if b.x < -BOUNDARY_MARGIN
+        || b.x > w + BOUNDARY_MARGIN
+        || b.y < -BOUNDARY_MARGIN
+        || b.y > h + BOUNDARY_MARGIN
+    {
+        if b.active {
+            events.push(BulletEvent::Despawn { bullet_id: b.id });
+        }
+        b.active = false;
+        b.expired_by_bounds = true;
+        return;
+    }
+
+    // If the pattern step deactivated us (e.g. decelerate floor) and we
+    // didn't otherwise emit a despawn above, do so now so the wrapper can
+    // release the slot.
+    if !b.active {
+        events.push(BulletEvent::Despawn { bullet_id: b.id });
+    }
+}
+
+/// Loop helper. Mirrors `js/sim/bullet.js::updateBullets` but specialized
+/// to enemy bullets.
+pub fn update_enemy_bullets(
+    bullets: &mut [EnemyBullet],
+    ctx: &EnemyBulletContext,
+    events: &mut Vec<BulletEvent>,
+) {
+    for b in bullets.iter_mut() {
+        update_enemy_bullet(b, ctx, events);
+    }
 }

--- a/server/tests/parity_enemy_bullet.rs
+++ b/server/tests/parity_enemy_bullet.rs
@@ -1,0 +1,271 @@
+//! Cross-language parity vectors for enemy-bullet ballistics (Phase 2.1).
+//!
+//! Mirrors `js/sim/bullet.js::updateEnemyBullet` for the 3 simplest movement
+//! patterns:
+//!
+//!   - `Straight` ↔ JS `aimed` / `crescent_beam` / `crescent_slice` (no-mod
+//!     velocity path).
+//!   - `Sine` ↔ JS `sine_wave_nospin` (perpendicular sine offset).
+//!   - `Decelerate` ↔ JS `missile_decelerate` (subtractive speed decay,
+//!     clamped at `min_speed`).
+//!
+//! See `server/src/sim/bullet.rs` module docstring for the full list of
+//! ~14 deferred patterns (helix, homing, ricochet, rocket, mine, spiral,
+//! energy_slash, bezier, charge, etc.).
+//!
+//! Reference values were captured against the JS source by running the
+//! one-liner embedded in this file; both sides compute the same trajectory
+//! within an f32-tolerance of 0.01 px.
+
+use rainboids_server::sim::bullet::{
+    update_enemy_bullet, BulletEvent, BulletPattern, EnemyBullet, EnemyBulletContext,
+};
+
+/// Helper — assert two f32 values are within 0.01 of each other.
+fn close(actual: f32, expected: f32, what: &str) {
+    let delta = (actual - expected).abs();
+    assert!(
+        delta < 0.01,
+        "{} diverged: rust={}, js={}, |Δ|={}",
+        what,
+        actual,
+        expected,
+        delta,
+    );
+}
+
+/// Build a default EnemyBullet shell — overrides applied by the caller.
+fn default_enemy_bullet(id: u32, pattern: BulletPattern) -> EnemyBullet {
+    EnemyBullet {
+        id,
+        pattern,
+        x: 0.0,
+        y: 0.0,
+        vx: 0.0,
+        vy: 0.0,
+        start_x: 0.0,
+        start_y: 0.0,
+        base_vx: 0.0,
+        base_vy: 0.0,
+        life: 1.0,
+        max_life: 180,
+        damage: 10.0,
+        radius: 4.0,
+        base_radius: 4.0,
+        max_range: 9999.0,
+        range_multiplier: 1.0,
+        pattern_timer: 0.0,
+        pattern_phase: 0.0,
+        sine_phase: 0.0,
+        sine_freq: 0.0,
+        sine_amp: 0.0,
+        sine_perp_x: 0.0,
+        sine_perp_y: 0.0,
+        deceleration: 0.0,
+        min_speed: 0.0,
+        active: true,
+        expired_by_range: false,
+        expired_by_bounds: false,
+        expired_by_distance: false,
+    }
+}
+
+fn default_ctx() -> EnemyBulletContext {
+    EnemyBulletContext {
+        tick_scale: 0.5,
+        logic_tick_seconds: 1.0 / 60.0,
+        boundary_width: 9999.0,
+        boundary_height: 9999.0,
+    }
+}
+
+// ── Fixture 1: straight-line drift ───────────────────────────────────────
+//
+// JS reference values captured 2026-05-10 from
+// `js/sim/bullet.js::updateEnemyBullet` via:
+//
+//   node --input-type=module -e "
+//     import { updateEnemyBullet } from './js/sim/bullet.js';
+//     import { freshBulletState } from './js/sim/state.js';
+//     const b = freshBulletState(1, 'enemy', { movementPattern: 'aimed',
+//         x: 200, y: 200, vx: 5, vy: 0, baseVx: 5, baseVy: 0,
+//         startX: 200, startY: 200, life: 0, maxLife: 180,
+//         damage: 10, radius: 4, baseRadius: 4,
+//         maxRange: 9999, rangeMultiplier: 1.0, active: true });
+//     const ctx = { tickScale: 0.5, logicTickSeconds: 1/60, bulletSpeed: 10,
+//         boundaryWidth: 9999, boundaryHeight: 9999, now: 0,
+//         targetPlayer: null, homingTarget: null, rngFloat: () => 0.5 };
+//     for (let i = 0; i < 30; i++) updateEnemyBullet(b, ctx, []);
+//     console.log(JSON.stringify({ x: b.x, y: b.y, vx: b.vx, vy: b.vy,
+//         life: b.life, active: b.active, patternTimer: b.patternTimer }));
+//   "
+//   → {"x":275,"y":200,"vx":5,"vy":0,"life":1,"active":true,
+//      "patternTimer":0.49999999999999994}
+#[test]
+fn enemy_bullet_straight_drift() {
+    let mut b = default_enemy_bullet(1, BulletPattern::Straight);
+    b.x = 200.0;
+    b.y = 200.0;
+    b.vx = 5.0;
+    b.vy = 0.0;
+    b.start_x = 200.0;
+    b.start_y = 200.0;
+    b.base_vx = 5.0;
+    b.base_vy = 0.0;
+    b.life = 0.0; // freshBulletState defaults enemy life to 1.0; the JS
+                  // override sets `life: 0` then the lifetime branch
+                  // overwrites it from progress on every tick — final value
+                  // is 1.0 (held during 0..0.65 progress).
+
+    let ctx = default_ctx();
+    let mut events: Vec<BulletEvent> = Vec::new();
+    for _ in 0..30 {
+        update_enemy_bullet(&mut b, &ctx, &mut events);
+    }
+
+    close(b.x, 275.0, "bullet.x");
+    close(b.y, 200.0, "bullet.y");
+    close(b.vx, 5.0, "bullet.vx");
+    close(b.vy, 0.0, "bullet.vy");
+    close(b.life, 1.0, "bullet.life");
+    close(b.pattern_timer, 0.5, "bullet.pattern_timer");
+    assert!(b.active, "bullet should still be active");
+
+    assert!(
+        events.is_empty(),
+        "unexpected despawn events for alive bullet: {:?}",
+        events,
+    );
+}
+
+// ── Fixture 2: sine-wave perpendicular offset ────────────────────────────
+//
+// JS reference values captured 2026-05-10 via:
+//
+//   node --input-type=module -e "
+//     import { updateEnemyBullet } from './js/sim/bullet.js';
+//     import { freshBulletState } from './js/sim/state.js';
+//     const b = freshBulletState(2, 'enemy', { movementPattern:
+//         'sine_wave_nospin', x: 300, y: 300, vx: 4, vy: 0,
+//         baseVx: 4, baseVy: 0, startX: 300, startY: 300,
+//         sinePhase: 0, sineFreq: 0.15, sineAmp: 20,
+//         sinePerpX: 0, sinePerpY: 1,
+//         life: 0, maxLife: 180, damage: 10, radius: 4, baseRadius: 4,
+//         maxRange: 9999, rangeMultiplier: 1.0, active: true });
+//     const ctx = { tickScale: 0.5, logicTickSeconds: 1/60, bulletSpeed: 10,
+//         boundaryWidth: 9999, boundaryHeight: 9999, now: 0,
+//         targetPlayer: null, homingTarget: null, rngFloat: () => 0.5 };
+//     for (let i = 0; i < 20; i++) updateEnemyBullet(b, ctx, []);
+//     console.log(JSON.stringify({ x: b.x, y: b.y, vx: b.vx, vy: b.vy,
+//         sinePhase: b.sinePhase, life: b.life, active: b.active }));
+//   "
+//   → {"x":340,"y":433.1229240873557,"vx":4,"vy":2.822400161197362,
+//      "sinePhase":2.999999999999999,"life":1,"active":true}
+#[test]
+fn enemy_bullet_sine_offset() {
+    let mut b = default_enemy_bullet(2, BulletPattern::Sine);
+    b.x = 300.0;
+    b.y = 300.0;
+    b.vx = 4.0;
+    b.vy = 0.0;
+    b.start_x = 300.0;
+    b.start_y = 300.0;
+    b.base_vx = 4.0;
+    b.base_vy = 0.0;
+    b.sine_phase = 0.0;
+    b.sine_freq = 0.15;
+    b.sine_amp = 20.0;
+    b.sine_perp_x = 0.0;
+    b.sine_perp_y = 1.0;
+    b.life = 0.0;
+
+    let ctx = default_ctx();
+    let mut events: Vec<BulletEvent> = Vec::new();
+    for _ in 0..20 {
+        update_enemy_bullet(&mut b, &ctx, &mut events);
+    }
+
+    close(b.x, 340.0, "bullet.x");
+    close(b.y, 433.1229240873557, "bullet.y");
+    close(b.vx, 4.0, "bullet.vx");
+    close(b.vy, 2.822400161197362, "bullet.vy");
+    close(b.sine_phase, 2.999999999999999, "bullet.sine_phase");
+    close(b.life, 1.0, "bullet.life");
+    assert!(b.active, "bullet should still be active");
+
+    assert!(
+        events.is_empty(),
+        "unexpected despawn events for alive bullet: {:?}",
+        events,
+    );
+}
+
+// ── Fixture 3: missile_decelerate floor expiry ───────────────────────────
+//
+// JS reference values captured 2026-05-10 via (note: deceleration & minSpeed
+// must be attached manually — `freshBulletState` doesn't propagate them):
+//
+//   node --input-type=module -e "
+//     import { updateEnemyBullet } from './js/sim/bullet.js';
+//     import { freshBulletState } from './js/sim/state.js';
+//     const b = freshBulletState(3, 'enemy', { movementPattern:
+//         'missile_decelerate', x: 400, y: 400, vx: 8, vy: 2,
+//         baseVx: 8, baseVy: 2, startX: 400, startY: 400,
+//         life: 0, maxLife: 180, damage: 10, radius: 4, baseRadius: 4,
+//         maxRange: 9999, rangeMultiplier: 1.0, active: true });
+//     b.deceleration = 0.96;
+//     b.minSpeed = 0.5;
+//     const ctx = { tickScale: 0.5, logicTickSeconds: 1/60, bulletSpeed: 10,
+//         boundaryWidth: 9999, boundaryHeight: 9999, now: 0,
+//         targetPlayer: null, homingTarget: null, rngFloat: () => 0.5 };
+//     for (let i = 0; i < 30; i++) updateEnemyBullet(b, ctx, []);
+//     console.log(JSON.stringify({ x: b.x, y: b.y, vx: b.vx, vy: b.vy,
+//         active: b.active, expiredByDistance: b.expiredByDistance }));
+//   "
+//   → {"x":415.7210088475614,"y":403.9302522118903,
+//      "vx":0.48507125007266594,"vy":0.12126781251816648,
+//      "active":false,"expiredByDistance":true}
+#[test]
+fn enemy_bullet_decelerate() {
+    let mut b = default_enemy_bullet(3, BulletPattern::Decelerate);
+    b.x = 400.0;
+    b.y = 400.0;
+    b.vx = 8.0;
+    b.vy = 2.0;
+    b.start_x = 400.0;
+    b.start_y = 400.0;
+    b.base_vx = 8.0;
+    b.base_vy = 2.0;
+    b.deceleration = 0.96;
+    b.min_speed = 0.5;
+    b.life = 0.0;
+
+    let ctx = default_ctx();
+    let mut events: Vec<BulletEvent> = Vec::new();
+    for _ in 0..30 {
+        update_enemy_bullet(&mut b, &ctx, &mut events);
+    }
+
+    close(b.x, 415.7210088475614, "bullet.x");
+    close(b.y, 403.9302522118903, "bullet.y");
+    close(b.vx, 0.48507125007266594, "bullet.vx");
+    close(b.vy, 0.12126781251816648, "bullet.vy");
+    assert!(!b.active, "bullet should have expired at min-speed floor");
+    assert!(
+        b.expired_by_distance,
+        "bullet should have expired_by_distance=true",
+    );
+
+    // Decelerate hitting min-speed floor emits exactly one Despawn — the
+    // wrapper releases the slot and triggers the explosion FX based on
+    // `expired_by_distance`. JS doesn't currently emit despawn events
+    // explicitly (the wrapper polls `bullet.active`), but our Rust API
+    // surfaces it as an enum so the wrapper can pre-allocate.
+    assert_eq!(
+        events.len(),
+        1,
+        "expected one Despawn event for decelerated bullet, got {:?}",
+        events,
+    );
+    assert_eq!(events[0], BulletEvent::Despawn { bullet_id: 3 });
+}


### PR DESCRIPTION
## Summary
Replaces the `unimplemented!()` stub in `update_enemy_bullet` (PR #20) with real impl handling **3 movement patterns** (straight, sine, decelerate). 14+ patterns remain deferred to follow-up sessions.

## Types added (in `bullet.rs`, enemy section at bottom)

- `BulletPattern` enum: `Straight, Sine, Decelerate` (TODO comments list 14 deferred patterns)
- `EnemyBullet` struct — 30 fields covering the 3 patterns; 14+ deferred fields commented as TODO Phase 2.1+
- `EnemyBulletContext` — tick_scale, logic_tick_seconds, boundary_width, boundary_height
- `update_enemy_bullet` pure step + `update_enemy_bullets` loop helper

## Constants extracted (JS line anchors)
- `DISTANCE_FADE_KNEE = 0.65` (bullet.js:235)
- `DISTANCE_FADE_RANGE = 0.35` (bullet.js:237)
- `DISTANCE_FADE_FINAL = 0.5` (bullet.js:237)
- Reused `BOUNDARY_MARGIN = 50.0` from PR #20

## Order of operations (matches JS exactly)
1. Active-guard
2. `apply_enemy_movement_pattern` (may deactivate via decelerate floor)
3. **Position update SCALED by `tick_scale`** (enemy-only — player skips this scaling)
4. `pattern_timer += logic_tick_seconds`
5. Distance-based lifetime (range expiry → `expired_by_range`)
6. Boundary cull (50 px margin → `expired_by_bounds`)
7. Single-emit `Despawn` event guard

## Two divergence resolutions captured during port

1. **JS has no `'straight'` pattern string.** The no-mod branches are `'aimed'`, `'crescent_beam'`, `'crescent_slice'`. Used `'aimed'` for the JS golden capture; named the Rust enum variant `Straight` per spec with a doc comment mapping it to all three JS strings.

2. **JS `decelerate` is SUBTRACTIVE, not multiplicative.** The JS source uses `Math.max(currentSpeed - deceleration, minSpeed)`. Followed JS as ground truth — Rust matches exactly. With `deceleration=0.96` and starting speed ≈ 8.246 over 30 ticks, bullet hits `min_speed=0.5` floor and emits `expired_by_distance=true`.

## Parity fixtures
| Test | Setup | Final |
|---|---|---|
| `enemy_bullet_straight_drift` | vx=5, 30 ticks | x=275, life=1, active=true |
| `enemy_bullet_sine_offset` | sine_amp=20, freq=0.15, 20 ticks | x=340, y=433.12 |
| `enemy_bullet_decelerate` | decel=0.96, min_speed=0.5, 30 ticks | `expired_by_distance=true`, vx≈0.485 |

All 3 pass at 0.01 px tolerance.

## Test plan
- [x] `cargo test --test parity_enemy_bullet` — 3 passed
- [x] All 36 workspace tests green
- [x] `cargo build --tests` — clean, no warnings
- [x] Original `unimplemented!()` stub fully replaced

## Phase 2.1 progress (task #45)
- ✓ drops magnet + tractor + expiry (PR #25)
- ✓ asteroid bounce + death-flash (PR #26)
- ✓ bullet helix + homing (PR #27)
- ✓ wave context plumbing (PR #28)
- ✓ enemy bullet 3/17 patterns (this PR)
- ⬜ enemy hunter_arc + 9 remaining kinds (blocked on PR #23 merging)
- ⬜ enemy bullet 14+ remaining patterns (Helix, Homing, Ricochet, Rocket, Mine, Spiral, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)