### PR TITLE
mp/sim-rs: enemy bullet +4 patterns (Burst/Pulse/EnergySlash/SineWaveRotation, Phase 2.1)

### DIFF
--- a/server/src/sim/bullet.rs
+++ b/server/src/sim/bullet.rs
@@ -8,7 +8,7 @@
 //! Mirrors `js/sim/bullet.js`. **Player bullets** (`update_player_bullet`)
 //! implement the linear drift + helix offset + predictive-lead homing
 //! branches (PR #27). **Enemy bullets** (`update_enemy_bullet`) implement
-//! 7 of ~17 movement patterns:
+//! 11 of ~17 movement patterns:
 //!
 //!   - `Straight` — js `aimed`/`crescent_beam`/`crescent_slice` (no-mod path). (PR #29)
 //!   - `Sine` — js `sine_wave_nospin` (perpendicular sine offset). (PR #29)
@@ -17,16 +17,21 @@
 //!   - `Spiral` — js `spiral` (rotating velocity vector + spreading radius).
 //!   - `WaveEnergy` — js `wave_energy` (large-amplitude sine on perp-of-base axis).
 //!   - `ShieldBurst` — js `shield_burst` (high-freq wobble on perp-of-base axis).
+//!   - `Burst` — js `burst` (patternTimer-driven linear acceleration on base velocity).
+//!   - `Pulse` — js `pulse` (patternTimer-driven linear acceleration on base velocity, steeper).
+//!   - `EnergySlash` — js `energy_slash` (slashProgress curve + patternTimer pulse).
+//!   - `SineWaveRotation` — js `sine_wave` (Sine variant that aligns rotation
+//!     to travel direction; differs from `Sine` only via the `rotation` field).
 //!
 //! Deferred to follow-up sessions:
 //!
 //!   - Piercing / piercedEnemies counter — collision-side, Phase 2.5
 //!   - Explosive / explosionRadius — collision-side, Phase 2.5
-//!   - 10+ remaining enemy patterns (js bullet.js:259–593): `mine`,
-//!     `homing_mine`, `rapid`, `burst`, `explosive`, `laser`,
-//!     `laser_beam`, `missile`, `homing`, `titan_homing`, `titan_rocket`,
-//!     `pulse`, `energy_slash`, `sine_wave` (with rotation),
-//!     `missile_fast_slow`.
+//!   - 6 remaining enemy patterns (js bullet.js:259–593): `mine`,
+//!     `homing_mine`, `rapid`, `explosive`, `laser`, `laser_beam`,
+//!     `missile`, `homing`, `titan_homing`, `titan_rocket`,
+//!     `missile_fast_slow`. (Several require `target_player`, RNG, or
+//!     persistent-timed lifetime; gated on context-plumbing PRs.)
 //!   - Boss-rage homing composition, mine HP-death, persistent timed
 //!     lifetime (mines / lightning orbs), `targetPlayer` lookups.
 //!
@@ -419,7 +424,7 @@ pub fn update_player_bullets(
 // ── ENEMY BULLETS ───────────────────────────────────────────────────────
 //
 // `js/sim/bullet.js::updateEnemyBullet` switches on `movementPattern` and
-// has ~17 distinct cases. Implemented so far (7):
+// has ~17 distinct cases. Implemented so far (11):
 //
 //   - `Straight` (aimed / crescent_beam / crescent_slice — no-mod path).
 //   - `Sine` (sine_wave_nospin — perpendicular sin(phase)*amp offset).
@@ -434,6 +439,15 @@ pub fn update_player_bullets(
 //     0.1 attenuation factor; pattern timer ramp).
 //   - `ShieldBurst` (high-freq sin(patternTimer*8)*0.2 wobble on
 //     baseAngle+π/2 axis).
+//   - `Burst` (`baseVel *= 1 + patternTimer * 0.5` — pure timer-driven
+//     linear acceleration on base velocity).
+//   - `Pulse` (`baseVel *= 1 + patternTimer * 0.8` — same shape as `Burst`
+//     but steeper).
+//   - `EnergySlash` (slashProgress curve on perp axis + patternTimer pulse
+//     intensity scale; no RNG, no target).
+//   - `SineWaveRotation` (Sine variant that additionally aligns
+//     `bullet.rotation` to atan2(vy, vx) inside the pattern step; the
+//     post-step rotation accumulator then adds `rotation_speed * tick_scale`).
 //
 // The remaining patterns are TODO; see module docstring for the full list.
 //
@@ -443,10 +457,14 @@ pub fn update_player_bullets(
 //   1. Active-guard (early return if !active).
 //   2. `applyEnemyMovementPattern(b, ctx)` — pattern-specific velocity
 //      mutation. May set `active=false` + `expired_by_distance=true`
-//      (decelerate at min-speed floor).
+//      (decelerate at min-speed floor). For `SineWaveRotation` it also
+//      writes `bullet.rotation = atan2(vy, vx)`.
 //   3. Position update: `x += vx * tick_scale; y += vy * tick_scale`.
 //      NOTE: enemy-bullet path **does** scale by tick_scale; player does not.
-//   4. Rotation tick — skipped here (cosmetic; not modeled).
+//   4. Rotation accumulator: `rotation += rotation_speed * tick_scale`
+//      (JS bullet.js:197). Composes with any rotation written by the
+//      pattern step — e.g. `SineWaveRotation` overwrites rotation in step
+//      2, then step 4 adds the per-tick rotation_speed delta.
 //   5. `pattern_timer += logic_tick_seconds`.
 //   6. Mine HP death — skipped (mine pattern not yet ported).
 //   7. Lifetime / fade:
@@ -487,7 +505,25 @@ const WAVE_ENERGY_VEL_SCALE: f32 = 0.1;
 const SHIELD_BURST_FREQ: f32 = 8.0;
 const SHIELD_BURST_AMP: f32 = 0.2;
 
-/// Enemy-bullet movement pattern. 7 of ~17 ported so far — see module
+// JS bullet.js:328 — `burst`: linear timer-acceleration on base velocity.
+// `bullet.vx = bullet.baseVx * (1 + patternTimer * 0.5)`.
+const BURST_ACCEL_RATE: f32 = 0.5;
+
+// JS bullet.js:478 — `pulse`: linear timer-acceleration on base velocity.
+// Same shape as `burst` but steeper coefficient: `*(1 + patternTimer * 0.8)`.
+const PULSE_ACCEL_RATE: f32 = 0.8;
+
+// JS bullet.js:507–509 — `energy_slash`: perpendicular curve driven by
+// `sin(slashProgress * π)` with amplitude `0.3`. JS code:
+//   curveOffset = sin(slashProgress * π) * 0.3
+const ENERGY_SLASH_CURVE_INTENSITY: f32 = 0.3;
+
+// JS bullet.js:515 — `energy_slash`: post-curve velocity scale by
+// `1 + sin(patternTimer * 8) * 0.1`. High-freq pulse, low amplitude.
+const ENERGY_SLASH_PULSE_FREQ: f32 = 8.0;
+const ENERGY_SLASH_PULSE_AMP: f32 = 0.1;
+
+/// Enemy-bullet movement pattern. 11 of ~17 ported so far — see module
 /// docstring for the deferred list.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BulletPattern {
@@ -496,8 +532,8 @@ pub enum BulletPattern {
     Straight,
     /// JS `sine_wave_nospin` — drift along base velocity plus perpendicular
     /// `sin(sine_phase) * sine_amp` offset; advances `sine_phase` by
-    /// `sine_freq` each tick. (The `sine_wave` variant additionally aligns
-    /// rotation to travel direction; not modeled here.)
+    /// `sine_freq` each tick. Does NOT modify rotation. (The `SineWaveRotation`
+    /// variant additionally aligns rotation to travel direction.)
     Sine,
     /// JS `missile_decelerate` — subtractive speed decay each tick. When the
     /// speed reaches `min_speed`, the bullet expires (`expired_by_distance`).
@@ -517,9 +553,26 @@ pub enum BulletPattern {
     /// JS `shield_burst` — high-frequency `sin(patternTimer*8)*0.2` wobble
     /// on the `baseAngle+π/2` axis. No pattern_phase or extra state.
     ShieldBurst,
-    // TODO Phase 2.1+: Helix, Homing, Ricochet, Rocket, Mine, EnergySlash,
-    // Bezier, Charge, Rapid, Burst, Explosive, Laser, LaserBeam, Missile,
-    // TitanHoming, TitanRocket, Pulse, SineWave (with rotation),
+    /// JS `burst` — `vx = baseVx * (1 + patternTimer * 0.5)`. Pure timer-driven
+    /// linear acceleration on the base velocity (both axes scaled identically).
+    Burst,
+    /// JS `pulse` — `vx = baseVx * (1 + patternTimer * 0.8)`. Same shape as
+    /// `Burst` with a steeper acceleration coefficient.
+    Pulse,
+    /// JS `energy_slash` — perpendicular curve from `sin(slashProgress * π)`
+    /// (amplitude `ENERGY_SLASH_CURVE_INTENSITY`) added to the base velocity,
+    /// then the whole vector is scaled by `1 + sin(patternTimer * 8) * 0.1`.
+    /// Reads `slash_progress` from the bullet; that field is treated as 0 if
+    /// unset (matches JS `bullet.slashProgress || 0`).
+    EnergySlash,
+    /// JS `sine_wave` — same as `Sine` (perpendicular sin offset) but also
+    /// writes `bullet.rotation = atan2(vy, vx)` inside the pattern step so
+    /// the bullet visually faces its travel direction. The post-step rotation
+    /// accumulator then adds `rotation_speed * tick_scale` to the overwritten
+    /// value, exactly matching the JS order of operations.
+    SineWaveRotation,
+    // TODO Phase 2.1+: Helix, Homing, Ricochet, Rocket, Mine, Bezier, Charge,
+    // Rapid, Explosive, Laser, LaserBeam, Missile, TitanHoming, TitanRocket,
     // MissileFastSlow, HomingMine.
 }
 
@@ -595,6 +648,24 @@ pub struct EnemyBullet {
     /// JS state.js:473 — floor for the speed clamp.
     pub min_speed: f32,
 
+    // ── EnergySlash pattern state ─────────────────────────────────────
+    /// JS state.js:474 — 0..1 progress used by `energy_slash` to drive the
+    /// `sin(slashProgress * π) * curveIntensity` perpendicular curve. JS
+    /// treats this as 0 if absent (`bullet.slashProgress || 0` at
+    /// bullet.js:508). The wrapper sets it from the spawning enemy's
+    /// slash animation; the pattern step does NOT advance it.
+    pub slash_progress: f32,
+
+    // ── Rotation (sprite orientation) ─────────────────────────────────
+    /// JS state.js:433 — bullet rotation in radians. Set per-tick by some
+    /// patterns (`SineWaveRotation`, `missile`, `missile_fast_slow`) and
+    /// also incremented by `rotation_speed * tick_scale` after the position
+    /// update (JS bullet.js:197). Default 0.
+    pub rotation: f32,
+    /// JS state.js:434 — per-tick rotation delta (radians). Added each tick
+    /// after the position update, regardless of pattern. Default 0.
+    pub rotation_speed: f32,
+
     // ── Lifecycle flags ───────────────────────────────────────────────
     pub active: bool,
     /// JS state.js:475 — wrapper triggers disappear-puff FX.
@@ -614,8 +685,6 @@ pub struct EnemyBullet {
     // TODO Phase 2.1+: boss_rage_homing.
     // TODO Phase 2.1+: rocket_speed, max_distance, distance_traveled
     //   (titan_rocket).
-    // TODO Phase 2.1+: slash_progress (energy_slash).
-    // TODO Phase 2.1+: rotation, rotation_speed (sprite orientation).
 }
 
 /// Per-tick context for enemy-bullet updates. Mirrors the relevant subset
@@ -735,6 +804,56 @@ fn apply_enemy_movement_pattern(b: &mut EnemyBullet, _ctx: &EnemyBulletContext) 
             b.vx = b.base_vx + perp_angle.cos() * wobble;
             b.vy = b.base_vy + perp_angle.sin() * wobble;
         }
+
+        // JS bullet.js:327–332 — `burst`. `accelFactor = 1 + patternTimer * 0.5`.
+        // Both axes scaled identically; same direction as base velocity.
+        BulletPattern::Burst => {
+            let accel_factor = 1.0 + b.pattern_timer * BURST_ACCEL_RATE;
+            b.vx = b.base_vx * accel_factor;
+            b.vy = b.base_vy * accel_factor;
+        }
+
+        // JS bullet.js:477–482 — `pulse`. Same shape as `Burst` but
+        // steeper acceleration (`* 0.8` vs `* 0.5`).
+        BulletPattern::Pulse => {
+            let pulse_accel = 1.0 + b.pattern_timer * PULSE_ACCEL_RATE;
+            b.vx = b.base_vx * pulse_accel;
+            b.vy = b.base_vy * pulse_accel;
+        }
+
+        // JS bullet.js:505–519 — `energy_slash`. Three-step velocity build:
+        //   1. Compute `curveOffset = sin(slashProgress * π) * 0.3`.
+        //   2. Add curve along the perp-of-slash-direction axis.
+        //   3. Multiply final velocity by `1 + sin(patternTimer * 8) * 0.1`.
+        // `slashProgress` is read from the bullet; JS treats absent as 0.
+        BulletPattern::EnergySlash => {
+            let slash_direction = b.base_vy.atan2(b.base_vx);
+            let curve_offset =
+                (b.slash_progress * std::f32::consts::PI).sin() * ENERGY_SLASH_CURVE_INTENSITY;
+            let perp_slash_direction = slash_direction + std::f32::consts::FRAC_PI_2;
+            let curve_vel_x = perp_slash_direction.cos() * curve_offset;
+            let curve_vel_y = perp_slash_direction.sin() * curve_offset;
+            b.vx = b.base_vx + curve_vel_x;
+            b.vy = b.base_vy + curve_vel_y;
+            let pulse_intensity =
+                1.0 + (b.pattern_timer * ENERGY_SLASH_PULSE_FREQ).sin() * ENERGY_SLASH_PULSE_AMP;
+            b.vx *= pulse_intensity;
+            b.vy *= pulse_intensity;
+        }
+
+        // JS bullet.js:526–534 — `sine_wave` (rotation variant of `Sine`).
+        // Same perpendicular sin displacement as `Sine`, but additionally
+        // writes `bullet.rotation = atan2(vy, vx)` so the needle visually
+        // points in its travel direction. The post-step rotation accumulator
+        // then adds `rotation_speed * tick_scale` to this value.
+        BulletPattern::SineWaveRotation => {
+            b.sine_phase += b.sine_freq;
+            let displacement = b.sine_phase.sin() * b.sine_amp;
+            b.vx = b.base_vx + b.sine_perp_x * displacement;
+            b.vy = b.base_vy + b.sine_perp_y * displacement;
+            // Align rotation with travel direction (JS bullet.js:532).
+            b.rotation = b.vy.atan2(b.vx);
+        }
     }
 }
 
@@ -762,7 +881,13 @@ pub fn update_enemy_bullet(
     b.x += b.vx * ctx.tick_scale;
     b.y += b.vy * ctx.tick_scale;
 
-    // 4. Rotation accumulator — skipped (cosmetic; not modeled).
+    // 4. Rotation accumulator (JS bullet.js:197). Adds `rotation_speed *
+    //    tick_scale` regardless of pattern. For patterns that overwrite
+    //    `rotation` inside step 2 (e.g. `SineWaveRotation`), this delta
+    //    composes on top of the just-written value — matching JS order
+    //    of operations exactly. For patterns whose `rotation_speed` is
+    //    0 (the default), this is a no-op.
+    b.rotation += b.rotation_speed * ctx.tick_scale;
 
     // 5. Pattern timer (JS bullet.js:200).
     b.pattern_timer += ctx.logic_tick_seconds;

--- a/server/tests/parity_enemy_bullet.rs
+++ b/server/tests/parity_enemy_bullet.rs
@@ -1,6 +1,6 @@
 //! Cross-language parity vectors for enemy-bullet ballistics (Phase 2.1).
 //!
-//! Mirrors `js/sim/bullet.js::updateEnemyBullet` for 7 movement patterns:
+//! Mirrors `js/sim/bullet.js::updateEnemyBullet` for 11 movement patterns:
 //!
 //!   - `Straight` ↔ JS `aimed` / `crescent_beam` / `crescent_slice` (no-mod
 //!     velocity path).
@@ -11,14 +11,21 @@
 //!   - `Spiral` ↔ JS `spiral` (rotating velocity vector + radius drift).
 //!   - `WaveEnergy` ↔ JS `wave_energy` (high-amplitude sin on perp axis).
 //!   - `ShieldBurst` ↔ JS `shield_burst` (high-freq sin wobble on perp axis).
+//!   - `Burst` ↔ JS `burst` (linear timer-acceleration, * 0.5 coefficient).
+//!   - `Pulse` ↔ JS `pulse` (linear timer-acceleration, * 0.8 coefficient).
+//!   - `EnergySlash` ↔ JS `energy_slash` (slashProgress curve + patternTimer
+//!     pulse intensity).
+//!   - `SineWaveRotation` ↔ JS `sine_wave` (Sine variant that aligns rotation
+//!     to travel direction via `rotation = atan2(vy, vx)`).
 //!
 //! See `server/src/sim/bullet.rs` module docstring for the deferred list
-//! (helix, homing, ricochet, rocket, mine, energy_slash, bezier, charge,
-//! etc.).
+//! (helix, homing, ricochet, rocket, mine, bezier, charge, rapid, missile,
+//! laser, etc.).
 //!
 //! Reference values were captured against the JS source by running the
 //! one-liner embedded in each fixture; both sides compute the same
-//! trajectory within an f32-tolerance of 0.01 px.
+//! trajectory within an f32-tolerance of 0.01 px (looser for trig-heavy
+//! patterns like `Spiral`).
 
 use rainboids_server::sim::bullet::{
     update_enemy_bullet, BulletEvent, BulletPattern, EnemyBullet, EnemyBulletContext,
@@ -66,6 +73,9 @@ fn default_enemy_bullet(id: u32, pattern: BulletPattern) -> EnemyBullet {
         sine_perp_y: 0.0,
         deceleration: 0.0,
         min_speed: 0.0,
+        slash_progress: 0.0,
+        rotation: 0.0,
+        rotation_speed: 0.0,
         active: true,
         expired_by_range: false,
         expired_by_bounds: false,
@@ -506,6 +516,263 @@ fn enemy_bullet_shield_burst() {
     close(b.vx, 4.00700489721131, "bullet.vx");
     close(b.vy, 2.990660137051587, "bullet.vy");
     close(b.pattern_timer, 0.41666666666666663, "bullet.pattern_timer");
+    close(b.life, 1.0, "bullet.life");
+    assert!(b.active, "bullet should still be active");
+
+    assert!(
+        events.is_empty(),
+        "unexpected despawn events for alive bullet: {:?}",
+        events,
+    );
+}
+
+// ── Fixture 8: pulse (timer-driven linear acceleration on base velocity) ─
+//
+// JS reference values captured 2026-05-10 via:
+//
+//   node --input-type=module -e "
+//     import { updateEnemyBullet } from './js/sim/bullet.js';
+//     import { freshBulletState } from './js/sim/state.js';
+//     const b = freshBulletState(8, 'enemy', { movementPattern: 'pulse',
+//         x: 200, y: 200, vx: 3, vy: 0, baseVx: 3, baseVy: 0,
+//         startX: 200, startY: 200,
+//         life: 0, maxLife: 180, damage: 10, radius: 4, baseRadius: 4,
+//         maxRange: 9999, rangeMultiplier: 1.0, active: true });
+//     const ctx = { tickScale: 0.5, logicTickSeconds: 1/60, bulletSpeed: 10,
+//         boundaryWidth: 9999, boundaryHeight: 9999, now: 0,
+//         targetPlayer: null, homingTarget: null, rngFloat: () => 0.5 };
+//     for (let i = 0; i < 25; i++) updateEnemyBullet(b, ctx, []);
+//     console.log(JSON.stringify({ x: b.x, y: b.y, vx: b.vx, vy: b.vy,
+//         patternTimer: b.patternTimer, life: b.life, active: b.active }));
+//   "
+//   → {"x":243.5,"y":200,"vx":3.96,"vy":0,
+//      "patternTimer":0.41666666666666663,"life":1,"active":true}
+//
+// vx growth confirms the formula: after 25 ticks, patternTimer = 25/60,
+// so final-tick velocity = 3 * (1 + (25/60) * 0.8) = 3 * 1.32 = 3.96.
+#[test]
+fn enemy_bullet_pulse() {
+    let mut b = default_enemy_bullet(8, BulletPattern::Pulse);
+    b.x = 200.0;
+    b.y = 200.0;
+    b.vx = 3.0;
+    b.vy = 0.0;
+    b.start_x = 200.0;
+    b.start_y = 200.0;
+    b.base_vx = 3.0;
+    b.base_vy = 0.0;
+    b.life = 0.0;
+
+    let ctx = default_ctx();
+    let mut events: Vec<BulletEvent> = Vec::new();
+    for _ in 0..25 {
+        update_enemy_bullet(&mut b, &ctx, &mut events);
+    }
+
+    close(b.x, 243.5, "bullet.x");
+    close(b.y, 200.0, "bullet.y");
+    close(b.vx, 3.96, "bullet.vx");
+    close(b.vy, 0.0, "bullet.vy");
+    close(b.pattern_timer, 0.41666666666666663, "bullet.pattern_timer");
+    close(b.life, 1.0, "bullet.life");
+    assert!(b.active, "bullet should still be active");
+
+    assert!(
+        events.is_empty(),
+        "unexpected despawn events for alive bullet: {:?}",
+        events,
+    );
+}
+
+// ── Fixture 9: burst (same shape as pulse, gentler coefficient) ──────────
+//
+// JS reference values captured 2026-05-10 via:
+//
+//   node --input-type=module -e "
+//     import { updateEnemyBullet } from './js/sim/bullet.js';
+//     import { freshBulletState } from './js/sim/state.js';
+//     const b = freshBulletState(9, 'enemy', { movementPattern: 'burst',
+//         x: 100, y: 100, vx: 2, vy: 1, baseVx: 2, baseVy: 1,
+//         startX: 100, startY: 100,
+//         life: 0, maxLife: 180, damage: 10, radius: 4, baseRadius: 4,
+//         maxRange: 9999, rangeMultiplier: 1.0, active: true });
+//     const ctx = { tickScale: 0.5, logicTickSeconds: 1/60, bulletSpeed: 10,
+//         boundaryWidth: 9999, boundaryHeight: 9999, now: 0,
+//         targetPlayer: null, homingTarget: null, rngFloat: () => 0.5 };
+//     for (let i = 0; i < 30; i++) updateEnemyBullet(b, ctx, []);
+//     console.log(JSON.stringify({ x: b.x, y: b.y, vx: b.vx, vy: b.vy,
+//         patternTimer: b.patternTimer, life: b.life, active: b.active }));
+//   "
+//   → {"x":133.625,"y":116.8125,
+//      "vx":2.4833333333333334,"vy":1.2416666666666667,
+//      "patternTimer":0.49999999999999994,"life":1,"active":true}
+//
+// vx growth confirms the formula: after 30 ticks, patternTimer = 30/60 = 0.5,
+// so final-tick velocity = base * (1 + 0.5 * 0.5) = base * 1.25.
+// 2.0 * 1.25 ≈ 2.4833 (uses pre-update timer of 29/60, not 30/60, since the
+// pattern step runs BEFORE the timer increment).
+#[test]
+fn enemy_bullet_burst() {
+    let mut b = default_enemy_bullet(9, BulletPattern::Burst);
+    b.x = 100.0;
+    b.y = 100.0;
+    b.vx = 2.0;
+    b.vy = 1.0;
+    b.start_x = 100.0;
+    b.start_y = 100.0;
+    b.base_vx = 2.0;
+    b.base_vy = 1.0;
+    b.life = 0.0;
+
+    let ctx = default_ctx();
+    let mut events: Vec<BulletEvent> = Vec::new();
+    for _ in 0..30 {
+        update_enemy_bullet(&mut b, &ctx, &mut events);
+    }
+
+    close(b.x, 133.625, "bullet.x");
+    close(b.y, 116.8125, "bullet.y");
+    close(b.vx, 2.4833333333333334, "bullet.vx");
+    close(b.vy, 1.2416666666666667, "bullet.vy");
+    close(b.pattern_timer, 0.49999999999999994, "bullet.pattern_timer");
+    close(b.life, 1.0, "bullet.life");
+    assert!(b.active, "bullet should still be active");
+
+    assert!(
+        events.is_empty(),
+        "unexpected despawn events for alive bullet: {:?}",
+        events,
+    );
+}
+
+// ── Fixture 10: energy_slash (slashProgress curve + patternTimer pulse) ──
+//
+// JS reference values captured 2026-05-10 via (note: slashProgress is set
+// explicitly because `freshBulletState` doesn't propagate it):
+//
+//   node --input-type=module -e "
+//     import { updateEnemyBullet } from './js/sim/bullet.js';
+//     import { freshBulletState } from './js/sim/state.js';
+//     const b = freshBulletState(10, 'enemy', { movementPattern: 'energy_slash',
+//         x: 200, y: 200, vx: 4, vy: 0, baseVx: 4, baseVy: 0,
+//         startX: 200, startY: 200,
+//         life: 0, maxLife: 180, damage: 10, radius: 4, baseRadius: 4,
+//         maxRange: 9999, rangeMultiplier: 1.0, active: true });
+//     b.slashProgress = 0.5;
+//     const ctx = { tickScale: 0.5, logicTickSeconds: 1/60, bulletSpeed: 10,
+//         boundaryWidth: 9999, boundaryHeight: 9999, now: 0,
+//         targetPlayer: null, homingTarget: null, rngFloat: () => 0.5 };
+//     for (let i = 0; i < 25; i++) updateEnemyBullet(b, ctx, []);
+//     console.log(JSON.stringify({ x: b.x, y: b.y, vx: b.vx, vy: b.vy,
+//         patternTimer: b.patternTimer, life: b.life, active: b.active }));
+//   "
+//   → {"x":252.98716277798522,"y":203.9740372083489,
+//      "vx":3.976650342628968,"vy":0.2982487756971726,
+//      "patternTimer":0.41666666666666663,"life":1,"active":true}
+//
+// slashProgress = 0.5 → sin(0.5π) = 1, so curveOffset = 0.3 (max). The perp
+// of baseVx=4,baseVy=0 is (0, 1), so curve adds 0.3 to vy each tick. Pulse
+// intensity = 1 + sin(t*8)*0.1 modulates the result modestly.
+#[test]
+fn enemy_bullet_energy_slash() {
+    let mut b = default_enemy_bullet(10, BulletPattern::EnergySlash);
+    b.x = 200.0;
+    b.y = 200.0;
+    b.vx = 4.0;
+    b.vy = 0.0;
+    b.start_x = 200.0;
+    b.start_y = 200.0;
+    b.base_vx = 4.0;
+    b.base_vy = 0.0;
+    b.slash_progress = 0.5;
+    b.life = 0.0;
+
+    let ctx = default_ctx();
+    let mut events: Vec<BulletEvent> = Vec::new();
+    for _ in 0..25 {
+        update_enemy_bullet(&mut b, &ctx, &mut events);
+    }
+
+    close(b.x, 252.98716277798522, "bullet.x");
+    close(b.y, 203.9740372083489, "bullet.y");
+    close(b.vx, 3.976650342628968, "bullet.vx");
+    close(b.vy, 0.2982487756971726, "bullet.vy");
+    close(b.pattern_timer, 0.41666666666666663, "bullet.pattern_timer");
+    close(b.life, 1.0, "bullet.life");
+    assert!(b.active, "bullet should still be active");
+
+    assert!(
+        events.is_empty(),
+        "unexpected despawn events for alive bullet: {:?}",
+        events,
+    );
+}
+
+// ── Fixture 11: sine_wave (Sine + rotation-alignment + rotation_speed) ───
+//
+// JS reference values captured 2026-05-10 via:
+//
+//   node --input-type=module -e "
+//     import { updateEnemyBullet } from './js/sim/bullet.js';
+//     import { freshBulletState } from './js/sim/state.js';
+//     const b = freshBulletState(11, 'enemy', { movementPattern: 'sine_wave',
+//         x: 300, y: 300, vx: 4, vy: 0, baseVx: 4, baseVy: 0,
+//         startX: 300, startY: 300,
+//         sinePhase: 0, sineFreq: 0.15, sineAmp: 20,
+//         sinePerpX: 0, sinePerpY: 1,
+//         rotation: 0, rotationSpeed: 0.05,
+//         life: 0, maxLife: 180, damage: 10, radius: 4, baseRadius: 4,
+//         maxRange: 9999, rangeMultiplier: 1.0, active: true });
+//     const ctx = { tickScale: 0.5, logicTickSeconds: 1/60, bulletSpeed: 10,
+//         boundaryWidth: 9999, boundaryHeight: 9999, now: 0,
+//         targetPlayer: null, homingTarget: null, rngFloat: () => 0.5 };
+//     for (let i = 0; i < 20; i++) updateEnemyBullet(b, ctx, []);
+//     console.log(JSON.stringify({ x: b.x, y: b.y, vx: b.vx, vy: b.vy,
+//         sinePhase: b.sinePhase, rotation: b.rotation,
+//         life: b.life, active: b.active }));
+//   "
+//   → {"x":340,"y":433.1229240873557,"vx":4,"vy":2.822400161197362,
+//      "sinePhase":2.999999999999999,"rotation":0.6394745011005886,
+//      "life":1,"active":true}
+//
+// Position / velocity / sine_phase match the `sine_offset` fixture exactly
+// (the only difference between `Sine` and `SineWaveRotation` is the rotation
+// write). Final rotation = atan2(2.8224, 4.0) + rotation_speed * tick_scale =
+//   0.6144745 + 0.05 * 0.5 ≈ 0.6394745. Only the LAST tick's
+// `rotation_speed * tick_scale` survives — every earlier tick's accumulator
+// is overwritten by the next pattern step's atan2 write.
+#[test]
+fn enemy_bullet_sine_wave_rotation() {
+    let mut b = default_enemy_bullet(11, BulletPattern::SineWaveRotation);
+    b.x = 300.0;
+    b.y = 300.0;
+    b.vx = 4.0;
+    b.vy = 0.0;
+    b.start_x = 300.0;
+    b.start_y = 300.0;
+    b.base_vx = 4.0;
+    b.base_vy = 0.0;
+    b.sine_phase = 0.0;
+    b.sine_freq = 0.15;
+    b.sine_amp = 20.0;
+    b.sine_perp_x = 0.0;
+    b.sine_perp_y = 1.0;
+    b.rotation = 0.0;
+    b.rotation_speed = 0.05;
+    b.life = 0.0;
+
+    let ctx = default_ctx();
+    let mut events: Vec<BulletEvent> = Vec::new();
+    for _ in 0..20 {
+        update_enemy_bullet(&mut b, &ctx, &mut events);
+    }
+
+    close(b.x, 340.0, "bullet.x");
+    close(b.y, 433.1229240873557, "bullet.y");
+    close(b.vx, 4.0, "bullet.vx");
+    close(b.vy, 2.822400161197362, "bullet.vy");
+    close(b.sine_phase, 2.999999999999999, "bullet.sine_phase");
+    close(b.rotation, 0.6394745011005886, "bullet.rotation");
     close(b.life, 1.0, "bullet.life");
     assert!(b.active, "bullet should still be active");
 


### PR DESCRIPTION
## Summary
Brings enemy-bullet pattern coverage from **7/17** (PR #33) to **11/17**. All 4 new patterns are pure trig + timer; no target_player, no RNG, no persistent-timed lifetime.

## New `BulletPattern` variants
| Variant | JS source | Notes |
|---|---|---|
| `Burst` | bullet.js:327-332 | `vx = baseVx * (1 + patternTimer * 0.5)` |
| `Pulse` | bullet.js:477-482 | Same shape as Burst, coefficient 0.8 |
| `EnergySlash` | bullet.js:505-519 | `sin(slashProgress*π)*0.3` curve + `sin(timer*8)*0.1` pulse |
| `SineWaveRotation` | bullet.js:526-534 | Sine variant + writes rotation; composes with global rotation accumulator |

## New `EnemyBullet` fields
- `slash_progress: f32` (state.js:474, EnergySlash)
- `rotation: f32` (state.js:433, rotation accumulator + SineWaveRotation)
- `rotation_speed: f32` (state.js:434, drives accumulator; default 0.0)

## New constants (JS line refs)
- `BURST_ACCEL_RATE = 0.5` (bullet.js:328)
- `PULSE_ACCEL_RATE = 0.8` (bullet.js:478)
- `ENERGY_SLASH_CURVE_INTENSITY = 0.3` (bullet.js:507)
- `ENERGY_SLASH_PULSE_FREQ = 8.0` (bullet.js:515)
- `ENERGY_SLASH_PULSE_AMP = 0.1` (bullet.js:515)

## New step in `update_enemy_bullet`
**Step 4 — rotation accumulator**: `b.rotation += b.rotation_speed * ctx.tick_scale` (bullet.js:197). Composes with patterns that overwrite rotation inside step 2 (e.g. SineWaveRotation). **No-op for existing patterns** since default `rotation_speed = 0.0` — backward compat preserved.

## Test plan
- [x] `cargo test --test parity_enemy_bullet` — 11 passed (7 existing + 4 new)
- [x] All 59 workspace tests green; build clean
- [x] All 7 existing patterns still pass

## Phase 2.1 enemy bullet progress (task #45)
- ✓ Patterns 1-3 (PR #29): Straight, Sine, Decelerate
- ✓ Patterns 4-7 (PR #33): Spread, Spiral, WaveEnergy, ShieldBurst
- ✓ Patterns 8-11 (this PR): Burst, Pulse, EnergySlash, SineWaveRotation
- ⬜ 6 remaining: mine, homing_mine, rapid, laser/laser_beam, missile/homing/titan_homing/titan_rocket/missile_fast_slow, explosive (all need RNG, target_player, persistent timed-lifetime, or combinations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)