### PR TITLE
mp/sim-rs: enemy bullet +4 patterns (Spread/Spiral/WaveEnergy/ShieldBurst, Phase 2.1)

### DIFF
--- a/js/sim/collision.js
+++ b/js/sim/collision.js
@@ -280,3 +280,344 @@ export function detectBulletAsteroidHits(bullets, asteroids, ctx, events) {
         }
     }
 }
+
+// ─── Constants — Player-vs-asteroid pair ─────────────────────────────
+//
+// Extracted verbatim from `COLLISION_CONFIG` in
+// `js/modules/combat/collision-system.js`. Each constant is pinned
+// here so the pure step stays self-contained (no legacy-module imports
+// leaking into the server / prediction path).
+//
+// Numerical parity with the legacy module is enforced by tests.
+
+/**
+ * Damage dealt to asteroid when player collides with it. Mirrors
+ * `COLLISION_CONFIG.PLAYER_ASTEROID_COLLISION_DAMAGE = 2`. Tiny by
+ * design: ramming asteroids is intentionally a *bad* strategy — the
+ * player gets deflected hard (see `ASTEROID_KNOCKBACK_MULTIPLIER`) and
+ * barely chips the rock. Asteroids carry 10-18 HP at full size, so
+ * destruction via ramming takes many hits, each costing the player
+ * health.
+ */
+export const PLAYER_ASTEROID_COLLISION_DAMAGE = 2;
+
+/**
+ * Bounce energy retention coefficient (0..1). Mirrors
+ * `COLLISION_CONFIG.BOUNCE_RESTITUTION = 0.9`. 1.0 = perfectly elastic
+ * (no energy loss), 0.0 = perfectly inelastic (stick). The 0.9 value
+ * here is the high-energy floor used for bounce reflections in the
+ * legacy player-asteroid path.
+ *
+ * Note: the legacy `handlePlayerAsteroidCollision` function does NOT
+ * use BOUNCE_RESTITUTION directly — restitution is consumed by the
+ * generic bounce path (`bounceObjects`, line 1774 of
+ * collision-system.js). The player-asteroid path uses the higher-level
+ * `ASTEROID_KNOCKBACK_MULTIPLIER` for the explosive deflection.
+ * BOUNCE_RESTITUTION is exposed here for use by future pairs
+ * (player-vs-enemy, enemy-vs-asteroid) and for parity with the legacy
+ * config block.
+ */
+export const BOUNCE_RESTITUTION = 0.9;
+
+/**
+ * Multiplier for bounce impulse force used by the generic bounce-pair
+ * path. Mirrors `COLLISION_CONFIG.BOUNCE_FORCE_MULTIPLIER = 12.0`. Like
+ * `BOUNCE_RESTITUTION` this isn't consumed directly by the
+ * player-asteroid pair (which uses the heavier
+ * `ASTEROID_KNOCKBACK_MULTIPLIER` path); exposed here for symmetry with
+ * the legacy config and for the upcoming enemy / asteroid-asteroid
+ * pairs.
+ */
+export const BOUNCE_FORCE_MULTIPLIER = 12.0;
+
+/**
+ * Fraction of computed overlap used by the generic bounce-pair
+ * separation push. Mirrors `COLLISION_CONFIG.OVERLAP_SEPARATION_RATIO
+ * = 0.6`. Same scoping note: the player-asteroid pair uses the FULL
+ * overlap plus `SEPARATION_BUFFER`, not this ratio — but the constant
+ * lives here so the wrapper / Rust mirror has the full collision
+ * config available without dipping back into the legacy module.
+ */
+export const OVERLAP_SEPARATION_RATIO = 0.6;
+
+/**
+ * Knockback multiplier for player-asteroid collisions. Mirrors
+ * `COLLISION_CONFIG.ASTEROID_KNOCKBACK_MULTIPLIER = 22.0`. Applied to
+ * the normal-projected relative velocity (`dvn / totalMass`) to derive
+ * the impulse magnitude that flings the player off the rock.
+ *
+ *   player.vel += knockbackAngle * (dvn / (player.mass + asteroid.mass)) * 22.0
+ *
+ * Bumped from earlier values because asteroid ramming was viable in
+ * older builds. The 22.0 value kills the exploit by shoving the player
+ * away too hard to keep grinding the rock.
+ */
+export const ASTEROID_KNOCKBACK_MULTIPLIER = 22.0;
+
+/**
+ * Extra pixels added to the separation distance after computing the
+ * overlap. Mirrors `COLLISION_CONFIG.SEPARATION_BUFFER = 6`. Ensures
+ * the player is moved *past* the surface boundary so the very next
+ * tick doesn't re-overlap and re-trigger the collision event.
+ */
+export const SEPARATION_BUFFER = 6;
+
+/**
+ * Additional velocity push applied to the player along the
+ * (asteroid → player) normal when an overlap was resolved. Mirrors
+ * `COLLISION_CONFIG.OVERLAP_PUSH_FORCE = 5.0`. Stacks on top of the
+ * knockback impulse — the knockback handles the "bounce off" reaction,
+ * while this provides a steady outward push to prevent slow-creep
+ * re-overlaps.
+ */
+export const OVERLAP_PUSH_FORCE = 5.0;
+
+// ─── Player-vs-asteroid pair detection ──────────────────────────────
+
+/**
+ * Internal helper: read a "mass" off an entity, falling back to a
+ * radius-derived approximation when the field isn't set.
+ *
+ *   - Live `Player` uses   `mass = π · r² · 0.5`
+ *   - Live `Asteroid` uses `mass = (4/3) · π · r³`
+ *
+ * The new f32 `ShipState` / `AsteroidState` don't carry a `mass` field,
+ * so for round-trip parity we fall back to the same formulas the live
+ * classes use. The wrapper can override by setting `mass` explicitly on
+ * the state object (matches legacy live-instance behavior).
+ *
+ * @param {Object} entity   live or pure-state shape
+ * @param {'player'|'asteroid'} kind
+ * @returns {number}
+ */
+function entityMass(entity, kind) {
+    if (entity.mass !== undefined && entity.mass !== null) return entity.mass;
+    const r = entity.radius || 0;
+    if (kind === 'asteroid') return (4 / 3) * Math.PI * r * r * r;
+    // player default
+    return Math.PI * r * r * 0.5;
+}
+
+/**
+ * Internal helper: read velocity off an entity. Live `Player` /
+ * `Asteroid` instances store `vel.x` / `vel.y`; pure-state `ShipState`
+ * / `AsteroidState` use top-level `vx` / `vy`. Accept either.
+ *
+ * @param {Object} entity
+ * @returns {{ x: number, y: number }}
+ */
+function entityVel(entity) {
+    if (entity.vel) return { x: entity.vel.x || 0, y: entity.vel.y || 0 };
+    return { x: entity.vx || 0, y: entity.vy || 0 };
+}
+
+/**
+ * Internal helper: read an entity's id, preferring `.id` then falling
+ * back to `.player` (ShipState uses `player` as its identifier slot).
+ */
+function entityId(entity) {
+    if (entity.id !== undefined) return entity.id;
+    if (entity.player !== undefined) return entity.player;
+    return null;
+}
+
+/**
+ * Detect player-vs-asteroid collisions for one tick.
+ *
+ * Pure step: reads player + asteroid positions / radii / velocities,
+ * decides which pairs overlap, and emits one `player_hit_asteroid`
+ * event per detected hit with the velocity + position *deltas* the
+ * wrapper applies to the live state. This function does NOT mutate
+ * player or asteroid — every effect is reported in the event payload
+ * for the wrapper / Rust mirror to apply downstream.
+ *
+ * Co-op ready: takes an array of players. The solo wrapper passes
+ * `[player]`; future co-op sessions will pass the full ship roster.
+ * Each player is scanned against every active asteroid; one player
+ * can emit multiple events per tick if it overlaps multiple rocks
+ * simultaneously (e.g. trapped between two boulders).
+ *
+ * Geometry:
+ *   Circle-circle overlap: `hypot(dx, dy) < player.radius + ast.radius`.
+ *   Identical to the legacy `collision()` helper.
+ *
+ * Bounce / impulse model (mirrors lines 2052-2073 of
+ * `collision-system.js::handlePlayerAsteroidCollision`):
+ *
+ *   knockbackAngle = atan2(player.y - asteroid.y, player.x - asteroid.x)
+ *   totalMass      = player.mass + asteroid.mass
+ *   dvn            = (player.vx - asteroid.vx) · cos(angle)
+ *                  + (player.vy - asteroid.vy) · sin(angle)
+ *   enhancedImpulse = 2 · dvn / totalMass
+ *   knockback      = enhancedImpulse · ASTEROID_KNOCKBACK_MULTIPLIER
+ *
+ *   player.vel  += (cos(angle + jitter), sin(angle + jitter)) · knockback
+ *   asteroid.vel -= (cos(angle), sin(angle)) · knockback · 0.3 · player.mass
+ *
+ * Determinism / jitter:
+ *   The legacy path uses `random(-π/4, π/4)` for a jitter angle. The
+ *   pure step is deterministic: if `ctx.rngFloat` is provided it
+ *   consumes one [0,1) sample and remaps it to `[-π/4, π/4]`; otherwise
+ *   jitter defaults to 0 so server/prediction stay reproducible.
+ *
+ * Separation push (mirrors lines 2076-2096):
+ *   If `overlap = (player.r + asteroid.r) - distance > 0`:
+ *     - Position delta (player only): unit normal · (overlap +
+ *       SEPARATION_BUFFER) — moves the ship clear of the surface.
+ *     - Velocity push (player only): unit normal · OVERLAP_PUSH_FORCE
+ *       added on top of the bounce impulse to keep the ship drifting
+ *       outward instead of slow-creeping back through.
+ *
+ * Asteroid damage:
+ *   Constant `PLAYER_ASTEROID_COLLISION_DAMAGE = 2`. The wrapper
+ *   subtracts this from `asteroid.hp` (or legacy `asteroid.health`)
+ *   and handles death-flash + drops. The pure step just reports the
+ *   number.
+ *
+ * Skipped pairs (no event emitted):
+ *   - Inactive player     (`!player.active`)
+ *   - Inactive asteroid   (`!asteroid.active`)
+ *   - Warping asteroid    (mid warp-in animation)
+ *   - Asteroid mid-death  (`asteroid.deathFlash > 0` or legacy
+ *                          `asteroid._deathFlash > 0`)
+ *
+ * @param {Array<Object>} players       active player ships. Each is
+ *                                      treated as having `{x, y, vx OR
+ *                                      vel.x, vy OR vel.y, radius,
+ *                                      mass?, active, id OR player}`.
+ *                                      Compatible with both the
+ *                                      `ShipState` typedef in
+ *                                      `js/sim/state.js` and the live
+ *                                      `Player` instance shape.
+ * @param {Array<Object>} asteroids     active asteroids. Each is
+ *                                      treated as having `{x, y, vx OR
+ *                                      vel.x, vy OR vel.y, radius,
+ *                                      mass?, active, warping,
+ *                                      deathFlash OR _deathFlash, id}`.
+ * @param {Object} ctx                  per-tick context bag. Optional
+ *                                      field: `rngFloat()` returning
+ *                                      [0,1) for deterministic jitter.
+ *                                      No `rngFloat` ⇒ jitter = 0.
+ * @param {Array<Object>} events        out-buffer. Pushes objects with
+ *                                      the shape documented below.
+ *
+ * Event shape (one per detected hit):
+ *   {
+ *     type: 'player_hit_asteroid',
+ *     playerId:               id of the colliding ship
+ *     asteroidId:             id of the colliding asteroid
+ *     damageToAsteroid:       constant 2 (see PLAYER_ASTEROID_COLLISION_DAMAGE)
+ *     playerImpulseDx,
+ *     playerImpulseDy:        velocity delta the wrapper adds to
+ *                             `player.vel` (legacy) or `player.vx/vy`
+ *                             (pure-state). Includes the knockback +
+ *                             overlap-push contributions.
+ *     asteroidImpulseDx,
+ *     asteroidImpulseDy:      velocity delta the wrapper adds to the
+ *                             asteroid's velocity (much smaller — 0.3 ·
+ *                             player.mass · knockback along the
+ *                             un-jittered normal).
+ *     separationDx,
+ *     separationDy:           position delta the wrapper adds to
+ *                             `player.x` / `player.y` to move the ship
+ *                             clear of the rock. Zero if no overlap
+ *                             was measured (defensive — the geometry
+ *                             check already requires overlap, but the
+ *                             distance-from-center math could degenerate
+ *                             on a perfect-center coincidence).
+ *   }
+ */
+export function detectPlayerAsteroidHits(players, asteroids, ctx, events) {
+    if (!players || !asteroids) return;
+    if (players.length === 0 || asteroids.length === 0) return;
+
+    for (let i = 0; i < players.length; i++) {
+        const player = players[i];
+        if (!player || !player.active) continue;
+
+        const playerRadius = player.radius || 0;
+        const playerVel = entityVel(player);
+        const playerMass = entityMass(player, 'player');
+        const pId = entityId(player);
+
+        for (let j = 0; j < asteroids.length; j++) {
+            const asteroid = asteroids[j];
+            if (!asteroid || !asteroid.active) continue;
+            if (asteroid.warping) continue;
+
+            // Death-flash gate — same dual-name accept as bullet path.
+            const dF = asteroid.deathFlash !== undefined
+                ? asteroid.deathFlash
+                : asteroid._deathFlash;
+            if (dF && dF > 0) continue;
+
+            // Circle-circle overlap check.
+            const dx = player.x - asteroid.x;
+            const dy = player.y - asteroid.y;
+            const sumR = playerRadius + (asteroid.radius || 0);
+            const distSq = dx * dx + dy * dy;
+            if (distSq >= sumR * sumR) continue;
+
+            // ── Hit detected — compute impulse + separation ──
+
+            const asteroidVel = entityVel(asteroid);
+            const asteroidMass = entityMass(asteroid, 'asteroid');
+
+            // Knockback angle: from asteroid → player. Defensive: if
+            // the centers exactly coincide (distSq === 0) use a
+            // fallback angle of 0 to avoid NaN from atan2(0,0)=0 and
+            // skip the separation-direction divide-by-zero.
+            const distance = Math.sqrt(distSq);
+            const knockbackAngle = distance > 0
+                ? Math.atan2(dy, dx)
+                : 0;
+
+            const totalMass = playerMass + asteroidMass;
+            const cosA = Math.cos(knockbackAngle);
+            const sinA = Math.sin(knockbackAngle);
+            const dvn = (playerVel.x - asteroidVel.x) * cosA
+                      + (playerVel.y - asteroidVel.y) * sinA;
+            const enhancedImpulse = totalMass > 0 ? (2 * dvn) / totalMass : 0;
+            const knockback = enhancedImpulse * ASTEROID_KNOCKBACK_MULTIPLIER;
+
+            // Deterministic jitter: ctx.rngFloat ∈ [0,1) → [-π/4, π/4].
+            const jitterFraction = (ctx && typeof ctx.rngFloat === 'function')
+                ? ctx.rngFloat()
+                : 0.5; // 0.5 ⇒ centered ⇒ jitter = 0
+            const jitter = (jitterFraction - 0.5) * (Math.PI / 2);
+
+            let playerImpulseDx = Math.cos(knockbackAngle + jitter) * knockback;
+            let playerImpulseDy = Math.sin(knockbackAngle + jitter) * knockback;
+
+            const asteroidImpulseDx = -knockback * 0.3 * playerMass * cosA;
+            const asteroidImpulseDy = -knockback * 0.3 * playerMass * sinA;
+
+            // Separation push (player-only position + velocity nudge).
+            let separationDx = 0;
+            let separationDy = 0;
+            const overlap = sumR - distance;
+            if (overlap > 0 && distance > 0) {
+                const nx = dx / distance;
+                const ny = dy / distance;
+                const totalSeparation = overlap + SEPARATION_BUFFER;
+                separationDx = nx * totalSeparation;
+                separationDy = ny * totalSeparation;
+                playerImpulseDx += nx * OVERLAP_PUSH_FORCE;
+                playerImpulseDy += ny * OVERLAP_PUSH_FORCE;
+            }
+
+            events.push({
+                type: 'player_hit_asteroid',
+                playerId: pId,
+                asteroidId: asteroid.id,
+                damageToAsteroid: PLAYER_ASTEROID_COLLISION_DAMAGE,
+                playerImpulseDx,
+                playerImpulseDy,
+                asteroidImpulseDx,
+                asteroidImpulseDy,
+                separationDx,
+                separationDy,
+            });
+        }
+    }
+}

--- a/server/src/sim/bullet.rs
+++ b/server/src/sim/bullet.rs
@@ -8,21 +8,25 @@
 //! Mirrors `js/sim/bullet.js`. **Player bullets** (`update_player_bullet`)
 //! implement the linear drift + helix offset + predictive-lead homing
 //! branches (PR #27). **Enemy bullets** (`update_enemy_bullet`) implement
-//! 3 of ~17 movement patterns (PR #29):
+//! 7 of ~17 movement patterns:
 //!
-//!   - `Straight` — js `aimed`/`crescent_beam`/`crescent_slice` (no-mod path).
-//!   - `Sine` — js `sine_wave_nospin` (perpendicular sine offset).
-//!   - `Decelerate` — js `missile_decelerate` (subtractive speed decay).
+//!   - `Straight` — js `aimed`/`crescent_beam`/`crescent_slice` (no-mod path). (PR #29)
+//!   - `Sine` — js `sine_wave_nospin` (perpendicular sine offset). (PR #29)
+//!   - `Decelerate` — js `missile_decelerate` (subtractive speed decay). (PR #29)
+//!   - `Spread` — js `spread` (patternTimer-driven sine on a perp-of-base axis).
+//!   - `Spiral` — js `spiral` (rotating velocity vector + spreading radius).
+//!   - `WaveEnergy` — js `wave_energy` (large-amplitude sine on perp-of-base axis).
+//!   - `ShieldBurst` — js `shield_burst` (high-freq wobble on perp-of-base axis).
 //!
 //! Deferred to follow-up sessions:
 //!
 //!   - Piercing / piercedEnemies counter — collision-side, Phase 2.5
 //!   - Explosive / explosionRadius — collision-side, Phase 2.5
-//!   - 14+ remaining enemy patterns (js bullet.js:259–593): `mine`,
-//!     `homing_mine`, `spread`, `rapid`, `spiral`, `burst`, `explosive`,
-//!     `laser`, `laser_beam`, `missile`, `homing`, `titan_homing`,
-//!     `titan_rocket`, `pulse`, `shield_burst`, `wave_energy`,
-//!     `energy_slash`, `sine_wave` (with rotation), `missile_fast_slow`
+//!   - 10+ remaining enemy patterns (js bullet.js:259–593): `mine`,
+//!     `homing_mine`, `rapid`, `burst`, `explosive`, `laser`,
+//!     `laser_beam`, `missile`, `homing`, `titan_homing`, `titan_rocket`,
+//!     `pulse`, `energy_slash`, `sine_wave` (with rotation),
+//!     `missile_fast_slow`.
 //!   - Boss-rage homing composition, mine HP-death, persistent timed
 //!     lifetime (mines / lightning orbs), `targetPlayer` lookups.
 //!
@@ -415,12 +419,21 @@ pub fn update_player_bullets(
 // ── ENEMY BULLETS ───────────────────────────────────────────────────────
 //
 // `js/sim/bullet.js::updateEnemyBullet` switches on `movementPattern` and
-// has ~17 distinct cases. Phase 2.1 implements the 3 simplest:
+// has ~17 distinct cases. Implemented so far (7):
 //
 //   - `Straight` (aimed / crescent_beam / crescent_slice — no-mod path).
 //   - `Sine` (sine_wave_nospin — perpendicular sin(phase)*amp offset).
 //   - `Decelerate` (missile_decelerate — subtract decel each tick, clamp
 //     at min_speed; expire when at floor).
+//   - `Spread` (patternTimer-driven sin offset on baseAngle+π/2 axis;
+//     amplitude 0.5, frequency 3, plus a fixed patternPhase offset).
+//   - `Spiral` (per-tick rotation of velocity vector; speed taken from
+//     baseVx/baseVy magnitude, angle drifts at `spiral_rate * patternTimer`,
+//     with a centrifugal `patternTimer * 0.05` perpendicular term).
+//   - `WaveEnergy` (high-amplitude sin on baseAngle+π/2 axis with the
+//     0.1 attenuation factor; pattern timer ramp).
+//   - `ShieldBurst` (high-freq sin(patternTimer*8)*0.2 wobble on
+//     baseAngle+π/2 axis).
 //
 // The remaining patterns are TODO; see module docstring for the full list.
 //
@@ -449,9 +462,33 @@ const DISTANCE_FADE_KNEE: f32 = 0.65;
 const DISTANCE_FADE_RANGE: f32 = 0.35;
 const DISTANCE_FADE_FINAL: f32 = 0.5;
 
-/// Enemy-bullet movement pattern. Phase 2.1 covers the 3 simplest cases
-/// only. The full JS dispatcher has ~17 — see module docstring for the
-/// deferred list.
+// JS bullet.js:300–301 — `spread` pattern: per-tick sin frequency and
+// amplitude (px/tick equivalent units). The wave is applied on the
+// `baseAngle + π/2` axis with an additional fixed `patternPhase` offset.
+const SPREAD_WAVE_FREQ: f32 = 3.0;
+const SPREAD_WAVE_AMP: f32 = 0.5;
+
+// JS bullet.js:319–323 — `spiral` pattern: `spiralRate` controls how fast
+// the velocity vector rotates per second; `0.1` is the perpendicular
+// centrifugal contribution applied to a radius that grows as
+// `patternTimer * 0.5`. The final formula factors to `patternTimer * 0.05`
+// on the perpendicular axis.
+const SPIRAL_RATE: f32 = 2.0;
+const SPIRAL_RADIUS_RATE: f32 = 0.5;
+const SPIRAL_PERP_FACTOR: f32 = 0.1;
+
+// JS bullet.js:493–494 — `wave_energy`: large amplitude (15) gated by a
+// `0.1` factor, plus frequency 3. Same perp axis as `spread`.
+const WAVE_ENERGY_FREQ: f32 = 3.0;
+const WAVE_ENERGY_AMP: f32 = 15.0;
+const WAVE_ENERGY_VEL_SCALE: f32 = 0.1;
+
+// JS bullet.js:485 — `shield_burst`: sin(patternTimer*8)*0.2 wobble.
+const SHIELD_BURST_FREQ: f32 = 8.0;
+const SHIELD_BURST_AMP: f32 = 0.2;
+
+/// Enemy-bullet movement pattern. 7 of ~17 ported so far — see module
+/// docstring for the deferred list.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BulletPattern {
     /// JS `aimed` / `crescent_beam` / `crescent_slice` — straight-line drift,
@@ -465,10 +502,25 @@ pub enum BulletPattern {
     /// JS `missile_decelerate` — subtractive speed decay each tick. When the
     /// speed reaches `min_speed`, the bullet expires (`expired_by_distance`).
     Decelerate,
-    // TODO Phase 2.1+: Helix, Homing, Ricochet, Rocket, Mine, Spiral,
-    // EnergySlash, Bezier, Charge, Spread, Rapid, Burst, Explosive, Laser,
-    // LaserBeam, Missile, TitanHoming, TitanRocket, Pulse, ShieldBurst,
-    // WaveEnergy, SineWave (with rotation), MissileFastSlow, HomingMine.
+    /// JS `spread` — patternTimer-driven sin offset on the `baseAngle+π/2`
+    /// axis. Frequency 3, amplitude 0.5, plus a fixed `pattern_phase`
+    /// offset that fans out a single volley.
+    Spread,
+    /// JS `spiral` — rotating velocity vector. Speed comes from the magnitude
+    /// of (base_vx, base_vy); the angle drifts at `SPIRAL_RATE * patternTimer`
+    /// relative to baseAngle, and the bullet also accumulates a centrifugal
+    /// perpendicular contribution that grows linearly with patternTimer.
+    Spiral,
+    /// JS `wave_energy` — large-amplitude sin offset on the `baseAngle+π/2`
+    /// axis. Frequency 3, amplitude 15, scaled down by 0.1 in velocity units.
+    WaveEnergy,
+    /// JS `shield_burst` — high-frequency `sin(patternTimer*8)*0.2` wobble
+    /// on the `baseAngle+π/2` axis. No pattern_phase or extra state.
+    ShieldBurst,
+    // TODO Phase 2.1+: Helix, Homing, Ricochet, Rocket, Mine, EnergySlash,
+    // Bezier, Charge, Rapid, Burst, Explosive, Laser, LaserBeam, Missile,
+    // TitanHoming, TitanRocket, Pulse, SineWave (with rotation),
+    // MissileFastSlow, HomingMine.
 }
 
 /// Minimal enemy-bullet state for the 3 patterns above.
@@ -523,10 +575,8 @@ pub struct EnemyBullet {
     // ── Pattern timing (seconds since spawn) ──────────────────────────
     /// JS bullet.js:200 — incremented each tick by `logic_tick_seconds`.
     pub pattern_timer: f32,
-    /// JS state.js:456 — pattern-specific phase offset (used by spread,
-    /// energy_slash, etc.). Reserved; not consumed by the 3 ported
-    /// patterns but kept on the struct for parity.
-    #[allow(dead_code)]
+    /// JS state.js:456 — pattern-specific phase offset (used by `Spread`
+    /// for fan-out; reserved for other future patterns like `energy_slash`).
     pub pattern_phase: f32,
 
     // ── Sine pattern state ────────────────────────────────────────────
@@ -631,6 +681,59 @@ fn apply_enemy_movement_pattern(b: &mut EnemyBullet, _ctx: &EnemyBulletContext) 
                 b.active = false;
                 b.expired_by_distance = true;
             }
+        }
+
+        // JS bullet.js:299–306 — `spread`. Sin wave on the perp axis of the
+        // base direction. Note the JS `speed` and `baseAngle` are computed
+        // from `bullet.baseVx/baseVy` at the TOP of `applyEnemyMovementPattern`
+        // (lines 265–266) — we recompute baseAngle locally where it's used.
+        BulletPattern::Spread => {
+            let base_angle = b.base_vy.atan2(b.base_vx);
+            let perp_angle = base_angle + std::f32::consts::FRAC_PI_2;
+            let wave_offset = (b.pattern_timer * SPREAD_WAVE_FREQ + b.pattern_phase).sin()
+                * SPREAD_WAVE_AMP;
+            b.vx = b.base_vx + perp_angle.cos() * wave_offset;
+            b.vy = b.base_vy + perp_angle.sin() * wave_offset;
+        }
+
+        // JS bullet.js:318–324 — `spiral`. Speed comes from the magnitude of
+        // the base velocity; angle rotates at `SPIRAL_RATE * patternTimer`.
+        // A perpendicular centrifugal term grows linearly with patternTimer
+        // (`patternTimer * SPIRAL_RADIUS_RATE * SPIRAL_PERP_FACTOR`, which
+        // is the JS `spiralRadius * 0.1` factored).
+        BulletPattern::Spiral => {
+            let speed = (b.base_vx * b.base_vx + b.base_vy * b.base_vy).sqrt();
+            let base_angle = b.base_vy.atan2(b.base_vx);
+            let spiral_angle = base_angle + b.pattern_timer * SPIRAL_RATE;
+            let spiral_radius = b.pattern_timer * SPIRAL_RADIUS_RATE;
+            let perp_angle = spiral_angle + std::f32::consts::FRAC_PI_2;
+            b.vx = spiral_angle.cos() * speed
+                + perp_angle.cos() * spiral_radius * SPIRAL_PERP_FACTOR;
+            b.vy = spiral_angle.sin() * speed
+                + perp_angle.sin() * spiral_radius * SPIRAL_PERP_FACTOR;
+        }
+
+        // JS bullet.js:492–502 — `wave_energy`. Large-amplitude (15)
+        // patternTimer-driven sin on the perp axis, scaled by 0.1 in
+        // velocity units.
+        BulletPattern::WaveEnergy => {
+            let base_angle = b.base_vy.atan2(b.base_vx);
+            let perp_angle = base_angle + std::f32::consts::FRAC_PI_2;
+            let energy_wave_offset =
+                (b.pattern_timer * WAVE_ENERGY_FREQ).sin() * WAVE_ENERGY_AMP;
+            let wave_vel_x = perp_angle.cos() * energy_wave_offset * WAVE_ENERGY_VEL_SCALE;
+            let wave_vel_y = perp_angle.sin() * energy_wave_offset * WAVE_ENERGY_VEL_SCALE;
+            b.vx = b.base_vx + wave_vel_x;
+            b.vy = b.base_vy + wave_vel_y;
+        }
+
+        // JS bullet.js:484–489 — `shield_burst`. High-frequency sin wobble
+        // on the perp axis.
+        BulletPattern::ShieldBurst => {
+            let wobble = (b.pattern_timer * SHIELD_BURST_FREQ).sin() * SHIELD_BURST_AMP;
+            let perp_angle = b.base_vy.atan2(b.base_vx) + std::f32::consts::FRAC_PI_2;
+            b.vx = b.base_vx + perp_angle.cos() * wobble;
+            b.vy = b.base_vy + perp_angle.sin() * wobble;
         }
     }
 }

--- a/server/tests/parity_enemy_bullet.rs
+++ b/server/tests/parity_enemy_bullet.rs
@@ -1,21 +1,24 @@
 //! Cross-language parity vectors for enemy-bullet ballistics (Phase 2.1).
 //!
-//! Mirrors `js/sim/bullet.js::updateEnemyBullet` for the 3 simplest movement
-//! patterns:
+//! Mirrors `js/sim/bullet.js::updateEnemyBullet` for 7 movement patterns:
 //!
 //!   - `Straight` ↔ JS `aimed` / `crescent_beam` / `crescent_slice` (no-mod
 //!     velocity path).
 //!   - `Sine` ↔ JS `sine_wave_nospin` (perpendicular sine offset).
 //!   - `Decelerate` ↔ JS `missile_decelerate` (subtractive speed decay,
 //!     clamped at `min_speed`).
+//!   - `Spread` ↔ JS `spread` (patternTimer-driven sin on perp-of-base axis).
+//!   - `Spiral` ↔ JS `spiral` (rotating velocity vector + radius drift).
+//!   - `WaveEnergy` ↔ JS `wave_energy` (high-amplitude sin on perp axis).
+//!   - `ShieldBurst` ↔ JS `shield_burst` (high-freq sin wobble on perp axis).
 //!
-//! See `server/src/sim/bullet.rs` module docstring for the full list of
-//! ~14 deferred patterns (helix, homing, ricochet, rocket, mine, spiral,
-//! energy_slash, bezier, charge, etc.).
+//! See `server/src/sim/bullet.rs` module docstring for the deferred list
+//! (helix, homing, ricochet, rocket, mine, energy_slash, bezier, charge,
+//! etc.).
 //!
 //! Reference values were captured against the JS source by running the
-//! one-liner embedded in this file; both sides compute the same trajectory
-//! within an f32-tolerance of 0.01 px.
+//! one-liner embedded in each fixture; both sides compute the same
+//! trajectory within an f32-tolerance of 0.01 px.
 
 use rainboids_server::sim::bullet::{
     update_enemy_bullet, BulletEvent, BulletPattern, EnemyBullet, EnemyBulletContext,
@@ -268,4 +271,247 @@ fn enemy_bullet_decelerate() {
         events,
     );
     assert_eq!(events[0], BulletEvent::Despawn { bullet_id: 3 });
+}
+
+// ── Fixture 4: spread (patternTimer sin on perp axis) ───────────────────
+//
+// JS reference values captured 2026-05-10 via:
+//
+//   node --input-type=module -e "
+//     import { updateEnemyBullet } from './js/sim/bullet.js';
+//     import { freshBulletState } from './js/sim/state.js';
+//     const b = freshBulletState(4, 'enemy', { movementPattern: 'spread',
+//         x: 100, y: 100, vx: 4, vy: 0, baseVx: 4, baseVy: 0,
+//         startX: 100, startY: 100, patternPhase: 0,
+//         life: 0, maxLife: 180, damage: 10, radius: 4, baseRadius: 4,
+//         maxRange: 9999, rangeMultiplier: 1.0, active: true });
+//     const ctx = { tickScale: 0.5, logicTickSeconds: 1/60, bulletSpeed: 10,
+//         boundaryWidth: 9999, boundaryHeight: 9999, now: 0,
+//         targetPlayer: null, homingTarget: null, rngFloat: () => 0.5 };
+//     for (let i = 0; i < 25; i++) updateEnemyBullet(b, ctx, []);
+//     console.log(JSON.stringify({ x: b.x, y: b.y, vx: b.vx, vy: b.vy,
+//         patternTimer: b.patternTimer, life: b.life, active: b.active }));
+//   "
+//   → {"x":150,"y":103.30405187501303,"vx":4,"vy":0.46601954298361314,
+//      "patternTimer":0.41666666666666663,"life":1,"active":true}
+#[test]
+fn enemy_bullet_spread() {
+    let mut b = default_enemy_bullet(4, BulletPattern::Spread);
+    b.x = 100.0;
+    b.y = 100.0;
+    b.vx = 4.0;
+    b.vy = 0.0;
+    b.start_x = 100.0;
+    b.start_y = 100.0;
+    b.base_vx = 4.0;
+    b.base_vy = 0.0;
+    b.pattern_phase = 0.0;
+    b.life = 0.0;
+
+    let ctx = default_ctx();
+    let mut events: Vec<BulletEvent> = Vec::new();
+    for _ in 0..25 {
+        update_enemy_bullet(&mut b, &ctx, &mut events);
+    }
+
+    close(b.x, 150.0, "bullet.x");
+    close(b.y, 103.30405187501303, "bullet.y");
+    close(b.vx, 4.0, "bullet.vx");
+    close(b.vy, 0.46601954298361314, "bullet.vy");
+    close(b.pattern_timer, 0.41666666666666663, "bullet.pattern_timer");
+    close(b.life, 1.0, "bullet.life");
+    assert!(b.active, "bullet should still be active");
+
+    assert!(
+        events.is_empty(),
+        "unexpected despawn events for alive bullet: {:?}",
+        events,
+    );
+}
+
+// ── Fixture 5: spiral (rotating velocity + spread radius) ────────────────
+//
+// JS reference values captured 2026-05-10 via:
+//
+//   node --input-type=module -e "
+//     import { updateEnemyBullet } from './js/sim/bullet.js';
+//     import { freshBulletState } from './js/sim/state.js';
+//     const b = freshBulletState(5, 'enemy', { movementPattern: 'spiral',
+//         x: 500, y: 500, vx: 3, vy: 0, baseVx: 3, baseVy: 0,
+//         startX: 500, startY: 500,
+//         life: 0, maxLife: 180, damage: 10, radius: 4, baseRadius: 4,
+//         maxRange: 9999, rangeMultiplier: 1.0, active: true });
+//     const ctx = { tickScale: 0.5, logicTickSeconds: 1/60, bulletSpeed: 10,
+//         boundaryWidth: 9999, boundaryHeight: 9999, now: 0,
+//         targetPlayer: null, homingTarget: null, rngFloat: () => 0.5 };
+//     for (let i = 0; i < 20; i++) updateEnemyBullet(b, ctx, []);
+//     console.log(JSON.stringify({ x: b.x, y: b.y, vx: b.vx, vy: b.vy,
+//         patternTimer: b.patternTimer, life: b.life, active: b.active }));
+//   "
+//   → {"x":527.9517691193454,"y":509.24140765384163,
+//      "vx":2.4088069018259324,"vy":1.7882673189879073,
+//      "patternTimer":0.3333333333333333,"life":1,"active":true}
+//
+// Trig-heavy: tolerance is loosened to 0.05 px to absorb the cumulative
+// difference between JS double-precision and Rust f32 single-precision
+// after 20 rotated-velocity ticks.
+#[test]
+fn enemy_bullet_spiral() {
+    let mut b = default_enemy_bullet(5, BulletPattern::Spiral);
+    b.x = 500.0;
+    b.y = 500.0;
+    b.vx = 3.0;
+    b.vy = 0.0;
+    b.start_x = 500.0;
+    b.start_y = 500.0;
+    b.base_vx = 3.0;
+    b.base_vy = 0.0;
+    b.life = 0.0;
+
+    let ctx = default_ctx();
+    let mut events: Vec<BulletEvent> = Vec::new();
+    for _ in 0..20 {
+        update_enemy_bullet(&mut b, &ctx, &mut events);
+    }
+
+    // Looser tolerance (0.05) for trig-heavy spiral accumulator. The
+    // velocity check has the tightest budget; position deltas accumulate
+    // 20 of those.
+    fn close_loose(actual: f32, expected: f32, tol: f32, what: &str) {
+        let delta = (actual - expected).abs();
+        assert!(
+            delta < tol,
+            "{} diverged: rust={}, js={}, |Δ|={}, tol={}",
+            what,
+            actual,
+            expected,
+            delta,
+            tol,
+        );
+    }
+    close_loose(b.x, 527.9517691193454, 0.05, "bullet.x");
+    close_loose(b.y, 509.24140765384163, 0.05, "bullet.y");
+    close_loose(b.vx, 2.4088069018259324, 0.01, "bullet.vx");
+    close_loose(b.vy, 1.7882673189879073, 0.01, "bullet.vy");
+    close(b.pattern_timer, 0.3333333333333333, "bullet.pattern_timer");
+    close(b.life, 1.0, "bullet.life");
+    assert!(b.active, "bullet should still be active");
+
+    assert!(
+        events.is_empty(),
+        "unexpected despawn events for alive bullet: {:?}",
+        events,
+    );
+}
+
+// ── Fixture 6: wave_energy (high-amp sin on perp axis) ───────────────────
+//
+// JS reference values captured 2026-05-10 via:
+//
+//   node --input-type=module -e "
+//     import { updateEnemyBullet } from './js/sim/bullet.js';
+//     import { freshBulletState } from './js/sim/state.js';
+//     const b = freshBulletState(6, 'enemy', { movementPattern: 'wave_energy',
+//         x: 200, y: 200, vx: 5, vy: 0, baseVx: 5, baseVy: 0,
+//         startX: 200, startY: 200,
+//         life: 0, maxLife: 180, damage: 10, radius: 4, baseRadius: 4,
+//         maxRange: 9999, rangeMultiplier: 1.0, active: true });
+//     const ctx = { tickScale: 0.5, logicTickSeconds: 1/60, bulletSpeed: 10,
+//         boundaryWidth: 9999, boundaryHeight: 9999, now: 0,
+//         targetPlayer: null, homingTarget: null, rngFloat: () => 0.5 };
+//     for (let i = 0; i < 30; i++) updateEnemyBullet(b, ctx, []);
+//     console.log(JSON.stringify({ x: b.x, y: b.y, vx: b.vx, vy: b.vy,
+//         patternTimer: b.patternTimer, life: b.life, active: b.active }));
+//   "
+//   → {"x":275,"y":213.56197728775817,"vx":5,
+//      "vy":1.4890694865563827,"patternTimer":0.49999999999999994,
+//      "life":1,"active":true}
+#[test]
+fn enemy_bullet_wave_energy() {
+    let mut b = default_enemy_bullet(6, BulletPattern::WaveEnergy);
+    b.x = 200.0;
+    b.y = 200.0;
+    b.vx = 5.0;
+    b.vy = 0.0;
+    b.start_x = 200.0;
+    b.start_y = 200.0;
+    b.base_vx = 5.0;
+    b.base_vy = 0.0;
+    b.life = 0.0;
+
+    let ctx = default_ctx();
+    let mut events: Vec<BulletEvent> = Vec::new();
+    for _ in 0..30 {
+        update_enemy_bullet(&mut b, &ctx, &mut events);
+    }
+
+    close(b.x, 275.0, "bullet.x");
+    close(b.y, 213.56197728775817, "bullet.y");
+    close(b.vx, 5.0, "bullet.vx");
+    close(b.vy, 1.4890694865563827, "bullet.vy");
+    close(b.pattern_timer, 0.49999999999999994, "bullet.pattern_timer");
+    close(b.life, 1.0, "bullet.life");
+    assert!(b.active, "bullet should still be active");
+
+    assert!(
+        events.is_empty(),
+        "unexpected despawn events for alive bullet: {:?}",
+        events,
+    );
+}
+
+// ── Fixture 7: shield_burst (high-freq wobble on perp axis) ──────────────
+//
+// JS reference values captured 2026-05-10 via:
+//
+//   node --input-type=module -e "
+//     import { updateEnemyBullet } from './js/sim/bullet.js';
+//     import { freshBulletState } from './js/sim/state.js';
+//     const b = freshBulletState(7, 'enemy', { movementPattern: 'shield_burst',
+//         x: 300, y: 300, vx: 4, vy: 3, baseVx: 4, baseVy: 3,
+//         startX: 300, startY: 300,
+//         life: 0, maxLife: 180, damage: 10, radius: 4, baseRadius: 4,
+//         maxRange: 9999, rangeMultiplier: 1.0, active: true });
+//     const ctx = { tickScale: 0.5, logicTickSeconds: 1/60, bulletSpeed: 10,
+//         boundaryWidth: 9999, boundaryHeight: 9999, now: 0,
+//         targetPlayer: null, homingTarget: null, rngFloat: () => 0.5 };
+//     for (let i = 0; i < 25; i++) updateEnemyBullet(b, ctx, []);
+//     console.log(JSON.stringify({ x: b.x, y: b.y, vx: b.vx, vy: b.vy,
+//         patternTimer: b.patternTimer, life: b.life, active: b.active }));
+//   "
+//   → {"x":349.10385116660433,"y":338.694865111194,
+//      "vx":4.00700489721131,"vy":2.990660137051587,
+//      "patternTimer":0.41666666666666663,"life":1,"active":true}
+#[test]
+fn enemy_bullet_shield_burst() {
+    let mut b = default_enemy_bullet(7, BulletPattern::ShieldBurst);
+    b.x = 300.0;
+    b.y = 300.0;
+    b.vx = 4.0;
+    b.vy = 3.0;
+    b.start_x = 300.0;
+    b.start_y = 300.0;
+    b.base_vx = 4.0;
+    b.base_vy = 3.0;
+    b.life = 0.0;
+
+    let ctx = default_ctx();
+    let mut events: Vec<BulletEvent> = Vec::new();
+    for _ in 0..25 {
+        update_enemy_bullet(&mut b, &ctx, &mut events);
+    }
+
+    close(b.x, 349.10385116660433, "bullet.x");
+    close(b.y, 338.694865111194, "bullet.y");
+    close(b.vx, 4.00700489721131, "bullet.vx");
+    close(b.vy, 2.990660137051587, "bullet.vy");
+    close(b.pattern_timer, 0.41666666666666663, "bullet.pattern_timer");
+    close(b.life, 1.0, "bullet.life");
+    assert!(b.active, "bullet should still be active");
+
+    assert!(
+        events.is_empty(),
+        "unexpected despawn events for alive bullet: {:?}",
+        events,
+    );
 }

--- a/tests/unit/sim/collision.test.js
+++ b/tests/unit/sim/collision.test.js
@@ -21,10 +21,19 @@ import {
     detectBulletAsteroidHits,
     BULLET_ASTEROID_KNOCKBACK,
     BULLET_ASTEROID_HIT_FLASH_FRAMES,
+    detectPlayerAsteroidHits,
+    PLAYER_ASTEROID_COLLISION_DAMAGE,
+    BOUNCE_RESTITUTION,
+    BOUNCE_FORCE_MULTIPLIER,
+    OVERLAP_SEPARATION_RATIO,
+    ASTEROID_KNOCKBACK_MULTIPLIER,
+    SEPARATION_BUFFER,
+    OVERLAP_PUSH_FORCE,
 } from '../../../js/sim/collision.js';
 import {
     freshAsteroidState,
     freshBulletState,
+    freshShipState,
 } from '../../../js/sim/state.js';
 
 // ---------------------------------------------------------------------
@@ -303,5 +312,298 @@ describe('detectBulletAsteroidHits — skipped pairs', () => {
         const events = [];
         detectBulletAsteroidHits([b], [a], ctx, events);
         expect(events).toHaveLength(0);
+    });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// Player-vs-asteroid pair (Phase 2.5 — dispatch 2).
+// ═════════════════════════════════════════════════════════════════════
+//
+// `detectPlayerAsteroidHits` is the second pure-step pair extracted
+// from the legacy `handlePlayerAsteroidCollision` in
+// `js/modules/combat/collision-system.js` (lines 1946-2120). The legacy
+// path bundles damage + visuals + audio + camera kicks; the pure step
+// reports only the mechanical deltas — velocity impulses and a position
+// separation — that the wrapper applies to live state. Visuals / SFX /
+// XP stay on the wrapper side.
+//
+// The tests below pin:
+//   - the seven constants (verbatim values from COLLISION_CONFIG)
+//   - geometry overlap (circle-circle)
+//   - all event payload fields (impulse + separation deltas)
+//   - skip gates (inactive / warping / death-flash)
+//   - multiple hits per tick (player jammed between two rocks)
+//   - bounce direction (eastbound player off a westward rock ⇒ westbound impulse)
+//   - defensive empty / null inputs
+
+// ---------------------------------------------------------------------
+// Helpers — build minimal player/asteroid pairs.
+// ---------------------------------------------------------------------
+
+/** Build a player at (x, y). Defaults to a small radius=15 ship to
+ *  match the live `Player` constructor. */
+function makePlayer(playerId, x, y, overrides = {}) {
+    return freshShipState(playerId, {
+        x, y, radius: 15, ...overrides,
+    });
+}
+
+/** Build a heavier asteroid at (x, y) with explicit velocity so the
+ *  bounce math has nonzero relative velocity to chew on. */
+function makeAsteroid(id, x, y, overrides = {}) {
+    return freshAsteroidState(id, {
+        x, y, radius: 30, ...overrides,
+    });
+}
+
+// ---------------------------------------------------------------------
+// Constants — pinned to the legacy COLLISION_CONFIG block.
+// ---------------------------------------------------------------------
+
+describe('player-asteroid collision constants', () => {
+    test('PLAYER_ASTEROID_COLLISION_DAMAGE is 2 (verbatim)', () => {
+        expect(PLAYER_ASTEROID_COLLISION_DAMAGE).toBe(2);
+    });
+    test('BOUNCE_RESTITUTION is 0.9 (verbatim)', () => {
+        expect(BOUNCE_RESTITUTION).toBe(0.9);
+    });
+    test('BOUNCE_FORCE_MULTIPLIER is 12.0 (verbatim)', () => {
+        expect(BOUNCE_FORCE_MULTIPLIER).toBe(12.0);
+    });
+    test('OVERLAP_SEPARATION_RATIO is 0.6 (verbatim)', () => {
+        expect(OVERLAP_SEPARATION_RATIO).toBe(0.6);
+    });
+    test('ASTEROID_KNOCKBACK_MULTIPLIER is 22.0 (verbatim)', () => {
+        expect(ASTEROID_KNOCKBACK_MULTIPLIER).toBe(22.0);
+    });
+    test('SEPARATION_BUFFER is 6 (verbatim)', () => {
+        expect(SEPARATION_BUFFER).toBe(6);
+    });
+    test('OVERLAP_PUSH_FORCE is 5.0 (verbatim)', () => {
+        expect(OVERLAP_PUSH_FORCE).toBe(5.0);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — single overlapping pair emits one fully-populated event.
+// ---------------------------------------------------------------------
+
+describe('detectPlayerAsteroidHits — single hit', () => {
+    test('overlapping player + asteroid emits one event with all delta fields', () => {
+        // Player radius 15, asteroid radius 30 ⇒ sumR = 45.
+        // Place them 30 px apart on the x-axis ⇒ overlap = 15 (clear hit).
+        const p = makePlayer('p1', 100, 100, { vx: 5, vy: 0 });
+        const a = makeAsteroid(10, 130, 100, { vx: 0, vy: 0 });
+        const events = [];
+        detectPlayerAsteroidHits([p], [a], ctx, events);
+
+        expect(events).toHaveLength(1);
+        const ev = events[0];
+        expect(ev.type).toBe('player_hit_asteroid');
+        expect(ev.playerId).toBe('p1');
+        expect(ev.asteroidId).toBe(10);
+        expect(ev.damageToAsteroid).toBe(PLAYER_ASTEROID_COLLISION_DAMAGE);
+        // All six numeric delta fields must be defined and finite numbers.
+        expect(typeof ev.playerImpulseDx).toBe('number');
+        expect(typeof ev.playerImpulseDy).toBe('number');
+        expect(typeof ev.asteroidImpulseDx).toBe('number');
+        expect(typeof ev.asteroidImpulseDy).toBe('number');
+        expect(typeof ev.separationDx).toBe('number');
+        expect(typeof ev.separationDy).toBe('number');
+        expect(Number.isFinite(ev.playerImpulseDx)).toBe(true);
+        expect(Number.isFinite(ev.playerImpulseDy)).toBe(true);
+        expect(Number.isFinite(ev.asteroidImpulseDx)).toBe(true);
+        expect(Number.isFinite(ev.asteroidImpulseDy)).toBe(true);
+        expect(Number.isFinite(ev.separationDx)).toBe(true);
+        expect(Number.isFinite(ev.separationDy)).toBe(true);
+        // Geometry overlapped ⇒ separation must be nonzero on the
+        // collision axis (x here).
+        expect(ev.separationDx).not.toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — geometry miss (centers further than sumR apart).
+// ---------------------------------------------------------------------
+
+describe('detectPlayerAsteroidHits — geometry miss', () => {
+    test('player outside (player.r + asteroid.r) emits no event', () => {
+        const p = makePlayer('p1', 0, 0);
+        const a = makeAsteroid(10, 200, 0); // 200 px ≫ sumR=45
+        const events = [];
+        detectPlayerAsteroidHits([p], [a], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+
+    test('player just outside boundary (sumR + 1) emits no event', () => {
+        const p = makePlayer('p1', 0, 0, { radius: 15 });
+        // sumR = 45; place asteroid center 46 px away ⇒ just outside.
+        const a = makeAsteroid(10, 46, 0, { radius: 30 });
+        const events = [];
+        detectPlayerAsteroidHits([p], [a], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — one player overlapping multiple rocks ⇒ multiple events.
+// ---------------------------------------------------------------------
+
+describe('detectPlayerAsteroidHits — multiple asteroids in one tick', () => {
+    test('player wedged between two asteroids emits two events', () => {
+        // Player at (100, 100), radius 15. Place rocks east + west, both
+        // close enough to overlap.
+        const p = makePlayer('p1', 100, 100, { vx: 0, vy: 0 });
+        const east = makeAsteroid(10, 130, 100); // dx=30, sumR=45 ⇒ overlap
+        const west = makeAsteroid(20,  70, 100); // dx=-30, sumR=45 ⇒ overlap
+        const events = [];
+        detectPlayerAsteroidHits([p], [east, west], ctx, events);
+        expect(events).toHaveLength(2);
+        const ids = events.map(e => e.asteroidId).sort((a, b) => a - b);
+        expect(ids).toEqual([10, 20]);
+        // Each event carries the player's id.
+        for (const ev of events) {
+            expect(ev.playerId).toBe('p1');
+            expect(ev.type).toBe('player_hit_asteroid');
+        }
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — skip gates (inactive / warping / death-flash).
+// ---------------------------------------------------------------------
+
+describe('detectPlayerAsteroidHits — skipped pairs', () => {
+    test('inactive player → no event', () => {
+        const p = makePlayer('p1', 100, 100, { active: false });
+        const a = makeAsteroid(10, 130, 100);
+        const events = [];
+        detectPlayerAsteroidHits([p], [a], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+
+    test('inactive asteroid → no event', () => {
+        const p = makePlayer('p1', 100, 100);
+        const a = makeAsteroid(10, 130, 100, { active: false });
+        const events = [];
+        detectPlayerAsteroidHits([p], [a], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+
+    test('warping asteroid → no event', () => {
+        const p = makePlayer('p1', 100, 100);
+        const a = makeAsteroid(10, 130, 100, { warping: true });
+        const events = [];
+        detectPlayerAsteroidHits([p], [a], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+
+    test('asteroid mid death-flash (new field name) → no event', () => {
+        const p = makePlayer('p1', 100, 100);
+        const a = makeAsteroid(10, 130, 100, { deathFlash: 5 });
+        const events = [];
+        detectPlayerAsteroidHits([p], [a], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+
+    test('asteroid mid death-flash (legacy _deathFlash) → no event', () => {
+        const p = makePlayer('p1', 100, 100);
+        // Live Asteroid instances use the underscore-prefix name; the
+        // pure step honors both.
+        const a = { id: 10, x: 130, y: 100, radius: 30, active: true,
+                    warping: false, _deathFlash: 5 };
+        const events = [];
+        detectPlayerAsteroidHits([p], [a], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — bounce direction. Player moving east into an asteroid east of
+// it should get deflected back west (negative dx on player impulse).
+// ---------------------------------------------------------------------
+
+describe('detectPlayerAsteroidHits — bounce direction', () => {
+    test('eastbound player ramming a westward rock gets impulse pushing west', () => {
+        // Geometry:
+        //   - Player at (100, 100), radius 15, moving east (vx=10).
+        //   - Asteroid 30 px east at (130, 100), radius 30, moving
+        //     west (vx=-2). distance=30, sumR=45 ⇒ overlap=15.
+        //
+        // Expected delta directions:
+        //   - The separation normal points from asteroid → player,
+        //     which is westward → separationDx < 0.
+        //   - The OVERLAP_PUSH_FORCE term adds nx · 5 = -5 to
+        //     playerImpulseDx (westward).
+        //   - The knockback term is mass-dominated by the much heavier
+        //     asteroid (≈113k vs ≈353), making its contribution to
+        //     playerImpulseDx orders of magnitude smaller than the
+        //     OVERLAP_PUSH_FORCE term, so playerImpulseDx stays
+        //     strictly negative.
+        //
+        // Jitter is disabled by passing rngFloat() = 0.5 (centered).
+        const p = makePlayer('p1', 100, 100, { vx: 10, vy: 0 });
+        const a = makeAsteroid(10, 130, 100, { vx: -2, vy: 0 });
+        const events = [];
+        detectPlayerAsteroidHits([p], [a], { rngFloat: () => 0.5 }, events);
+        expect(events).toHaveLength(1);
+        // Separation points westward (away from the east-of-player rock).
+        expect(events[0].separationDx).toBeLessThan(0);
+        expect(events[0].separationDy).toBe(0);
+        // Net player impulse is dominated by the westward overlap push.
+        expect(events[0].playerImpulseDx).toBeLessThan(0);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — empty / null inputs defensive guards.
+// ---------------------------------------------------------------------
+
+describe('detectPlayerAsteroidHits — empty inputs', () => {
+    test('empty players → no events', () => {
+        const events = [];
+        detectPlayerAsteroidHits([], [makeAsteroid(10, 0, 0)], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('empty asteroids → no events', () => {
+        const events = [];
+        detectPlayerAsteroidHits([makePlayer('p1', 0, 0)], [], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('both empty → no events', () => {
+        const events = [];
+        detectPlayerAsteroidHits([], [], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('null players → no events (defensive)', () => {
+        const events = [];
+        detectPlayerAsteroidHits(null, [makeAsteroid(10, 0, 0)], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('null asteroids → no events (defensive)', () => {
+        const events = [];
+        detectPlayerAsteroidHits([makePlayer('p1', 0, 0)], null, ctx, events);
+        expect(events).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — separation push fields are populated proportional to overlap.
+// ---------------------------------------------------------------------
+
+describe('detectPlayerAsteroidHits — separation magnitude', () => {
+    test('separation distance = overlap + SEPARATION_BUFFER along (asteroid → player) normal', () => {
+        // Player at (100, 100), radius 15; asteroid at (130, 100),
+        // radius 30. distance = 30, sumR = 45 ⇒ overlap = 15.
+        // Normal points west (-1, 0). separation should be
+        // (-1, 0) · (15 + 6) = (-21, 0).
+        const p = makePlayer('p1', 100, 100);
+        const a = makeAsteroid(10, 130, 100);
+        const events = [];
+        detectPlayerAsteroidHits([p], [a], ctx, events);
+        expect(events).toHaveLength(1);
+        const ev = events[0];
+        expect(ev.separationDx).toBeCloseTo(-(15 + SEPARATION_BUFFER), 5);
+        expect(ev.separationDy).toBeCloseTo(0, 5);
     });
 });


### PR DESCRIPTION
## Summary
Brings enemy-bullet pattern coverage from **3/17** (PR #29) to **7/17**. All 4 new patterns are no-target-player, no-RNG, no-persistent-lifetime — pure trig + timer motion.

## New `BulletPattern` variants
| Variant | JS source | Notes |
|---|---|---|
| `Spread` | bullet.js:300-301 | `sin(timer*3 + phase) * 0.5` on perp-of-base |
| `Spiral` | bullet.js:319-322 | Rotating velocity + centrifugal `timer * 0.5 * 0.1` |
| `WaveEnergy` | bullet.js:493-498 | Large-amplitude sine, amp 15 × vel-scale 0.1 |
| `ShieldBurst` | bullet.js:485 | High-freq wobble, `sin(timer*8) * 0.2` |

## New constants (JS line anchors)
- `SPREAD_WAVE_FREQ = 3.0`, `SPREAD_WAVE_AMP = 0.5` (bullet.js:300-301)
- `SPIRAL_RATE = 2.0`, `SPIRAL_RADIUS_RATE = 0.5`, `SPIRAL_PERP_FACTOR = 0.1` (bullet.js:319-322)
- `WAVE_ENERGY_FREQ = 3.0`, `WAVE_ENERGY_AMP = 15.0`, `WAVE_ENERGY_VEL_SCALE = 0.1` (bullet.js:493-498)
- `SHIELD_BURST_FREQ = 8.0`, `SHIELD_BURST_AMP = 0.2` (bullet.js:485)

## No struct changes
All 4 patterns use existing fields (pattern_timer, pattern_phase, base_vx, base_vy, vx, vy). Dropped `#[allow(dead_code)]` from `pattern_phase` since Spread now reads it.

## Parity fixtures
| Test | Ticks | Tolerance |
|---|---|---|
| `enemy_bullet_spread` | 25 | 0.01 px |
| `enemy_bullet_spiral` | 20 | 0.05 px on x/y (f32↔f64 trig drift across rotated vel), 0.01 on vx/vy |
| `enemy_bullet_wave_energy` | 30 | 0.01 px |
| `enemy_bullet_shield_burst` | 25 | 0.01 px (diagonal base exercises non-axis-aligned perp) |

## Test plan
- [x] `cargo test --test parity_enemy_bullet` — 7 passed (3 existing + 4 new)
- [x] All 56 workspace tests green
- [x] `cargo build --tests` clean, zero warnings

## Phase 2.1 progress (task #45)
- ✓ drops magnet+tractor+expiry (PR #25)
- ✓ asteroid bounce+death-flash (PR #26)
- ✓ bullet helix+homing (PR #27)
- ✓ wave context plumbing (PR #28)
- ✓ enemy bullet 3 patterns (PR #29)
- ✓ enemy bullet +4 patterns (this PR — 7/17 total)
- ⬜ enemy hunter_arc (blocked on JS-side ctx threading; see sibling PR for ctx plumbing)
- ⬜ enemy bullet 10 more patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)