### PR TITLE
mp/sim: js/sim/collision.js bullet-vs-asteroid pure step (Phase 2.5)

### DIFF
--- a/js/sim/collision.js
+++ b/js/sim/collision.js
@@ -1,0 +1,282 @@
+// Pure collision-detection step (server / prediction path).
+//
+// This module is a NEW parallel implementation of the collision system,
+// designed for the multiplayer server and the client-side prediction
+// engine. It does NOT replace `js/modules/combat/collision-system.js` —
+// the legacy, solo-gameplay path stays untouched. The two run side by
+// side:
+//
+//   - Solo:           `collision-system.js::handleCollisions()` (legacy)
+//   - Multiplayer:    `js/sim/collision.js` pure functions          (new)
+//   - Prediction:     `js/sim/collision.js` pure functions          (new)
+//
+// Solo-gameplay stability is paramount. Refactoring collision is high
+// risk; instead, the new code is written from scratch as a set of pure
+// pair-detection functions that the wrapper drains via an event queue.
+// The legacy module remains the single source of truth for solo play
+// until the prediction wiring (Phase 3) is ready to switch over.
+//
+// ─── Scope of THIS file (Phase 2.5, dispatch 1) ──────────────────────
+//
+// What's ported here:
+//   - Bullet-vs-asteroid pair detection (`detectBulletAsteroidHits`)
+//
+// What's deferred to follow-up sessions (Phase 2.5, dispatch 2..N):
+//   - Player-vs-asteroid (needs ship velocity + bounce/restitution)
+//   - Player-vs-enemy   (ramming damage, bounce, knockback)
+//   - Enemy-vs-asteroid (push forces both ways)
+//   - Bullet-vs-enemy   (mirror of bullet-vs-asteroid, plus boss-rage)
+//   - Drops pickup (player-vs-drop, magnet/tractor pulls happen earlier)
+//   - Power-weapon collisions (mines, missiles, lightning arcs, charged
+//     shots, energy slashes)
+//   - Defense-skill collisions (deflector orbs absorb enemy bullets,
+//     EMP pulse stuns enemies, tractor shield repels)
+//
+// What does NOT live in this module at all:
+//   - Damage NUMBER spawning / hit-flash visuals (presentation)
+//   - Audio events / particle FX (presentation)
+//   - Screen shake / hitstop (presentation)
+//   - Spatial-grid construction (a wrapper concern; the pure step takes
+//     pre-filtered candidates if the wrapper wants to use a grid)
+//   - XP / score / kill-streak side effects (game-state concerns; the
+//     wrapper drains events and applies them)
+//
+// The pure step **emits events**; the wrapper drains them to apply
+// damage, despawn bullets, spawn debris/orbs, and run the legacy FX
+// helpers. This mirrors the pattern used by `js/sim/wave.js` (Phase 1,
+// agent F) and `js/sim/asteroid.js` (Phase 1, agent C).
+
+// ─── Constants ──────────────────────────────────────────────────────
+//
+// Extracted verbatim from `COLLISION_CONFIG` in
+// `js/modules/combat/collision-system.js` so the pure step is
+// self-contained — no hidden constants leaking from the legacy module.
+// Only the constants this pair (bullet-asteroid) consumes live here;
+// the next dispatches will append the constants for their pairs.
+
+/**
+ * Bullet → asteroid knockback impulse multiplier. Mirrors
+ * `COLLISION_CONFIG.BULLET_KNOCKBACK = 0.05`. Applied to the bullet's
+ * velocity when imparting momentum to the asteroid:
+ *   `asteroid.vx += bullet.vx * BULLET_ASTEROID_KNOCKBACK`
+ * (the wrapper performs this mutation, this module just reports the
+ * pre-knockback bullet velocity in the event).
+ */
+export const BULLET_ASTEROID_KNOCKBACK = 0.05;
+
+/**
+ * Frames the asteroid's hit-flash effect runs for after a bullet
+ * impact. Mirrors `COLLISION_CONFIG.HIT_FLASH_FRAMES = 10`. Presentation
+ * concern in the strict sense, but the wrapper sets it from the event
+ * so we expose it here for convenience.
+ */
+export const BULLET_ASTEROID_HIT_FLASH_FRAMES = 10;
+
+// ─── Bullet-vs-asteroid pair detection ──────────────────────────────
+
+/**
+ * Detect bullet-vs-asteroid collisions for one tick.
+ *
+ * Pure step: reads bullet + asteroid positions/radii, decides which
+ * pairs collided, and emits one `bullet_hit_asteroid` event per
+ * detected hit. This function does NOT mutate asteroid state (no
+ * damage, no death-flash); the wrapper drains events into the legacy
+ * damage / despawn / FX helpers.
+ *
+ * Mutation note — `bullet.piercedAsteroidIds`:
+ *   The pure step DOES mutate one field on the bullet: a
+ *   `piercedAsteroidIds: Set<AsteroidId|number>` carrying the ids of
+ *   asteroids this bullet has already pierced. This is allowed because
+ *   the Set is intrinsic to that single bullet's state — it's the
+ *   bullet's "memory" of which targets it has already passed through,
+ *   conceptually equivalent to the legacy `bullet.hitTargets` Set on
+ *   the live `Bullet` class.
+ *
+ *   Lifetime of the Set:
+ *     - Lazily created on first hit (we don't pre-allocate per-bullet)
+ *     - Carried across ticks for as long as the bullet lives
+ *     - The wrapper is responsible for destroying / pooling the bullet
+ *       which clears the Set with it
+ *
+ *   Why not a separate `Map<bullet_id, Set<asteroid_id>>` in ctx?
+ *     - Putting it on the bullet keeps the bullet's collision history
+ *       co-located with the bullet itself (matching legacy semantics)
+ *     - Avoids the wrapper having to manage a separate map keyed by
+ *       bullet id (and the map cleanup when bullets despawn)
+ *     - Server / prediction path can serialize `piercedAsteroidIds`
+ *       as part of the bullet's state if needed for rollback
+ *
+ * Iteration order:
+ *   For each bullet, scan asteroids in array order. The first hit a
+ *   non-piercing bullet detects becomes its only event for the tick;
+ *   the bullet then has `piercedAsteroidIds` containing that asteroid's
+ *   id and any future call (this tick or next) will skip it. A bullet
+ *   with `piercing > 0` may emit up to `piercing + 1` hit events per
+ *   tick (matching `bullet.onHit` legacy semantics where piercing=1
+ *   means it can hit 2 targets — the original target plus 1 more).
+ *
+ * Geometry:
+ *   Circle-circle overlap: `hypot(dx, dy) < bullet.radius + ast.radius`.
+ *   Mirrors the live `collision()` helper in `js/modules/core/utils.js`.
+ *
+ * Skipped pairs (no event emitted):
+ *   - Inactive bullet         (`!bullet.active`)
+ *   - Inactive asteroid       (`!asteroid.active`)
+ *   - Warping asteroid        (asteroid is mid warp-in animation)
+ *   - Asteroid mid-death      (`asteroid.deathFlash > 0` or legacy
+ *                              `asteroid._deathFlash > 0`)
+ *   - Asteroid already pierced by this bullet (id in
+ *     `bullet.piercedAsteroidIds`)
+ *   - Bullet's piercing budget exhausted
+ *     (`bullet.piercedEnemies > bullet.piercing`)
+ *
+ * @param {Array<Object>} bullets       - active player bullets. Each
+ *                                        bullet is treated as having
+ *                                        `{x, y, vx, vy, radius, damage,
+ *                                        piercing, piercedEnemies,
+ *                                        piercedAsteroidIds?, active,
+ *                                        id}`. Compatible with both
+ *                                        the BulletState typedef in
+ *                                        `js/sim/state.js` and the
+ *                                        live `Bullet` instance shape.
+ * @param {Array<Object>} asteroids     - active asteroids. Each is
+ *                                        treated as having `{x, y,
+ *                                        radius, active, warping, hp
+ *                                        OR health, deathFlash OR
+ *                                        _deathFlash, id}`.
+ * @param {Object} ctx                  - per-tick context bag
+ *                                        (currently unused; reserved
+ *                                        for future extensions like
+ *                                        a one-punch-man cheat flag,
+ *                                        or a spatial-grid filter).
+ * @param {Array<Object>} events        - out-buffer. Pushes objects:
+ *                                        `{ type, bulletId, asteroidId,
+ *                                          damage, bulletX, bulletY,
+ *                                          bulletVx, bulletVy,
+ *                                          bulletPiercingRemaining,
+ *                                          bulletWillDespawn }`
+ *                                        See "Event shape" below.
+ *
+ * Event shape (one event per detected hit):
+ *   {
+ *     type: 'bullet_hit_asteroid',
+ *     bulletId:                bullet.id,
+ *     asteroidId:              asteroid.id,
+ *     damage:                  bullet.damage (defaults to 1),
+ *     bulletX, bulletY:        impact point (used for hit-flash
+ *                              localization + shrapnel particles)
+ *     bulletVx, bulletVy:      bullet velocity, used by the wrapper to
+ *                              apply knockback to the asteroid via
+ *                              BULLET_ASTEROID_KNOCKBACK
+ *     bulletPiercingRemaining: how many more piercing hits the bullet
+ *                              has after this one. -1 means non-
+ *                              piercing (bullet despawns now).
+ *     bulletWillDespawn:       true iff the bullet should be removed
+ *                              after this hit (non-piercing OR piercing
+ *                              budget reached).
+ *   }
+ */
+export function detectBulletAsteroidHits(bullets, asteroids, ctx, events) {
+    if (!bullets || !asteroids) return;
+    if (bullets.length === 0 || asteroids.length === 0) return;
+
+    for (let i = 0; i < bullets.length; i++) {
+        const bullet = bullets[i];
+        if (!bullet || !bullet.active) continue;
+
+        // Piercing budget already exhausted? Skip — the wrapper hasn't
+        // despawned this bullet yet but it has no more hits in it. This
+        // mirrors the legacy `bullet.onHit()` behavior where a piercing
+        // bullet starts dying once `piercedEnemies > piercing`.
+        const piercing = bullet.piercing | 0;
+        // Live-tracked counter — starts at the bullet's running total,
+        // bumps once per detected hit during this scan. Persisted back
+        // onto the bullet at the end so subsequent ticks see the
+        // accumulated count.
+        let piercedSoFar = bullet.piercedEnemies | 0;
+        if (piercing > 0 && piercedSoFar > piercing) continue;
+        // Non-piercing bullet that's somehow still active despite already
+        // hitting something this scan: skip. (Defensive — the wrapper
+        // should have flipped active=false, but we guard anyway.)
+        if (piercing === 0 && piercedSoFar > 0) continue;
+
+        const bulletRadius = bullet.radius || 0;
+
+        for (let j = 0; j < asteroids.length; j++) {
+            const asteroid = asteroids[j];
+            if (!asteroid || !asteroid.active) continue;
+            if (asteroid.warping) continue;
+
+            // Death flash gate — accept either the new sim field name
+            // (`deathFlash`) or the legacy underscore-prefix
+            // (`_deathFlash`). Same semantic: "rock is mid-explosion,
+            // don't re-hit it".
+            const dF = asteroid.deathFlash !== undefined
+                ? asteroid.deathFlash
+                : asteroid._deathFlash;
+            if (dF && dF > 0) continue;
+
+            // Has this bullet already pierced this asteroid (this or
+            // a prior tick)? The Set lives on the bullet — see
+            // mutation note in the JSDoc above.
+            const pierced = bullet.piercedAsteroidIds;
+            if (pierced && pierced.has(asteroid.id)) continue;
+
+            // Geometry check — circle-circle overlap. Mirrors
+            // `collision(a, b)` in `js/modules/core/utils.js`.
+            const dx = bullet.x - asteroid.x;
+            const dy = bullet.y - asteroid.y;
+            const sumR = bulletRadius + (asteroid.radius || 0);
+            // Squared distance avoids the sqrt; equivalent test.
+            if (dx * dx + dy * dy >= sumR * sumR) continue;
+
+            // ── Hit detected ──
+
+            // Update the bullet's piercing-tracker Set. Lazy create.
+            // This is the one bullet-state mutation this pure step
+            // performs; see JSDoc note.
+            if (!bullet.piercedAsteroidIds) {
+                bullet.piercedAsteroidIds = new Set();
+            }
+            bullet.piercedAsteroidIds.add(asteroid.id);
+
+            // Bookkeeping: bump the live pierce counter and persist it
+            // onto the bullet so the outer "budget exhausted?" check
+            // sees the latest value next tick. Matches the legacy
+            // `onHit` increment (the wrapper still calls
+            // `bullet.onHit(ast)` on the live Bullet to drive the
+            // hitTargets Set + startDying — this counter is the
+            // sim-side mirror so the pure step can decide despawn
+            // without consulting the wrapper).
+            piercedSoFar += 1;
+            bullet.piercedEnemies = piercedSoFar;
+
+            // Despawn decision — matches legacy `onHit`:
+            //   - Non-piercing: dies on first hit
+            //   - Piercing > 0: dies once piercedEnemies > piercing
+            //     (i.e. it's already hit `piercing + 1` targets)
+            const willDespawn = piercing === 0
+                ? true
+                : (piercedSoFar > piercing);
+            const piercingRemaining = piercing === 0
+                ? -1
+                : Math.max(0, piercing - piercedSoFar);
+
+            events.push({
+                type: 'bullet_hit_asteroid',
+                bulletId: bullet.id,
+                asteroidId: asteroid.id,
+                damage: (bullet.damage || 1),
+                bulletX: bullet.x,
+                bulletY: bullet.y,
+                bulletVx: bullet.vx,
+                bulletVy: bullet.vy,
+                bulletPiercingRemaining: piercingRemaining,
+                bulletWillDespawn: willDespawn,
+            });
+
+            // If the bullet despawned, stop scanning asteroids for it.
+            if (willDespawn) break;
+        }
+    }
+}

--- a/tests/unit/sim/collision.test.js
+++ b/tests/unit/sim/collision.test.js
@@ -1,0 +1,307 @@
+// Pure bullet-vs-asteroid collision unit tests.
+//
+// `detectBulletAsteroidHits` was created in the Phase-2.5 multiplayer
+// engine refactor as a NEW parallel implementation alongside the legacy
+// `js/modules/combat/collision-system.js::handleCollisions()`. These
+// tests pin the behavior the wrapper (and the future Rust mirror) will
+// depend on:
+//
+//   - circle-circle overlap geometry (sum-of-radii)
+//   - non-piercing bullets fire one event then despawn
+//   - piercing bullets emit one event per pierced asteroid up to
+//     `piercing + 1` targets
+//   - per-bullet `piercedAsteroidIds` Set carries across ticks so a
+//     piercing bullet doesn't re-hit a target it's already passed through
+//   - dead / warping / mid-death-flash asteroids are skipped
+//   - event payload includes the fields the wrapper needs (impact point,
+//     bullet velocity for knockback, damage, willDespawn flag)
+
+import { describe, test, expect } from '@jest/globals';
+import {
+    detectBulletAsteroidHits,
+    BULLET_ASTEROID_KNOCKBACK,
+    BULLET_ASTEROID_HIT_FLASH_FRAMES,
+} from '../../../js/sim/collision.js';
+import {
+    freshAsteroidState,
+    freshBulletState,
+} from '../../../js/sim/state.js';
+
+// ---------------------------------------------------------------------
+// Helpers — build minimal bullet/asteroid pairs that overlap (or not).
+// ---------------------------------------------------------------------
+
+/** Place a bullet at (x, y) with optional overrides. Defaults pin a
+ *  small player bullet sized like the live game. */
+function bullet(id, x, y, overrides = {}) {
+    return freshBulletState(id, 'player', {
+        x, y, radius: 4, baseRadius: 4, damage: 1, ...overrides,
+    });
+}
+
+/** Place an asteroid at (x, y). Default radius matches the live game's
+ *  smallest size. */
+function asteroid(id, x, y, overrides = {}) {
+    return freshAsteroidState(id, {
+        x, y, radius: 30, hp: 10, maxHp: 10, ...overrides,
+    });
+}
+
+// Empty per-tick context — the pure step doesn't consume ctx today,
+// but pass an object so the signature contract is honored.
+const ctx = {};
+
+// ---------------------------------------------------------------------
+// Constants exported for the wrapper / Rust mirror.
+// ---------------------------------------------------------------------
+
+describe('collision constants', () => {
+    test('BULLET_ASTEROID_KNOCKBACK is 0.05 (verbatim from collision-system.js)', () => {
+        expect(BULLET_ASTEROID_KNOCKBACK).toBe(0.05);
+    });
+    test('BULLET_ASTEROID_HIT_FLASH_FRAMES is 10 (verbatim from collision-system.js)', () => {
+        expect(BULLET_ASTEROID_HIT_FLASH_FRAMES).toBe(10);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test 1 — single bullet hits single asteroid.
+// ---------------------------------------------------------------------
+
+describe('detectBulletAsteroidHits — single hit', () => {
+    test('overlapping bullet + asteroid emits one event with correct fields', () => {
+        const b = bullet(1, 100, 100, { vx: 8, vy: 0, damage: 3 });
+        const a = asteroid(101, 110, 100); // dx=10, sumR=34 → overlap
+        const events = [];
+        detectBulletAsteroidHits([b], [a], ctx, events);
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({
+            type: 'bullet_hit_asteroid',
+            bulletId: 1,
+            asteroidId: 101,
+            damage: 3,
+            bulletX: 100,
+            bulletY: 100,
+            bulletVx: 8,
+            bulletVy: 0,
+            bulletWillDespawn: true,
+            bulletPiercingRemaining: -1, // non-piercing
+        });
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test 2 — distance > sum of radii → no hit.
+// ---------------------------------------------------------------------
+
+describe('detectBulletAsteroidHits — geometry miss', () => {
+    test('bullet outside (radius + asteroid.radius) emits no event', () => {
+        const b = bullet(1, 0, 0);
+        // dx=200 ≫ sumR=34 → clearly no overlap.
+        const a = asteroid(101, 200, 0);
+        const events = [];
+        detectBulletAsteroidHits([b], [a], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+
+    test('bullet just outside boundary (sum of radii + 1) emits no event', () => {
+        const b = bullet(1, 0, 0, { radius: 4 });
+        // sumR = 4 + 30 = 34; place asteroid center 35 px away → just outside.
+        const a = asteroid(101, 35, 0, { radius: 30 });
+        const events = [];
+        detectBulletAsteroidHits([b], [a], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test 3 — piercing bullet hits multiple asteroids in same tick.
+// ---------------------------------------------------------------------
+
+describe('detectBulletAsteroidHits — piercing within a tick', () => {
+    test('piercing=2 bullet hits 3 overlapping asteroids in same tick', () => {
+        const b = bullet(1, 100, 100, { piercing: 2, damage: 1 });
+        // All three asteroids overlap the bullet's circle (radius 30 each,
+        // bullet radius 4 → sumR 34; bullet at (100, 100)).
+        const a1 = asteroid(101, 110, 100);
+        const a2 = asteroid(102, 120, 100);
+        const a3 = asteroid(103,  90, 100);
+        const events = [];
+        detectBulletAsteroidHits([b], [a1, a2, a3], ctx, events);
+        // piercing=2 means it can hit piercing+1 = 3 targets.
+        expect(events).toHaveLength(3);
+        expect(events.map(e => e.asteroidId).sort()).toEqual([101, 102, 103]);
+        // Last hit should mark the bullet for despawn (budget reached).
+        const lastEvent = events[events.length - 1];
+        expect(lastEvent.bulletWillDespawn).toBe(true);
+        // Earlier events should NOT despawn — the bullet is still alive.
+        expect(events[0].bulletWillDespawn).toBe(false);
+        expect(events[1].bulletWillDespawn).toBe(false);
+    });
+
+    test('piercing=1 bullet hits 2 asteroids in same tick (piercing + 1)', () => {
+        const b = bullet(1, 100, 100, { piercing: 1 });
+        const a1 = asteroid(101, 110, 100);
+        const a2 = asteroid(102, 120, 100);
+        const events = [];
+        detectBulletAsteroidHits([b], [a1, a2], ctx, events);
+        expect(events).toHaveLength(2);
+        expect(events[0].bulletWillDespawn).toBe(false);
+        expect(events[0].bulletPiercingRemaining).toBe(0);
+        expect(events[1].bulletWillDespawn).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test 4 — non-piercing bullet only hits ONE asteroid.
+// ---------------------------------------------------------------------
+
+describe('detectBulletAsteroidHits — non-piercing single-hit', () => {
+    test('non-piercing bullet emits exactly one event when 3 asteroids overlap', () => {
+        const b = bullet(1, 100, 100, { piercing: 0 });
+        const a1 = asteroid(101, 110, 100);
+        const a2 = asteroid(102, 120, 100);
+        const a3 = asteroid(103,  90, 100);
+        const events = [];
+        detectBulletAsteroidHits([b], [a1, a2, a3], ctx, events);
+        expect(events).toHaveLength(1);
+        // It should hit the FIRST overlapping asteroid in array order.
+        expect(events[0].asteroidId).toBe(101);
+        expect(events[0].bulletWillDespawn).toBe(true);
+        expect(events[0].bulletPiercingRemaining).toBe(-1);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test 5 — piercedAsteroidIds Set carry-over across frames.
+// ---------------------------------------------------------------------
+
+describe('detectBulletAsteroidHits — piercedAsteroidIds across ticks', () => {
+    test('a piercing bullet that hit asteroid X last frame does NOT re-hit it this frame', () => {
+        const b = bullet(1, 100, 100, { piercing: 5, damage: 1 });
+        const a = asteroid(101, 110, 100);
+
+        // ── Frame 1 ──
+        const frame1Events = [];
+        detectBulletAsteroidHits([b], [a], ctx, frame1Events);
+        expect(frame1Events).toHaveLength(1);
+        // After frame 1, the bullet should remember it pierced this asteroid.
+        expect(b.piercedAsteroidIds).toBeDefined();
+        expect(b.piercedAsteroidIds.has(101)).toBe(true);
+
+        // ── Frame 2 — same asteroid, still overlapping ──
+        const frame2Events = [];
+        detectBulletAsteroidHits([b], [a], ctx, frame2Events);
+        expect(frame2Events).toHaveLength(0);
+    });
+
+    test('piercedAsteroidIds is lazily created (not pre-allocated)', () => {
+        // A bullet that never hits anything shouldn't carry a Set.
+        const b = bullet(1, 0, 0);
+        const a = asteroid(101, 999, 999); // Far away — no hit.
+        const events = [];
+        detectBulletAsteroidHits([b], [a], ctx, events);
+        expect(events).toHaveLength(0);
+        // Set should not have been allocated (defensive — keeps GC quiet).
+        expect(b.piercedAsteroidIds).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test 6 — empty inputs.
+// ---------------------------------------------------------------------
+
+describe('detectBulletAsteroidHits — empty inputs', () => {
+    test('empty bullets array → no events', () => {
+        const events = [];
+        detectBulletAsteroidHits([], [asteroid(101, 0, 0)], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('empty asteroids array → no events', () => {
+        const events = [];
+        detectBulletAsteroidHits([bullet(1, 0, 0)], [], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('both empty → no events', () => {
+        const events = [];
+        detectBulletAsteroidHits([], [], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('null bullets → no events (defensive)', () => {
+        const events = [];
+        detectBulletAsteroidHits(null, [asteroid(101, 0, 0)], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('null asteroids → no events (defensive)', () => {
+        const events = [];
+        detectBulletAsteroidHits([bullet(1, 0, 0)], null, ctx, events);
+        expect(events).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test 7 — damage carries through to event.
+// ---------------------------------------------------------------------
+
+describe('detectBulletAsteroidHits — damage propagation', () => {
+    test('event.damage matches bullet.damage', () => {
+        const b = bullet(1, 100, 100, { damage: 7 });
+        const a = asteroid(101, 110, 100);
+        const events = [];
+        detectBulletAsteroidHits([b], [a], ctx, events);
+        expect(events).toHaveLength(1);
+        expect(events[0].damage).toBe(7);
+    });
+
+    test('event.damage defaults to 1 when bullet.damage is missing/zero', () => {
+        const b = bullet(1, 100, 100, { damage: 0 });
+        const a = asteroid(101, 110, 100);
+        const events = [];
+        detectBulletAsteroidHits([b], [a], ctx, events);
+        expect(events[0].damage).toBe(1);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test 8 — skipped pairs (inactive / warping / death-flash).
+// ---------------------------------------------------------------------
+
+describe('detectBulletAsteroidHits — skipped pairs', () => {
+    test('inactive bullet is skipped', () => {
+        const b = bullet(1, 100, 100, { active: false });
+        const a = asteroid(101, 110, 100);
+        const events = [];
+        detectBulletAsteroidHits([b], [a], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('inactive asteroid is skipped', () => {
+        const b = bullet(1, 100, 100);
+        const a = asteroid(101, 110, 100, { active: false });
+        const events = [];
+        detectBulletAsteroidHits([b], [a], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('warping asteroid is skipped', () => {
+        const b = bullet(1, 100, 100);
+        const a = asteroid(101, 110, 100, { warping: true });
+        const events = [];
+        detectBulletAsteroidHits([b], [a], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('asteroid mid-death-flash (deathFlash > 0) is skipped', () => {
+        const b = bullet(1, 100, 100);
+        const a = asteroid(101, 110, 100, { deathFlash: 5 });
+        const events = [];
+        detectBulletAsteroidHits([b], [a], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('legacy _deathFlash field is also honored (live-game compat)', () => {
+        const b = bullet(1, 100, 100);
+        // Live `Asteroid` instances use the underscore-prefix name.
+        const a = { id: 101, x: 110, y: 100, radius: 30, active: true,
+                    warping: false, _deathFlash: 5 };
+        const events = [];
+        detectBulletAsteroidHits([b], [a], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Summary
**Phase 2.5 (collision-system extraction) — dispatch 1 of ~9 pairs.** Adds the first pure-step collision pair (bullet → asteroid) into a NEW `js/sim/collision.js`. Legacy `collision-system.js` (2139 LOC, solo gameplay path) is **intentionally untouched** — the two paths run in parallel.

## Architectural decision: parallel implementation, NOT refactor
- **Solo path** keeps using `collision-system.js` (zero risk to solo gameplay)
- **Server / multiplayer path** uses `js/sim/collision.js` (this PR)
- **Phase 3** wires the new pure functions in for client prediction

## Pure function

```js
detectBulletAsteroidHits(bullets, asteroids, ctx, events)
```

- Pure pair-detection: emits one event per detected hit
- Does NOT mutate asteroids; mutates `bullet.piercedAsteroidIds` Set as documented (intrinsic per-bullet state)
- Honors active/warping/death-flash gates on both sides
- Honors both `asteroid.deathFlash` (sim) and `._deathFlash` (legacy) for live-game compat
- Pure circle-circle overlap geometry mirroring `utils.js::collision()`

## Constants extracted
- `BULLET_ASTEROID_KNOCKBACK = 0.05` (from `COLLISION_CONFIG.BULLET_KNOCKBACK`)
- `BULLET_ASTEROID_HIT_FLASH_FRAMES = 10` (from `HIT_FLASH_FRAMES`)

## Event shape

```js
{
  type: 'bullet_hit_asteroid',
  bulletId, asteroidId,
  damage,                    // bullet.damage (defaults to 1)
  bulletX, bulletY,          // impact point for hit-flash + shrapnel
  bulletVx, bulletVy,        // for wrapper to apply knockback
  bulletPiercingRemaining,   // -1 for non-piercing, else 0..piercing
  bulletWillDespawn,         // true iff bullet should be removed after hit
}
```

The wrapper drains these into existing `handleBulletAsteroidImpact` / `damageAsteroid` helpers.

## Tests
22 tests across 8 describe blocks covering: constants verbatim, geometry hit/miss, piercing within tick (piercing=1, 2), non-piercing single-hit guard, piercedAsteroidIds Set carry-over across frames, lazy Set creation, empty/null defensive, damage passthrough, all skip-gates (inactive bullet/asteroid, warping, death-flash, legacy _deathFlash).

## Test plan
- [x] New collision tests: 22/22 pass
- [x] Full unit suite: 18 suites, 355 tests, all green
- [x] `collision-system.js` verified UNTOUCHED (size + mtime unchanged)

## Architectural notes for next dispatches
- **Player-vs-asteroid** needs `ctx` with ship state for bounce restitution; emits dual-impulse events (mutates both sides). Will need 7 more constants from `COLLISION_CONFIG` (BOUNCE_RESTITUTION, BOUNCE_FORCE_MULTIPLIER, etc.)
- **Bullet-vs-enemy** is near-mirror of bullet-asteroid; can reuse the `piercedAsteroidIds` pattern (consider unifying to `piercedTargetIds` once both land)
- **Spatial-grid pre-filtering** stays in the wrapper, not the pure step — wrapper passes pre-filtered slice
- **One-punch-man cheat** stays in wrapper (game-engine state, not sim state)
- **Damage application + asteroid death + split spawning** all stay in wrapper today; Phase 3 server promotes them to pure step

## Phase 2.5 progress (task #46)
- ✓ bullet-vs-asteroid (this PR)
- ⬜ player-vs-asteroid
- ⬜ bullet-vs-enemy
- ⬜ player-vs-enemy
- ⬜ enemy-vs-asteroid
- ⬜ player-vs-enemy-bullet
- ⬜ drops pickup
- ⬜ power-weapon collisions (lance, mine, nova, lightning, missile)
- ⬜ defense-skill collisions (deflector, tractor)

Rust mirror is a separate Phase 2.5 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)