### PR TITLE
mp/sim-rs: Rust mirror of player-asteroid collision (Phase 2.5)

### DIFF
--- a/server/src/sim/collision.rs
+++ b/server/src/sim/collision.rs
@@ -1,7 +1,713 @@
-//! Broadphase + narrowphase. Stub.
+//! Pair-detection collision step. Rust mirror of `js/sim/collision.js`.
+//!
+//! This module is the Rust-side companion to the new pure-collision system
+//! introduced for the multiplayer server and the client-side prediction
+//! engine. It does NOT replace the legacy `js/modules/combat/collision-system.js`
+//! solo-gameplay path — that stays the single source of truth for solo
+//! gameplay until the prediction wiring (Phase 3) flips over.
+//!
+//! ─── Scope (Phase 2.5, dispatch 1 + dispatch 2) ──────────────────────
+//!
+//! Ported here:
+//!   - Bullet-vs-asteroid pair detection (`detect_bullet_asteroid_hits`).
+//!   - Player-vs-asteroid pair detection (`detect_player_asteroid_hits`).
+//!
+//! Deferred to follow-up sessions (Phase 2.5, dispatch 3..N):
+//!   - Player-vs-enemy       (ramming damage, bounce, knockback)
+//!   - Enemy-vs-asteroid     (push forces both ways)
+//!   - Bullet-vs-enemy       (mirror of bullet-vs-asteroid, plus boss-rage)
+//!   - Drops pickup          (player-vs-drop)
+//!   - Power-weapon collisions  (mines, missiles, lightning arcs, charged
+//!                               shots, energy slashes)
+//!   - Defense-skill collisions (deflector orbs, EMP pulse, tractor shield)
+//!
+//! Not in scope at all:
+//!   - Damage NUMBER spawning / hit-flash visuals (presentation)
+//!   - Audio / particle FX / screen shake / hitstop (presentation)
+//!   - Spatial-grid construction (wrapper concern; pure step takes
+//!     whatever pre-filtered candidates the wrapper hands it)
+//!   - XP / score / kill-streak side effects (game-state concerns; the
+//!     wrapper drains events and applies them)
+//!
+//! The pure step **emits events**; the wrapper drains them to apply
+//! damage, despawn bullets, spawn debris/orbs, and run the legacy FX
+//! helpers. Mirrors `js/sim/wave.js` (Phase 1, agent F) and
+//! `js/sim/asteroid.js` (Phase 1, agent C).
+//!
+//! ─── Design note: minimal input types ──────────────────────────────
+//!
+//! The detector takes `CollisionBullet` / `CollisionAsteroid` /
+//! `CollisionPlayer` rather than the full `PlayerBullet` / `Asteroid` /
+//! `ShipState` structs defined elsewhere. Reasons:
+//!
+//!   - Decouples the pure step from storage layout. When entities migrate
+//!     to SoA pools (plan §"Contiguous storage"), the collision module
+//!     won't have to change — the wrapper just maps the pool view into
+//!     these small structs.
+//!   - The collision check only needs the geometry-and-physics subset of
+//!     each entity, not the full lifecycle / FX / range / fade state.
+//!   - Enemy bullets and player bullets share `CollisionBullet`, even
+//!     though they're different Rust types in `bullet.rs`.
+//!
+//! Parity fixture: `server/tests/parity_collision.rs`.
+
+use std::collections::HashSet;
 
 use crate::protocol::GameEvent;
 
 use super::state::GameState;
 
+// ─── Constants — Bullet-vs-asteroid pair ────────────────────────────
+//
+// Extracted from `COLLISION_CONFIG` in
+// `js/modules/combat/collision-system.js`. Mirrors the corresponding
+// `export const` block in `js/sim/collision.js` so both Rust and JS
+// keep the values in lockstep.
+
+/// Bullet → asteroid knockback impulse multiplier. Mirrors
+/// `BULLET_ASTEROID_KNOCKBACK = 0.05` in `js/sim/collision.js`.
+///
+/// Applied by the wrapper to the asteroid's velocity using the bullet
+/// velocity reported in the event:
+///   `asteroid.vx += event.bullet_vx * BULLET_ASTEROID_KNOCKBACK`
+/// The pure step never mutates the asteroid — it just hands over the
+/// pre-knockback bullet velocity in the event payload.
+pub const BULLET_ASTEROID_KNOCKBACK: f32 = 0.05;
+
+/// Frames the asteroid's hit-flash effect runs after a bullet impact.
+/// Mirrors `BULLET_ASTEROID_HIT_FLASH_FRAMES = 10` in `js/sim/collision.js`.
+///
+/// Presentation concern in the strict sense, but exposed here so the
+/// wrapper can set the asteroid's hit-flash from a single source of
+/// truth without re-deriving the count.
+pub const BULLET_ASTEROID_HIT_FLASH_FRAMES: u32 = 10;
+
+// ─── Constants — Player-vs-asteroid pair ────────────────────────────
+//
+// Extracted verbatim from `COLLISION_CONFIG` in
+// `js/modules/combat/collision-system.js`. Each constant is pinned here
+// so the pure step stays self-contained — no legacy-module imports
+// leaking into the server / prediction path. Numerical parity with the
+// legacy module is enforced by the parity tests.
+
+/// Damage dealt to asteroid when player collides with it. Mirrors
+/// `PLAYER_ASTEROID_COLLISION_DAMAGE = 2` in `js/sim/collision.js`.
+///
+/// Tiny by design: ramming asteroids is intentionally a *bad* strategy.
+/// The player gets deflected hard (see `ASTEROID_KNOCKBACK_MULTIPLIER`)
+/// and barely chips the rock.
+pub const PLAYER_ASTEROID_COLLISION_DAMAGE: f32 = 2.0;
+
+/// Bounce energy retention coefficient (0..1). Mirrors
+/// `BOUNCE_RESTITUTION = 0.9` in `js/sim/collision.js`. Used by the
+/// generic bounce path; not consumed directly by the player-asteroid
+/// pair (which uses the heavier `ASTEROID_KNOCKBACK_MULTIPLIER`).
+/// Exposed for parity + future enemy/asteroid-asteroid pair use.
+pub const BOUNCE_RESTITUTION: f32 = 0.9;
+
+/// Multiplier for bounce impulse force used by the generic bounce-pair
+/// path. Mirrors `BOUNCE_FORCE_MULTIPLIER = 12.0` in `js/sim/collision.js`.
+/// Not consumed directly by the player-asteroid pair; exposed for
+/// symmetry with the legacy config and upcoming pairs.
+pub const BOUNCE_FORCE_MULTIPLIER: f32 = 12.0;
+
+/// Fraction of computed overlap used by the generic bounce-pair
+/// separation push. Mirrors `OVERLAP_SEPARATION_RATIO = 0.6` in
+/// `js/sim/collision.js`. The player-asteroid pair uses the FULL
+/// overlap + `SEPARATION_BUFFER` rather than this ratio — exposed here
+/// for parity with the legacy config block.
+pub const OVERLAP_SEPARATION_RATIO: f32 = 0.6;
+
+/// Knockback multiplier for player-asteroid collisions. Mirrors
+/// `ASTEROID_KNOCKBACK_MULTIPLIER = 22.0` in `js/sim/collision.js`.
+///
+/// Applied to the normal-projected relative velocity (`dvn / totalMass`)
+/// to derive the impulse magnitude that flings the player off the rock.
+///
+///   player.vel += knockbackAngle * (dvn / (player.mass + asteroid.mass)) * 22.0
+pub const ASTEROID_KNOCKBACK_MULTIPLIER: f32 = 22.0;
+
+/// Extra pixels added to the separation distance after computing the
+/// overlap. Mirrors `SEPARATION_BUFFER = 6` in `js/sim/collision.js`.
+///
+/// Ensures the player is moved *past* the surface boundary so the very
+/// next tick doesn't re-overlap and re-trigger the collision event.
+pub const SEPARATION_BUFFER: f32 = 6.0;
+
+/// Additional velocity push applied to the player along the
+/// (asteroid → player) normal when an overlap was resolved. Mirrors
+/// `OVERLAP_PUSH_FORCE = 5.0` in `js/sim/collision.js`. Stacks on top
+/// of the knockback impulse — the knockback handles the "bounce off"
+/// reaction, while this provides a steady outward push to prevent
+/// slow-creep re-overlaps.
+pub const OVERLAP_PUSH_FORCE: f32 = 5.0;
+
+// ─── Collision-input types ──────────────────────────────────────────
+
+/// Minimal bullet view for collision detection.
+///
+/// Mirrors the relevant JS fields read by `detectBulletAsteroidHits`:
+///   `{ id, x, y, vx, vy, radius, damage, piercing, active,
+///      piercedEnemies, piercedAsteroidIds }`.
+///
+/// Mutation surface:
+///   - `pierced_enemies` is bumped per-hit (mirrors JS counter).
+///   - `pierced_asteroid_ids` is a per-bullet Set the detector adds to
+///     when an asteroid is pierced, so the same bullet won't re-hit
+///     that asteroid on a later tick. JS lazily allocates this Set
+///     on first hit; the Rust mirror starts with an empty `HashSet`
+///     because allocating an empty set per bullet costs nothing.
+///
+/// `piercing` semantics (mirroring `js/sim/collision.js`):
+///   - `0` → non-piercing; bullet despawns on first hit.
+///   - `N > 0` → piercing budget; bullet may hit `N + 1` total targets
+///     before despawning (matches legacy `bullet.onHit`: piercing=1
+///     can hit 2 targets).
+///   - `-1` is NOT a sentinel; the JS source treats `piercing | 0`
+///     as a plain integer. Use `0` for non-piercing.
+#[derive(Debug, Clone)]
+pub struct CollisionBullet {
+    pub id: u32,
+    pub x: f32,
+    pub y: f32,
+    pub vx: f32,
+    pub vy: f32,
+    pub radius: f32,
+    pub damage: f32,
+    /// Piercing budget — see struct docstring for semantics.
+    pub piercing: i32,
+    /// Live counter — number of pierces this bullet has performed so far.
+    /// JS: `bullet.piercedEnemies | 0`.
+    pub pierced_enemies: i32,
+    pub active: bool,
+    /// Per-bullet memory of which asteroid ids have already been pierced.
+    /// JS: `bullet.piercedAsteroidIds: Set<AsteroidId|number>`.
+    pub pierced_asteroid_ids: HashSet<u32>,
+}
+
+impl CollisionBullet {
+    /// Construct a fresh non-piercing player bullet at the origin.
+    /// Used as a building block in tests; production code populates
+    /// fields directly from the live bullet pool.
+    pub fn fresh(id: u32) -> Self {
+        Self {
+            id,
+            x: 0.0,
+            y: 0.0,
+            vx: 0.0,
+            vy: 0.0,
+            radius: 4.0,
+            damage: 1.0,
+            piercing: 0,
+            pierced_enemies: 0,
+            active: true,
+            pierced_asteroid_ids: HashSet::new(),
+        }
+    }
+}
+
+/// Minimal asteroid view for collision detection.
+///
+/// Mirrors the JS fields read by `detectBulletAsteroidHits` and
+/// `detectPlayerAsteroidHits`:
+///   `{ id, x, y, vx, vy, radius, active, warping, deathFlash }`.
+///
+/// `vx` / `vy` are read only by the player-vs-asteroid path (to compute
+/// the relative-velocity normal-projection `dvn` for the bounce
+/// impulse). The bullet-vs-asteroid path ignores them — asteroids are
+/// treated as static from the bullet's perspective.
+///
+/// The JS guards `!asteroid.active`, `asteroid.warping`, and
+/// `asteroid.deathFlash > 0` collapse into the boolean / counter fields
+/// below — the wrapper translates from the full sim-level `Asteroid`
+/// (`asteroid.rs`) to this view by reading those fields directly.
+#[derive(Debug, Clone, Copy)]
+pub struct CollisionAsteroid {
+    pub id: u32,
+    pub x: f32,
+    pub y: f32,
+    /// Asteroid velocity. Used by the player-vs-asteroid pair to compute
+    /// the relative-velocity normal-projection (`dvn`). Bullet-vs-asteroid
+    /// ignores this field.
+    pub vx: f32,
+    pub vy: f32,
+    pub radius: f32,
+    /// Optional explicit mass. When `None`, the player-vs-asteroid pair
+    /// falls back to the JS formula `(4/3) · π · r³` (matching the live
+    /// `Asteroid` class). Bullet-vs-asteroid ignores this field.
+    pub mass: Option<f32>,
+    pub active: bool,
+    pub warping: bool,
+    /// Frames remaining of mid-death flash. Treated as "skip if > 0".
+    /// JS accepts either `deathFlash` or `_deathFlash`; the Rust mirror
+    /// collapses both into this single counter (the wrapper picks the
+    /// right field on the JS side).
+    pub death_flash: u32,
+}
+
+impl CollisionAsteroid {
+    /// Construct a fresh asteroid at the origin with default radius.
+    /// Test convenience.
+    pub fn fresh(id: u32) -> Self {
+        Self {
+            id,
+            x: 0.0,
+            y: 0.0,
+            vx: 0.0,
+            vy: 0.0,
+            radius: 30.0,
+            mass: None,
+            active: true,
+            warping: false,
+            death_flash: 0,
+        }
+    }
+}
+
+/// Minimal player view for collision detection.
+///
+/// Mirrors the relevant JS fields read by `detectPlayerAsteroidHits`:
+///   `{ id, x, y, vx, vy, radius, mass?, active }`.
+///
+/// The pure step does NOT read player state outside this struct — no
+/// `warping`, no `isDying`, no `_deathFlash` on players (those are
+/// enemy / asteroid concerns). The wrapper filters the active roster
+/// before handing it to the detector.
+///
+/// Mass is optional: when `None`, the JS formula `π · r² · 0.5`
+/// (matching the live `Player` class) is used as a fallback. The
+/// wrapper can override by setting `mass` explicitly to match
+/// powerup-modified ship mass on the live side.
+#[derive(Debug, Clone, Copy)]
+pub struct CollisionPlayer {
+    pub id: u32,
+    pub x: f32,
+    pub y: f32,
+    pub vx: f32,
+    pub vy: f32,
+    pub radius: f32,
+    /// Optional explicit mass. `None` ⇒ fallback to `π · r² · 0.5`.
+    pub mass: Option<f32>,
+    pub active: bool,
+}
+
+impl CollisionPlayer {
+    /// Construct a fresh player at the origin with a live-game ship
+    /// radius of 15 px. Test convenience.
+    pub fn fresh(id: u32) -> Self {
+        Self {
+            id,
+            x: 0.0,
+            y: 0.0,
+            vx: 0.0,
+            vy: 0.0,
+            radius: 15.0,
+            mass: None,
+            active: true,
+        }
+    }
+}
+
+/// Per-tick context for the collision-detection step. Currently empty —
+/// reserved for future extensions (e.g. spatial-grid filter,
+/// one-punch-man cheat flag, deterministic RNG handle). Matches the
+/// empty-object `ctx` in `js/sim/collision.js`.
+///
+/// Determinism note: the JS path uses `ctx.rngFloat()` for the
+/// player-asteroid bounce jitter; the Rust mirror is deterministic-by-
+/// default and treats `rngFloat()` as the centered value 0.5 (yielding
+/// zero jitter), matching the parity tests on the JS side which pass
+/// `{ rngFloat: () => 0.5 }`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CollisionContext;
+
+/// Events emitted by the collision pair-detection step.
+///
+/// One variant per pair (currently `BulletHitAsteroid` and
+/// `PlayerHitAsteroid`; further pairs land as additional variants when
+/// their dispatches port). Field names mirror the JS event keys with
+/// snake_case translation.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CollisionEvent {
+    /// Mirrors `{ type: 'bullet_hit_asteroid', ... }` in `js/sim/collision.js`.
+    BulletHitAsteroid {
+        bullet_id: u32,
+        asteroid_id: u32,
+        damage: f32,
+        bullet_x: f32,
+        bullet_y: f32,
+        bullet_vx: f32,
+        bullet_vy: f32,
+        /// How many more piercing hits the bullet has after this one.
+        /// `-1` ↔ non-piercing (bullet despawns now).
+        bullet_piercing_remaining: i32,
+        /// `true` ↔ wrapper should remove the bullet from the pool.
+        bullet_will_despawn: bool,
+    },
+    /// Mirrors `{ type: 'player_hit_asteroid', ... }` in `js/sim/collision.js`.
+    ///
+    /// Velocity deltas the wrapper applies:
+    ///   - `player.vel.x += player_impulse_dx; player.vel.y += player_impulse_dy`
+    ///   - `asteroid.vel.x += asteroid_impulse_dx; asteroid.vel.y += asteroid_impulse_dy`
+    /// Position deltas the wrapper applies:
+    ///   - `player.x += separation_dx; player.y += separation_dy`
+    ///
+    /// All deltas come from the pure step — no mutation happens here.
+    PlayerHitAsteroid {
+        player_id: u32,
+        asteroid_id: u32,
+        damage_to_asteroid: f32,
+        player_impulse_dx: f32,
+        player_impulse_dy: f32,
+        asteroid_impulse_dx: f32,
+        asteroid_impulse_dy: f32,
+        separation_dx: f32,
+        separation_dy: f32,
+    },
+}
+
+// ─── Bullet-vs-asteroid pair detection ──────────────────────────────
+
+/// Detect bullet-vs-asteroid collisions for one tick.
+///
+/// Pure step: reads bullet + asteroid positions/radii, decides which
+/// pairs collided, and pushes one `BulletHitAsteroid` event per detected
+/// hit. The function does NOT mutate asteroid state — no damage, no
+/// death-flash — the wrapper drains events into the legacy damage /
+/// despawn / FX helpers.
+///
+/// Mutation surface on `bullets`:
+///   - `pierced_asteroid_ids` — Set is mutated; asteroid id is inserted
+///     on each hit. Carried across ticks so a piercing bullet doesn't
+///     re-hit a target it's already passed through. JS line refs:
+///     `js/sim/collision.js:238–241`.
+///   - `pierced_enemies` — running counter; bumped on each hit so the
+///     "budget exhausted?" check on the next tick sees the latest value.
+///     JS line refs: `js/sim/collision.js:251–252`.
+///
+/// Iteration order: for each bullet, scan asteroids in slice order. The
+/// first hit a non-piercing bullet detects becomes its only event for
+/// the tick. A bullet with `piercing > 0` may emit up to `piercing + 1`
+/// hit events per tick.
+///
+/// Geometry: circle-circle overlap using squared distance to skip the
+/// sqrt. `(dx² + dy²) < (br + ar)²`. JS line refs: `js/sim/collision.js:225–231`.
+///
+/// Skipped pairs (no event emitted):
+///   - Inactive bullet            (`!bullet.active`)
+///   - Inactive asteroid          (`!asteroid.active`)
+///   - Warping asteroid           (`asteroid.warping`)
+///   - Asteroid mid-death-flash   (`asteroid.death_flash > 0`)
+///   - Asteroid already pierced   (id in `bullet.pierced_asteroid_ids`)
+///   - Piercing budget exhausted  (`bullet.pierced_enemies > bullet.piercing`)
+pub fn detect_bullet_asteroid_hits(
+    bullets: &mut [CollisionBullet],
+    asteroids: &[CollisionAsteroid],
+    _ctx: &CollisionContext,
+    events: &mut Vec<CollisionEvent>,
+) {
+    if bullets.is_empty() || asteroids.is_empty() {
+        return;
+    }
+
+    for bullet in bullets.iter_mut() {
+        // 1. Active-guard (JS collision.js:185).
+        if !bullet.active {
+            continue;
+        }
+
+        // 2. Piercing-budget exhausted? (JS collision.js:191–201).
+        //    A piercing bullet that's already eaten its `piercing + 1`
+        //    targets has `pierced_enemies > piercing`. A non-piercing
+        //    bullet that's somehow active with prior hits is similarly
+        //    guarded defensively.
+        let piercing = bullet.piercing;
+        if piercing > 0 && bullet.pierced_enemies > piercing {
+            continue;
+        }
+        if piercing == 0 && bullet.pierced_enemies > 0 {
+            continue;
+        }
+
+        let bullet_radius = bullet.radius;
+
+        for asteroid in asteroids.iter() {
+            // 3. Asteroid gating (JS collision.js:207–217).
+            if !asteroid.active {
+                continue;
+            }
+            if asteroid.warping {
+                continue;
+            }
+            if asteroid.death_flash > 0 {
+                continue;
+            }
+
+            // 4. Already-pierced? (JS collision.js:222–223).
+            if bullet.pierced_asteroid_ids.contains(&asteroid.id) {
+                continue;
+            }
+
+            // 5. Circle-circle overlap (JS collision.js:227–231).
+            let dx = bullet.x - asteroid.x;
+            let dy = bullet.y - asteroid.y;
+            let sum_r = bullet_radius + asteroid.radius;
+            if dx * dx + dy * dy >= sum_r * sum_r {
+                continue;
+            }
+
+            // ── Hit detected ──
+
+            // 6. Update piercing tracker (JS collision.js:238–242).
+            bullet.pierced_asteroid_ids.insert(asteroid.id);
+            bullet.pierced_enemies += 1;
+            let pierced_so_far = bullet.pierced_enemies;
+
+            // 7. Despawn / piercing-remaining decision
+            //    (JS collision.js:258–263).
+            let will_despawn = if piercing == 0 {
+                true
+            } else {
+                pierced_so_far > piercing
+            };
+            let piercing_remaining = if piercing == 0 {
+                -1
+            } else {
+                (piercing - pierced_so_far).max(0)
+            };
+
+            // 8. Damage default — JS `bullet.damage || 1`. We treat any
+            //    non-positive `damage` (0 or NaN-less zero) as the
+            //    default-1 fallback (JS truthy check on a number).
+            let damage = if bullet.damage > 0.0 { bullet.damage } else { 1.0 };
+
+            // 9. Emit the event (JS collision.js:265–276).
+            events.push(CollisionEvent::BulletHitAsteroid {
+                bullet_id: bullet.id,
+                asteroid_id: asteroid.id,
+                damage,
+                bullet_x: bullet.x,
+                bullet_y: bullet.y,
+                bullet_vx: bullet.vx,
+                bullet_vy: bullet.vy,
+                bullet_piercing_remaining: piercing_remaining,
+                bullet_will_despawn: will_despawn,
+            });
+
+            // 10. Non-piercing or budget reached → stop scanning more
+            //     asteroids for this bullet (JS collision.js:278–279).
+            if will_despawn {
+                break;
+            }
+        }
+    }
+}
+
+// ─── Player-vs-asteroid pair detection ──────────────────────────────
+
+/// Player mass fallback formula — mirrors the live `Player` class:
+///   `mass = π · r² · 0.5`
+/// Called when `CollisionPlayer::mass` is `None`. JS line ref:
+/// `js/sim/collision.js:394–398`.
+#[inline]
+fn player_mass_fallback(radius: f32) -> f32 {
+    std::f32::consts::PI * radius * radius * 0.5
+}
+
+/// Asteroid mass fallback formula — mirrors the live `Asteroid` class:
+///   `mass = (4/3) · π · r³`
+/// Called when `CollisionAsteroid::mass` is `None`. JS line ref:
+/// `js/sim/collision.js:394–398`.
+#[inline]
+fn asteroid_mass_fallback(radius: f32) -> f32 {
+    (4.0 / 3.0) * std::f32::consts::PI * radius * radius * radius
+}
+
+/// Detect player-vs-asteroid collisions for one tick.
+///
+/// Pure step: reads player + asteroid positions / radii / velocities,
+/// decides which pairs overlap, and emits one `PlayerHitAsteroid` event
+/// per detected hit with the velocity + position *deltas* the wrapper
+/// applies to the live state. This function does NOT mutate player or
+/// asteroid — every effect is reported in the event payload for the
+/// wrapper / JS mirror to apply downstream.
+///
+/// Co-op ready: takes a slice of players. The solo wrapper passes a
+/// one-element slice; future co-op sessions will pass the full ship
+/// roster. Each player is scanned against every active asteroid; one
+/// player can emit multiple events per tick if it overlaps multiple
+/// rocks simultaneously (e.g. trapped between two boulders).
+///
+/// Geometry:
+///   Circle-circle overlap: `(dx² + dy²) < (player.r + ast.r)²`.
+///   JS line refs: `js/sim/collision.js:555–559`.
+///
+/// Bounce / impulse model (mirrors JS lines 562–593):
+///
+///   distance      = sqrt(dx² + dy²)         [dx = player.x - asteroid.x]
+///   angle         = atan2(dy, dx)           [asteroid → player normal]
+///   totalMass     = player.mass + asteroid.mass
+///   cosA, sinA    = cos(angle), sin(angle)
+///   dvn           = (player.vx - asteroid.vx) · cosA
+///                 + (player.vy - asteroid.vy) · sinA
+///   enhanced      = (2 · dvn) / totalMass   [0 if totalMass ≤ 0]
+///   knockback     = enhanced · ASTEROID_KNOCKBACK_MULTIPLIER
+///
+///   playerImpulseDx = cos(angle + jitter) · knockback
+///   playerImpulseDy = sin(angle + jitter) · knockback
+///   asteroidImpulseDx = -knockback · 0.3 · player.mass · cosA
+///   asteroidImpulseDy = -knockback · 0.3 · player.mass · sinA
+///
+/// Determinism / jitter:
+///   The JS path uses `ctx.rngFloat() ∈ [0,1)` to derive a jitter
+///   angle in `[-π/4, π/4]`. The Rust mirror is deterministic-by-
+///   default and uses `rngFloat = 0.5` (i.e. zero jitter), matching
+///   the JS tests which pass `{ rngFloat: () => 0.5 }`. When a real
+///   RNG is wired into `CollisionContext` later, the jitter formula
+///   reactivates without changing this function's signature.
+///
+/// Separation push (mirrors JS lines 596–607):
+///   If `overlap = sumR - distance > 0` and `distance > 0`:
+///     - Position delta: unit normal · (overlap + SEPARATION_BUFFER)
+///     - Velocity push:  unit normal · OVERLAP_PUSH_FORCE
+///     The normal is `(dx/distance, dy/distance)` — pointing from
+///     asteroid → player (away from the rock).
+///
+/// Asteroid damage:
+///   Constant `PLAYER_ASTEROID_COLLISION_DAMAGE = 2`. The wrapper
+///   subtracts this from `asteroid.hp` and handles death-flash + drops.
+///   The pure step just reports the number.
+///
+/// Skipped pairs (no event emitted):
+///   - Inactive player     (`!player.active`)
+///   - Inactive asteroid   (`!asteroid.active`)
+///   - Warping asteroid    (mid warp-in animation)
+///   - Asteroid mid-death  (`asteroid.death_flash > 0`)
+pub fn detect_player_asteroid_hits(
+    players: &[CollisionPlayer],
+    asteroids: &[CollisionAsteroid],
+    _ctx: &CollisionContext,
+    events: &mut Vec<CollisionEvent>,
+) {
+    if players.is_empty() || asteroids.is_empty() {
+        return;
+    }
+
+    for player in players.iter() {
+        // 1. Active-guard (JS collision.js:536).
+        if !player.active {
+            continue;
+        }
+
+        let player_radius = player.radius;
+        let player_mass = player
+            .mass
+            .unwrap_or_else(|| player_mass_fallback(player_radius));
+
+        for asteroid in asteroids.iter() {
+            // 2. Asteroid gating (JS collision.js:544–552).
+            if !asteroid.active {
+                continue;
+            }
+            if asteroid.warping {
+                continue;
+            }
+            if asteroid.death_flash > 0 {
+                continue;
+            }
+
+            // 3. Circle-circle overlap (JS collision.js:555–559).
+            let dx = player.x - asteroid.x;
+            let dy = player.y - asteroid.y;
+            let sum_r = player_radius + asteroid.radius;
+            let dist_sq = dx * dx + dy * dy;
+            if dist_sq >= sum_r * sum_r {
+                continue;
+            }
+
+            // ── Hit detected — compute impulse + separation ──
+
+            let asteroid_mass = asteroid
+                .mass
+                .unwrap_or_else(|| asteroid_mass_fallback(asteroid.radius));
+
+            // 4. Knockback angle: asteroid → player (JS collision.js:570–573).
+            //    Defensive: if centers exactly coincide, fall back to angle = 0.
+            let distance = dist_sq.sqrt();
+            let knockback_angle = if distance > 0.0 {
+                dy.atan2(dx)
+            } else {
+                0.0
+            };
+
+            // 5. Bounce impulse formula (JS collision.js:575–581).
+            let total_mass = player_mass + asteroid_mass;
+            let cos_a = knockback_angle.cos();
+            let sin_a = knockback_angle.sin();
+            let dvn = (player.vx - asteroid.vx) * cos_a + (player.vy - asteroid.vy) * sin_a;
+            let enhanced_impulse = if total_mass > 0.0 {
+                (2.0 * dvn) / total_mass
+            } else {
+                0.0
+            };
+            let knockback = enhanced_impulse * ASTEROID_KNOCKBACK_MULTIPLIER;
+
+            // 6. Jitter — deterministic-by-default (JS collision.js:584–587).
+            //    JS path: jitterFraction = ctx.rngFloat() OR 0.5;
+            //             jitter = (jitterFraction - 0.5) · π/2
+            //    Rust mirror has no RNG wired into CollisionContext yet,
+            //    so we mirror the "rngFloat = 0.5" centered case ⇒
+            //    jitter = 0. Future RNG plumbing fills this in without
+            //    changing the signature.
+            let jitter: f32 = 0.0;
+            let angle_with_jitter = knockback_angle + jitter;
+
+            let mut player_impulse_dx = angle_with_jitter.cos() * knockback;
+            let mut player_impulse_dy = angle_with_jitter.sin() * knockback;
+
+            // 7. Asteroid impulse — heavy mass scaler dampens the rock's
+            //    reaction (JS collision.js:592–593).
+            let asteroid_impulse_dx = -knockback * 0.3 * player_mass * cos_a;
+            let asteroid_impulse_dy = -knockback * 0.3 * player_mass * sin_a;
+
+            // 8. Separation push (JS collision.js:596–607).
+            //    Pushes the player along the (asteroid → player) unit normal
+            //    by (overlap + buffer); also adds OVERLAP_PUSH_FORCE to the
+            //    player velocity along the same normal to keep the ship
+            //    drifting outward.
+            let mut separation_dx = 0.0;
+            let mut separation_dy = 0.0;
+            let overlap = sum_r - distance;
+            if overlap > 0.0 && distance > 0.0 {
+                let nx = dx / distance;
+                let ny = dy / distance;
+                let total_separation = overlap + SEPARATION_BUFFER;
+                separation_dx = nx * total_separation;
+                separation_dy = ny * total_separation;
+                player_impulse_dx += nx * OVERLAP_PUSH_FORCE;
+                player_impulse_dy += ny * OVERLAP_PUSH_FORCE;
+            }
+
+            // 9. Emit the event (JS collision.js:609–620).
+            events.push(CollisionEvent::PlayerHitAsteroid {
+                player_id: player.id,
+                asteroid_id: asteroid.id,
+                damage_to_asteroid: PLAYER_ASTEROID_COLLISION_DAMAGE,
+                player_impulse_dx,
+                player_impulse_dy,
+                asteroid_impulse_dx,
+                asteroid_impulse_dy,
+                separation_dx,
+                separation_dy,
+            });
+        }
+    }
+}
+
+// ─── Wire-state integration stub (Phase 3) ──────────────────────────
+//
+// Existing entry point called from `simulate_tick` in `mod.rs`. The real
+// wire ↔ sim bridging will land when client prediction wires up; for
+// now this is a no-op that satisfies the existing call site. Mirrors
+// the matching stub in `asteroid.rs::update_all`.
 pub fn detect_and_resolve(_state: &mut GameState, _events: &mut Vec<GameEvent>) {}

--- a/server/tests/parity_collision.rs
+++ b/server/tests/parity_collision.rs
@@ -1,0 +1,683 @@
+//! Cross-language parity vectors for collision pair-detection
+//! (Phase 2.5, dispatch 1 + dispatch 2).
+//!
+//! Mirrors `js/sim/collision.js::detectBulletAsteroidHits` and
+//! `detectPlayerAsteroidHits`. The JS pure step has its own Jest suite at
+//! `tests/unit/sim/collision.test.js`; the fixtures here drive the Rust
+//! mirror through the equivalent scenarios and assert the same event
+//! counts / ids / damage / despawn flags / impulse-and-separation deltas.
+//!
+//! ─── Bullet-vs-asteroid coverage ─────────────────────────────────────
+//!   1. `collision_single_hit`           — basic overlap → 1 event
+//!   2. `collision_piercing_within_tick` — piercing=2 → 3 events, last
+//!                                          despawns
+//!   3. `collision_geometry_miss`        — outside sum-of-radii → 0 events
+//!   4. `collision_pierced_set_carryover`— second tick doesn't re-hit
+//!
+//! ─── Player-vs-asteroid coverage ─────────────────────────────────────
+//!   5. `player_asteroid_single_hit`         — basic overlap → 1 event w/
+//!                                             all 9 fields populated
+//!   6. `player_asteroid_geometry_miss`      — outside sum-of-radii → 0 events
+//!   7. `player_asteroid_bounce_direction`   — eastbound vs westbound
+//!                                             ⇒ playerImpulseDx < 0
+//!   8. `player_asteroid_multiple_hits_one_tick`
+//!                                           — wedged between two rocks
+//!                                             ⇒ 2 events, both for same player
+//!   9. `player_asteroid_skip_gates`         — inactive / warping /
+//!                                             death-flash gates → 0 events
+//!  10. `player_asteroid_separation_magnitude`
+//!                                           — separation distance ==
+//!                                             overlap + SEPARATION_BUFFER
+//!
+//! Why no floating-point goldens for bullet-asteroid: pair-discovery only,
+//! no accumulated multiplication, so no f32-vs-f64 drift to tolerate.
+//! Player-asteroid uses a 0.01 tolerance on impulse / separation deltas
+//! because the math involves trig + mass-fallback formulas that diverge
+//! between JS (f64) and Rust (f32) at the last decimal places.
+//!
+//! Reference: `js/sim/collision.js` (PR #30 for bullet-asteroid,
+//! PR #32 for player-asteroid).
+
+use rainboids_server::sim::collision::{
+    detect_bullet_asteroid_hits, detect_player_asteroid_hits, CollisionAsteroid, CollisionBullet,
+    CollisionContext, CollisionEvent, CollisionPlayer, ASTEROID_KNOCKBACK_MULTIPLIER,
+    OVERLAP_PUSH_FORCE, PLAYER_ASTEROID_COLLISION_DAMAGE, SEPARATION_BUFFER,
+};
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+/// Build a player-style bullet at (x, y). Defaults pin a small player
+/// bullet sized like the live game (radius 4, damage 1).
+fn make_bullet(id: u32, x: f32, y: f32) -> CollisionBullet {
+    let mut b = CollisionBullet::fresh(id);
+    b.x = x;
+    b.y = y;
+    b
+}
+
+/// Build an asteroid at (x, y) with the live game's mid-size default
+/// radius of 30 and zero velocity (override after construction).
+fn make_asteroid(id: u32, x: f32, y: f32) -> CollisionAsteroid {
+    let mut a = CollisionAsteroid::fresh(id);
+    a.x = x;
+    a.y = y;
+    a
+}
+
+/// Build a player ship at (x, y) with the live game's default radius of 15.
+fn make_player(id: u32, x: f32, y: f32) -> CollisionPlayer {
+    let mut p = CollisionPlayer::fresh(id);
+    p.x = x;
+    p.y = y;
+    p
+}
+
+/// Float-tolerance assertion helper for impulse/separation math.
+fn approx_eq(actual: f32, expected: f32, what: &str) {
+    let delta = (actual - expected).abs();
+    assert!(
+        delta < 0.01,
+        "{} diverged: rust={}, expected={}, |Δ|={}",
+        what,
+        actual,
+        expected,
+        delta,
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Bullet-vs-asteroid fixtures (dispatch 1).
+// ═════════════════════════════════════════════════════════════════════
+
+// ---------------------------------------------------------------------
+// Fixture 1 — single bullet hits single asteroid.
+//
+// Mirrors `tests/unit/sim/collision.test.js::"overlapping bullet + asteroid
+// emits one event with correct fields"`. JS asserts:
+//   - 1 event
+//   - bulletId=1, asteroidId=101, damage=3
+//   - bullet_will_despawn=true, bullet_piercing_remaining=-1 (non-piercing)
+//   - bullet velocity + position carried through to event
+// ---------------------------------------------------------------------
+
+#[test]
+fn collision_single_hit() {
+    // Bullet at (100, 100), asteroid at (110, 100). dx=10, sum_r=4+30=34 →
+    // squared distance 100 < 1156 → overlap.
+    let mut bullet = make_bullet(1, 100.0, 100.0);
+    bullet.vx = 8.0;
+    bullet.vy = 0.0;
+    bullet.damage = 3.0;
+
+    let asteroid = make_asteroid(101, 110.0, 100.0);
+
+    let mut bullets = vec![bullet];
+    let asteroids = vec![asteroid];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_bullet_asteroid_hits(&mut bullets, &asteroids, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1, "expected exactly one bullet-hit-asteroid event");
+
+    match events[0] {
+        CollisionEvent::BulletHitAsteroid {
+            bullet_id,
+            asteroid_id,
+            damage,
+            bullet_x,
+            bullet_y,
+            bullet_vx,
+            bullet_vy,
+            bullet_piercing_remaining,
+            bullet_will_despawn,
+        } => {
+            assert_eq!(bullet_id, 1, "bullet_id");
+            assert_eq!(asteroid_id, 101, "asteroid_id");
+            assert!((damage - 3.0).abs() < 1e-6, "damage carries through");
+            assert!((bullet_x - 100.0).abs() < 1e-6, "bullet_x");
+            assert!((bullet_y - 100.0).abs() < 1e-6, "bullet_y");
+            assert!((bullet_vx - 8.0).abs() < 1e-6, "bullet_vx");
+            assert!((bullet_vy - 0.0).abs() < 1e-6, "bullet_vy");
+            assert_eq!(
+                bullet_piercing_remaining, -1,
+                "non-piercing bullet → -1 remaining"
+            );
+            assert!(bullet_will_despawn, "non-piercing bullet despawns on hit");
+        }
+        ev => panic!("expected BulletHitAsteroid, got {:?}", ev),
+    }
+
+    // Bullet should now remember the pierce.
+    assert!(
+        bullets[0].pierced_asteroid_ids.contains(&101),
+        "pierced_asteroid_ids should include the hit asteroid"
+    );
+    assert_eq!(
+        bullets[0].pierced_enemies, 1,
+        "pierced_enemies counter incremented"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Fixture 2 — piercing=2 bullet hits 3 overlapping asteroids in the same tick.
+//
+// Mirrors `tests/unit/sim/collision.test.js::"piercing=2 bullet hits 3
+// overlapping asteroids in same tick"`.
+// ---------------------------------------------------------------------
+
+#[test]
+fn collision_piercing_within_tick() {
+    let mut bullet = make_bullet(1, 100.0, 100.0);
+    bullet.piercing = 2;
+    bullet.damage = 1.0;
+
+    // All three asteroids overlap (each radius 30, bullet radius 4 →
+    // sum_r 34; bullet at (100, 100), asteroids within 20 px).
+    let a1 = make_asteroid(101, 110.0, 100.0);
+    let a2 = make_asteroid(102, 120.0, 100.0);
+    let a3 = make_asteroid(103, 90.0, 100.0);
+
+    let mut bullets = vec![bullet];
+    let asteroids = vec![a1, a2, a3];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_bullet_asteroid_hits(&mut bullets, &asteroids, &ctx, &mut events);
+
+    assert_eq!(events.len(), 3, "piercing=2 → 3 events (piercing + 1 targets)");
+
+    // Collect ids in event-emit order — should be array order: 101, 102, 103.
+    let ids: Vec<u32> = events
+        .iter()
+        .map(|e| match *e {
+            CollisionEvent::BulletHitAsteroid { asteroid_id, .. } => asteroid_id,
+            ev => panic!("expected BulletHitAsteroid, got {:?}", ev),
+        })
+        .collect();
+    assert_eq!(ids, vec![101, 102, 103], "asteroids hit in array order");
+
+    // First two events: bullet still alive.
+    for (i, ev) in events.iter().take(2).enumerate() {
+        match *ev {
+            CollisionEvent::BulletHitAsteroid {
+                bullet_will_despawn,
+                bullet_piercing_remaining,
+                ..
+            } => {
+                assert!(
+                    !bullet_will_despawn,
+                    "event[{}] should not despawn (budget remaining)",
+                    i
+                );
+                // After hit 1: remaining=1; after hit 2: remaining=0.
+                let expected = (2 - (i as i32 + 1)).max(0);
+                assert_eq!(
+                    bullet_piercing_remaining, expected,
+                    "event[{}] piercing_remaining",
+                    i
+                );
+            }
+            ev => panic!("expected BulletHitAsteroid, got {:?}", ev),
+        }
+    }
+
+    // Last event: budget exhausted → despawn.
+    match events[2] {
+        CollisionEvent::BulletHitAsteroid {
+            bullet_will_despawn,
+            bullet_piercing_remaining,
+            ..
+        } => {
+            assert!(bullet_will_despawn, "third hit exhausts piercing budget");
+            assert_eq!(
+                bullet_piercing_remaining, 0,
+                "piercing_remaining clamps to 0 on last hit"
+            );
+        }
+        ev => panic!("expected BulletHitAsteroid, got {:?}", ev),
+    }
+
+    // All three asteroid ids should now live in the bullet's pierced set.
+    assert_eq!(
+        bullets[0].pierced_asteroid_ids.len(),
+        3,
+        "pierced_asteroid_ids should have all three"
+    );
+    assert_eq!(bullets[0].pierced_enemies, 3, "pierced_enemies counter");
+}
+
+// ---------------------------------------------------------------------
+// Fixture 3 — bullet outside sum-of-radii emits no event.
+// ---------------------------------------------------------------------
+
+#[test]
+fn collision_geometry_miss() {
+    let bullet = make_bullet(1, 0.0, 0.0);
+    // dx=200, sum_r=4+30=34 → squared distance 40_000 ≫ 1156 → no overlap.
+    let asteroid = make_asteroid(101, 200.0, 0.0);
+
+    let mut bullets = vec![bullet];
+    let asteroids = vec![asteroid];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_bullet_asteroid_hits(&mut bullets, &asteroids, &ctx, &mut events);
+
+    assert!(
+        events.is_empty(),
+        "bullet outside sum-of-radii should emit no event, got {:?}",
+        events
+    );
+    // Pierce-tracking Set should still be empty — no hit recorded.
+    assert!(
+        bullets[0].pierced_asteroid_ids.is_empty(),
+        "no pierces recorded on miss"
+    );
+    assert_eq!(bullets[0].pierced_enemies, 0, "no pierce-counter bump");
+}
+
+// ---------------------------------------------------------------------
+// Fixture 4 — piercedAsteroidIds carries across ticks.
+// ---------------------------------------------------------------------
+
+#[test]
+fn collision_pierced_set_carryover() {
+    let mut bullet = make_bullet(1, 100.0, 100.0);
+    bullet.piercing = 5;
+    bullet.damage = 1.0;
+
+    let asteroid = make_asteroid(101, 110.0, 100.0);
+
+    let mut bullets = vec![bullet];
+    let asteroids = vec![asteroid];
+    let ctx = CollisionContext;
+
+    // ── Tick 1 — fresh bullet, fresh asteroid, should hit. ──
+    let mut events_tick1: Vec<CollisionEvent> = Vec::new();
+    detect_bullet_asteroid_hits(&mut bullets, &asteroids, &ctx, &mut events_tick1);
+    assert_eq!(events_tick1.len(), 1, "tick 1 should emit one hit event");
+    assert!(
+        bullets[0].pierced_asteroid_ids.contains(&101),
+        "tick 1 should record the asteroid in the pierce set"
+    );
+    assert_eq!(bullets[0].pierced_enemies, 1, "tick 1 bumps counter to 1");
+
+    // ── Tick 2 — same bullet, same asteroid. Pierce set should
+    //    short-circuit the geometry check. ──
+    let mut events_tick2: Vec<CollisionEvent> = Vec::new();
+    detect_bullet_asteroid_hits(&mut bullets, &asteroids, &ctx, &mut events_tick2);
+    assert!(
+        events_tick2.is_empty(),
+        "tick 2 should NOT re-hit the already-pierced asteroid, got {:?}",
+        events_tick2
+    );
+    // Pierce counter should be unchanged — no new hits.
+    assert_eq!(
+        bullets[0].pierced_enemies, 1,
+        "tick 2 should not bump the pierce counter"
+    );
+    // Pierce set unchanged.
+    assert_eq!(
+        bullets[0].pierced_asteroid_ids.len(),
+        1,
+        "pierce set should still have exactly one entry"
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Player-vs-asteroid fixtures (dispatch 2).
+// ═════════════════════════════════════════════════════════════════════
+
+// ---------------------------------------------------------------------
+// Fixture 5 — single overlapping player + asteroid emits one event with
+// all nine fields populated.
+//
+// Mirrors `tests/unit/sim/collision.test.js::"overlapping player + asteroid
+// emits one event with all delta fields"`. JS asserts the event carries
+// playerId, asteroidId, damage_to_asteroid=2, and six finite numeric
+// delta fields with separationDx non-zero (overlap is on the x-axis).
+// ---------------------------------------------------------------------
+
+#[test]
+fn player_asteroid_single_hit() {
+    // Player radius 15, asteroid radius 30 ⇒ sum_r = 45.
+    // Place 30 px apart on the x-axis ⇒ overlap = 15 (clear hit).
+    let mut player = make_player(1, 100.0, 100.0);
+    player.vx = 5.0;
+    player.vy = 0.0;
+
+    let mut asteroid = make_asteroid(10, 130.0, 100.0);
+    asteroid.vx = 0.0;
+    asteroid.vy = 0.0;
+
+    let players = vec![player];
+    let asteroids = vec![asteroid];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_player_asteroid_hits(&players, &asteroids, &ctx, &mut events);
+
+    assert_eq!(
+        events.len(),
+        1,
+        "expected exactly one player-hit-asteroid event"
+    );
+
+    match events[0] {
+        CollisionEvent::PlayerHitAsteroid {
+            player_id,
+            asteroid_id,
+            damage_to_asteroid,
+            player_impulse_dx,
+            player_impulse_dy,
+            asteroid_impulse_dx,
+            asteroid_impulse_dy,
+            separation_dx,
+            separation_dy,
+        } => {
+            assert_eq!(player_id, 1, "player_id");
+            assert_eq!(asteroid_id, 10, "asteroid_id");
+            assert!(
+                (damage_to_asteroid - PLAYER_ASTEROID_COLLISION_DAMAGE).abs() < 1e-6,
+                "damage_to_asteroid"
+            );
+            // All six numeric delta fields must be finite.
+            assert!(player_impulse_dx.is_finite(), "player_impulse_dx finite");
+            assert!(player_impulse_dy.is_finite(), "player_impulse_dy finite");
+            assert!(asteroid_impulse_dx.is_finite(), "asteroid_impulse_dx finite");
+            assert!(asteroid_impulse_dy.is_finite(), "asteroid_impulse_dy finite");
+            assert!(separation_dx.is_finite(), "separation_dx finite");
+            assert!(separation_dy.is_finite(), "separation_dy finite");
+            // Overlap is on the x-axis only ⇒ separation has nonzero dx.
+            assert!(
+                separation_dx.abs() > 1e-6,
+                "separation_dx must be nonzero on collision axis (got {})",
+                separation_dx
+            );
+        }
+        ev => panic!("expected PlayerHitAsteroid, got {:?}", ev),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture 6 — geometry miss: centers further than sum_r apart emits no event.
+//
+// Mirrors `tests/unit/sim/collision.test.js::"player outside (player.r +
+// asteroid.r) emits no event"`.
+// ---------------------------------------------------------------------
+
+#[test]
+fn player_asteroid_geometry_miss() {
+    let player = make_player(1, 0.0, 0.0);
+    // 200 px ≫ sum_r=45 ⇒ no overlap.
+    let asteroid = make_asteroid(10, 200.0, 0.0);
+
+    let players = vec![player];
+    let asteroids = vec![asteroid];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_player_asteroid_hits(&players, &asteroids, &ctx, &mut events);
+
+    assert!(
+        events.is_empty(),
+        "player outside sum-of-radii should emit no event, got {:?}",
+        events
+    );
+}
+
+// ---------------------------------------------------------------------
+// Fixture 7 — bounce direction.
+//
+// Mirrors `tests/unit/sim/collision.test.js::"eastbound player ramming a
+// westward rock gets impulse pushing west"`.
+//
+// Geometry:
+//   - Player at (100, 100), radius 15, moving east (vx=10).
+//   - Asteroid 30 px east at (130, 100), radius 30, moving west (vx=-2).
+//   - distance=30, sum_r=45 ⇒ overlap=15.
+//
+// Expected delta directions:
+//   - The separation normal points from asteroid → player, which is
+//     westward → separationDx < 0.
+//   - The OVERLAP_PUSH_FORCE term adds nx · 5 = -5 to playerImpulseDx
+//     (westward).
+//   - The knockback term is mass-dominated by the much heavier asteroid
+//     (≈113k vs ≈353), making its contribution orders of magnitude
+//     smaller than the OVERLAP_PUSH_FORCE term, so playerImpulseDx
+//     stays strictly negative.
+// ---------------------------------------------------------------------
+
+#[test]
+fn player_asteroid_bounce_direction() {
+    let mut player = make_player(1, 100.0, 100.0);
+    player.vx = 10.0;
+    player.vy = 0.0;
+
+    let mut asteroid = make_asteroid(10, 130.0, 100.0);
+    asteroid.vx = -2.0;
+    asteroid.vy = 0.0;
+
+    let players = vec![player];
+    let asteroids = vec![asteroid];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_player_asteroid_hits(&players, &asteroids, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1, "expected exactly one event");
+    match events[0] {
+        CollisionEvent::PlayerHitAsteroid {
+            player_impulse_dx,
+            separation_dx,
+            separation_dy,
+            ..
+        } => {
+            // Separation points westward (away from the east-of-player rock).
+            assert!(
+                separation_dx < 0.0,
+                "separation_dx should be westward (negative), got {}",
+                separation_dx
+            );
+            // Player + asteroid both on the x-axis ⇒ no y-component.
+            approx_eq(separation_dy, 0.0, "separation_dy");
+            // Net player impulse dominated by westward overlap push.
+            assert!(
+                player_impulse_dx < 0.0,
+                "player_impulse_dx should be westward (negative), got {}",
+                player_impulse_dx
+            );
+        }
+        ev => panic!("expected PlayerHitAsteroid, got {:?}", ev),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture 8 — one player overlapping two rocks emits two events.
+//
+// Mirrors `tests/unit/sim/collision.test.js::"player wedged between two
+// asteroids emits two events"`.
+// ---------------------------------------------------------------------
+
+#[test]
+fn player_asteroid_multiple_hits_one_tick() {
+    let player = make_player(1, 100.0, 100.0);
+
+    // East rock: dx=+30, sum_r=45 ⇒ overlap.
+    let east = make_asteroid(10, 130.0, 100.0);
+    // West rock: dx=-30, sum_r=45 ⇒ overlap.
+    let west = make_asteroid(20, 70.0, 100.0);
+
+    let players = vec![player];
+    let asteroids = vec![east, west];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_player_asteroid_hits(&players, &asteroids, &ctx, &mut events);
+
+    assert_eq!(events.len(), 2, "expected two events (one per overlapping rock)");
+
+    // Both events should be for the same player.
+    let mut ids: Vec<u32> = events
+        .iter()
+        .map(|e| match *e {
+            CollisionEvent::PlayerHitAsteroid {
+                player_id,
+                asteroid_id,
+                ..
+            } => {
+                assert_eq!(player_id, 1, "all events should be for player 1");
+                asteroid_id
+            }
+            ev => panic!("expected PlayerHitAsteroid, got {:?}", ev),
+        })
+        .collect();
+    ids.sort();
+    assert_eq!(ids, vec![10, 20], "expected asteroids 10 and 20");
+}
+
+// ---------------------------------------------------------------------
+// Fixture 9 — skip gates (inactive / warping / death-flash) emit no event.
+//
+// Mirrors the five `tests/unit/sim/collision.test.js::"skip"`-flavored
+// scenarios. We combine all four gate types into a single fixture for
+// brevity; each sub-block constructs the smallest possible failing state.
+// ---------------------------------------------------------------------
+
+#[test]
+fn player_asteroid_skip_gates() {
+    let ctx = CollisionContext;
+
+    // Sub-test (a): inactive player → no event.
+    {
+        let mut player = make_player(1, 100.0, 100.0);
+        player.active = false;
+        let asteroid = make_asteroid(10, 130.0, 100.0);
+        let mut events: Vec<CollisionEvent> = Vec::new();
+        detect_player_asteroid_hits(&[player], &[asteroid], &ctx, &mut events);
+        assert!(events.is_empty(), "inactive player must not emit event");
+    }
+
+    // Sub-test (b): inactive asteroid → no event.
+    {
+        let player = make_player(1, 100.0, 100.0);
+        let mut asteroid = make_asteroid(10, 130.0, 100.0);
+        asteroid.active = false;
+        let mut events: Vec<CollisionEvent> = Vec::new();
+        detect_player_asteroid_hits(&[player], &[asteroid], &ctx, &mut events);
+        assert!(events.is_empty(), "inactive asteroid must not emit event");
+    }
+
+    // Sub-test (c): warping asteroid → no event.
+    {
+        let player = make_player(1, 100.0, 100.0);
+        let mut asteroid = make_asteroid(10, 130.0, 100.0);
+        asteroid.warping = true;
+        let mut events: Vec<CollisionEvent> = Vec::new();
+        detect_player_asteroid_hits(&[player], &[asteroid], &ctx, &mut events);
+        assert!(events.is_empty(), "warping asteroid must not emit event");
+    }
+
+    // Sub-test (d): asteroid mid-death-flash → no event.
+    {
+        let player = make_player(1, 100.0, 100.0);
+        let mut asteroid = make_asteroid(10, 130.0, 100.0);
+        asteroid.death_flash = 5;
+        let mut events: Vec<CollisionEvent> = Vec::new();
+        detect_player_asteroid_hits(&[player], &[asteroid], &ctx, &mut events);
+        assert!(
+            events.is_empty(),
+            "asteroid mid-death-flash must not emit event"
+        );
+    }
+
+    // Sub-test (e): empty inputs (defensive) → no event.
+    {
+        let mut events: Vec<CollisionEvent> = Vec::new();
+        detect_player_asteroid_hits(&[], &[make_asteroid(10, 0.0, 0.0)], &ctx, &mut events);
+        assert!(events.is_empty(), "empty players → no event");
+
+        let mut events2: Vec<CollisionEvent> = Vec::new();
+        detect_player_asteroid_hits(&[make_player(1, 0.0, 0.0)], &[], &ctx, &mut events2);
+        assert!(events2.is_empty(), "empty asteroids → no event");
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture 10 — separation magnitude equals `overlap + SEPARATION_BUFFER`
+// along the (asteroid → player) normal.
+//
+// Mirrors `tests/unit/sim/collision.test.js::"separation distance =
+// overlap + SEPARATION_BUFFER along (asteroid → player) normal"`.
+//
+// Geometry: player at (100, 100) r=15; asteroid at (130, 100) r=30.
+//   distance = 30, sum_r = 45 ⇒ overlap = 15.
+//   Normal (asteroid → player) = (-1, 0).
+//   Expected separation = (-1, 0) · (15 + 6) = (-21, 0).
+//
+// We also sanity-check that:
+//   - player_impulse_dx includes the OVERLAP_PUSH_FORCE term
+//     (nx · 5 = -5) PLUS the (tiny) knockback contribution.
+//   - asteroid_impulse_dx is in the opposite direction
+//     (-knockback · 0.3 · player_mass · cos_a).
+// ---------------------------------------------------------------------
+
+#[test]
+fn player_asteroid_separation_magnitude() {
+    let player = make_player(1, 100.0, 100.0);
+    let asteroid = make_asteroid(10, 130.0, 100.0);
+
+    let players = vec![player];
+    let asteroids = vec![asteroid];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_player_asteroid_hits(&players, &asteroids, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1, "expected exactly one event");
+
+    let expected_separation_dx = -(15.0 + SEPARATION_BUFFER); // = -21
+    let expected_separation_dy: f32 = 0.0;
+
+    match events[0] {
+        CollisionEvent::PlayerHitAsteroid {
+            separation_dx,
+            separation_dy,
+            player_impulse_dx,
+            player_impulse_dy,
+            asteroid_impulse_dx,
+            asteroid_impulse_dy,
+            damage_to_asteroid,
+            ..
+        } => {
+            approx_eq(separation_dx, expected_separation_dx, "separation_dx");
+            approx_eq(separation_dy, expected_separation_dy, "separation_dy");
+
+            // Both players have zero velocity here ⇒ dvn = 0 ⇒ knockback = 0
+            // ⇒ player_impulse comes purely from OVERLAP_PUSH_FORCE along
+            // the westward normal: (-1, 0) · 5 = (-5, 0).
+            approx_eq(player_impulse_dx, -OVERLAP_PUSH_FORCE, "player_impulse_dx");
+            approx_eq(player_impulse_dy, 0.0, "player_impulse_dy");
+
+            // Zero relative velocity ⇒ knockback term vanishes ⇒ asteroid
+            // impulse is exactly zero (no jitter, no knockback contribution).
+            approx_eq(asteroid_impulse_dx, 0.0, "asteroid_impulse_dx");
+            approx_eq(asteroid_impulse_dy, 0.0, "asteroid_impulse_dy");
+
+            assert!(
+                (damage_to_asteroid - PLAYER_ASTEROID_COLLISION_DAMAGE).abs() < 1e-6,
+                "damage_to_asteroid"
+            );
+        }
+        ev => panic!("expected PlayerHitAsteroid, got {:?}", ev),
+    }
+
+    // Sanity: ensure the multipliers we exposed pin to their JS values
+    // (caught indirectly by the math above, but a direct assert documents
+    // intent).
+    assert!(
+        (ASTEROID_KNOCKBACK_MULTIPLIER - 22.0).abs() < 1e-6,
+        "ASTEROID_KNOCKBACK_MULTIPLIER must mirror JS verbatim"
+    );
+}


### PR DESCRIPTION
## Summary
Phase 2.5 dispatch 3 — Rust mirror of PR #32's `detectPlayerAsteroidHits`. **6 new parity fixtures, all passing, zero divergences from JS.**

## Constants added (match JS verbatim)
- `PLAYER_ASTEROID_COLLISION_DAMAGE = 2.0`
- `BOUNCE_RESTITUTION = 0.9`
- `BOUNCE_FORCE_MULTIPLIER = 12.0`
- `OVERLAP_SEPARATION_RATIO = 0.6`
- `ASTEROID_KNOCKBACK_MULTIPLIER = 22.0`
- `SEPARATION_BUFFER = 6.0`
- `OVERLAP_PUSH_FORCE = 5.0`

## New `CollisionPlayer` struct
`id, x, y, vx, vy, radius, mass: Option<f32>, active`. Mass fallback: `π·r²·0.5` (mirrors JS exactly).

## Extended `CollisionAsteroid`
Added `vx, vy, mass: Option<f32>` — required for bounce math; backward-compat with existing bullet-asteroid fixtures (zero defaults via `fresh()`). Asteroid mass fallback: `(4/3)·π·r³`.

## New `CollisionEvent::PlayerHitAsteroid`
9 fields: `player_id, asteroid_id, damage_to_asteroid, player_impulse_dx/dy, asteroid_impulse_dx/dy, separation_dx/dy`. Wrapper drains into legacy helpers.

## Pure function
```rust
pub fn detect_player_asteroid_hits(
    players: &[CollisionPlayer],
    asteroids: &[CollisionAsteroid],
    _ctx: &CollisionContext,
    events: &mut Vec<CollisionEvent>,
)
```

Mirrors JS exactly — same `atan2` normal, same `dvn` projection, same `(2·dvn)/totalMass` enhanced impulse, same scaling, same recoil, same separation, same jitter handling (`rngFloat = 0.5` for deterministic parity).

## New parity fixtures
| Test | Scenario |
|---|---|
| `player_asteroid_single_hit` | all 9 fields finite, nonzero separation |
| `player_asteroid_geometry_miss` | 200 px gap → 0 events |
| `player_asteroid_bounce_direction` | eastbound vs westbound → `playerImpulseDx < 0` |
| `player_asteroid_multiple_hits_one_tick` | wedged between 2 rocks → 2 events |
| `player_asteroid_skip_gates` | 5 sub-blocks (inactive/warping/death_flash/empty) → 0 events |
| `player_asteroid_separation_magnitude` | exact-value pin: zero-vel r=15 vs r=30 at (130,100) → sep=(-21, 0), playerImpulseDx=-5 |

## Test plan
- [x] `cargo test --test parity_collision` — 10 passed (4 existing bullet-asteroid + 6 new)
- [x] All workspace tests green
- [x] Build clean, zero warnings
- [x] `js/sim/collision.js`, `collision-system.js`, `state.rs`, `mod.rs`, `Cargo.toml` UNTOUCHED

## Phase 2.5 progress (task #46)
- ✓ bullet-asteroid JS (PR #30) + Rust (PR #31)
- ✓ player-asteroid JS (PR #32) + Rust (this PR)
- ⬜ bullet-enemy, player-enemy, enemy-asteroid, player-enemy-bullet, drops pickup, power-weapon, defense-skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)