### PR TITLE
mp/sim: js/sim/collision.js player-vs-enemy pure step (Phase 2.5)

### DIFF
--- a/js/sim/collision.js
+++ b/js/sim/collision.js
@@ -890,3 +890,320 @@ export function detectBulletEnemyHits(bullets, enemies, ctx, events) {
         }
     }
 }
+
+// =====================================================================
+// PLAYER ↔ ENEMY — Phase 2.5 dispatch 4
+// =====================================================================
+//
+// IMPORTANT: This pair uses DIFFERENT math than `detectPlayerAsteroidHits`.
+// The legacy `handlePlayerEnemyCollision` (collision-system.js:1657-1819)
+// does NOT use the heavier `ASTEROID_KNOCKBACK_MULTIPLIER` + jittered-atan2
+// path. Instead it runs a textbook restitution-based impulse model:
+//
+//   1. Normalize collision direction (player.x - enemy.x, ...) / distance
+//   2. relativeVel = player.vel - enemy.vel
+//   3. velAlongNormal = relativeVel · normal
+//   4. IF velAlongNormal > 0 (separating) → BAIL, no impulse applied
+//   5. impulseScalar = -(1 + BOUNCE_RESTITUTION) · velAlongNormal
+//                      / (playerMass + enemyMass)
+//   6. impulse = impulseScalar · normal
+//   7. player.vel += impulse · enemyMass · BOUNCE_FORCE_MULTIPLIER
+//   8. enemy.vel  -= impulse · playerMass · BOUNCE_FORCE_MULTIPLIER
+//
+// And separation uses `OVERLAP_SEPARATION_RATIO * overlap` SPLIT between
+// the two bodies (both move, ratio rather than full overlap + buffer);
+// NO `OVERLAP_PUSH_FORCE` velocity nudge is applied — that constant is
+// asteroid-pair only.
+//
+// What stays the same as player-vs-asteroid:
+//   - Circle-circle geometry check.
+//   - Inactive-side / warping / death-flash skip gates (enemy-side
+//     `_deathFlash` is the legacy name).
+//   - Pure-step discipline: emit one event per hit, never mutate either
+//     side's HP / vel / position directly. The wrapper applies the
+//     reported deltas.
+//
+// What does NOT live in this module at all (stays in the wrapper):
+//   - Damage application to player.hp / enemy.hp (legacy: takeDamage)
+//   - Shield / Bulwark / Phase-Dash damage reduction
+//   - Tank consumption / death handling on player HP ≤ 0
+//   - Enemy death-flash trigger (_deathFlash = 8) and drops / XP / kills
+//   - Boss-rage enrage trigger              (legacy: boss reactive logic)
+//   - Hit-flash visuals, hit-stop, camera kick, screen shake, audio
+//   - Damage numbers, sparks, post-hit invincibility
+//
+// Source-of-truth lines in `js/modules/combat/collision-system.js`:
+//   - Player-side damage block:      1658-1731
+//   - Enemy.takeDamage + death-flash:1733-1751
+//   - Bounce / impulse model:        1753-1794
+//   - Separation push:               1796-1806
+//   - Impact particles:              1809-1815  (presentation only)
+
+// ─── Constants — Player-vs-enemy pair ───────────────────────────────
+//
+// Mirror `COLLISION_CONFIG` entries from
+// `js/modules/combat/collision-system.js`. Numerical parity with the
+// legacy module is enforced by tests below.
+
+/**
+ * Damage dealt to enemy when player collides with it. Mirrors
+ * `COLLISION_CONFIG.PLAYER_ENEMY_COLLISION_DAMAGE = 5`. Higher than the
+ * asteroid equivalent (2) but still tiny relative to enemy HP, by
+ * design: ramming enemies is intentionally a *bad* strategy — the
+ * player gets bounced off (see `BOUNCE_FORCE_MULTIPLIER`) while only
+ * chipping the enemy. Killing via collision takes many rams, each
+ * costing the player health.
+ */
+export const PLAYER_ENEMY_COLLISION_DAMAGE = 5;
+
+// NOTE: BOUNCE_RESTITUTION (0.9), BOUNCE_FORCE_MULTIPLIER (12.0), and
+// OVERLAP_SEPARATION_RATIO (0.6) — all consumed by this pair — are
+// already exported from the player-vs-asteroid block above. We do NOT
+// re-export them under enemy-specific aliases; the wrapper / Rust mirror
+// uses the same constant values for the bounce-pair path regardless of
+// which pair it dispatches.
+
+// ─── Player-vs-enemy pair detection ─────────────────────────────────
+
+/**
+ * Detect player-vs-enemy collisions for one tick.
+ *
+ * Pure step: reads player + enemy positions / radii / velocities,
+ * decides which pairs overlap, and emits one `player_hit_enemy` event
+ * per detected hit with the velocity + position *deltas* the wrapper
+ * applies to the live state. Does NOT mutate player or enemy — every
+ * effect is reported in the event payload for the wrapper / Rust mirror
+ * to apply downstream.
+ *
+ * Co-op ready: takes an array of players. The solo wrapper passes
+ * `[player]`; future co-op sessions will pass the full ship roster.
+ * Each player is scanned against every active enemy; one player can
+ * emit multiple events per tick if it overlaps multiple enemies
+ * simultaneously (e.g. caught in a swarm).
+ *
+ * Geometry:
+ *   Circle-circle overlap: `hypot(dx, dy) < player.radius + enemy.radius`.
+ *   Identical to the legacy `collision()` helper.
+ *
+ * Bounce / impulse model (mirrors lines 1753-1794 of
+ * `collision-system.js::handlePlayerEnemyCollision`):
+ *
+ *   nx, ny         = (player.x - enemy.x, player.y - enemy.y) / distance
+ *   relVx, relVy   = (player.vx - enemy.vx, player.vy - enemy.vy)
+ *   velAlongNormal = relVx · nx + relVy · ny
+ *
+ *   IF velAlongNormal > 0  (separating)  →  BAIL — geometry overlap is
+ *      reported in the event but impulse and separation deltas are all
+ *      zero. The wrapper still applies damage on these "graze" frames;
+ *      this matches the legacy behavior (damage block at line 1658
+ *      runs unconditionally on overlap, the bounce block at line 1758
+ *      gates on `velAlongNormal > 0`).
+ *
+ *   impulseScalar  = -(1 + BOUNCE_RESTITUTION) · velAlongNormal
+ *                    / (playerMass + enemyMass)
+ *   impulseX       = impulseScalar · nx
+ *   impulseY       = impulseScalar · ny
+ *
+ *   playerImpulseDx = impulseX · enemyMass  · BOUNCE_FORCE_MULTIPLIER
+ *   playerImpulseDy = impulseY · enemyMass  · BOUNCE_FORCE_MULTIPLIER
+ *   enemyImpulseDx  = -impulseX · playerMass · BOUNCE_FORCE_MULTIPLIER
+ *   enemyImpulseDy  = -impulseY · playerMass · BOUNCE_FORCE_MULTIPLIER
+ *
+ * Separation push (mirrors lines 1796-1806):
+ *   If `overlap = (player.r + enemy.r) - distance > 0`:
+ *     - separationForce = overlap · OVERLAP_SEPARATION_RATIO
+ *     - Player position delta:  +(nx, ny) · separationForce
+ *     - Enemy  position delta:  -(nx, ny) · separationForce  (reported
+ *       via enemySeparationDx/Dy fields; wrapper applies if !destroyed)
+ *   No `OVERLAP_PUSH_FORCE` velocity nudge — that's asteroid-pair only.
+ *
+ * Enemy damage:
+ *   Constant `PLAYER_ENEMY_COLLISION_DAMAGE = 5`. The wrapper subtracts
+ *   this from `enemy.hp` and handles death-flash + drops + kill streak.
+ *   The pure step just reports the number.
+ *
+ * Skipped pairs (no event emitted):
+ *   - Inactive player    (`!player.active`)
+ *   - Inactive enemy     (`!enemy.active`)
+ *   - Warping enemy      (`enemy.warping`, mid warp-in animation)
+ *   - Enemy mid-death    (`enemy.deathFlash > 0` or legacy
+ *                         `enemy._deathFlash > 0`)
+ *
+ * NOTE: Unlike asteroids, players themselves have no `_deathFlash` /
+ * `warping` gate on the player side — the legacy path only checks
+ * `player.active` (and the wrapper handles `player.invincible` as a
+ * damage-reduction layer, not a collision skip). The pure step matches
+ * that: invincibility is a wrapper concern, not a geometry concern.
+ *
+ * Boss-rage trigger:
+ *   The legacy `enemy.takeDamage()` call inside `handlePlayerEnemyCollision`
+ *   can trigger boss-rage / enrage logic via `notifyBossDeath` and the
+ *   `onEnemyKill` chain. ALL of that stays in the wrapper. The pure step
+ *   reports only the geometric / mechanical hit; the wrapper decides
+ *   whether the damage triggers rage, enrage, drops, etc.
+ *
+ * @param {Array<Object>} players   active player ships. Each treated as
+ *                                  having `{x, y, vx OR vel.x, vy OR
+ *                                  vel.y, radius, mass?, active, id OR
+ *                                  player}`. Compatible with both the
+ *                                  `ShipState` typedef in
+ *                                  `js/sim/state.js` and the live
+ *                                  `Player` instance shape.
+ * @param {Array<Object>} enemies   active enemies. Each treated as having
+ *                                  `{x, y, vx OR vel.x, vy OR vel.y,
+ *                                  radius, mass?, active, warping,
+ *                                  deathFlash OR _deathFlash, id}`.
+ * @param {Object} ctx              per-tick context bag (currently
+ *                                  unused; reserved for future use, e.g.
+ *                                  a one-punch-man cheat flag or a
+ *                                  spatial-grid filter).
+ * @param {Array<Object>} events    out-buffer. Pushes objects with the
+ *                                  shape documented below.
+ *
+ * Event shape (one event per detected hit):
+ *   {
+ *     type: 'player_hit_enemy',
+ *     playerId:               id of the colliding ship
+ *     enemyId:                id of the colliding enemy
+ *     damageToEnemy:          constant 5 (see PLAYER_ENEMY_COLLISION_DAMAGE)
+ *     playerImpulseDx,
+ *     playerImpulseDy:        velocity delta the wrapper adds to
+ *                             `player.vel` (legacy) or `player.vx/vy`.
+ *                             Zero if velAlongNormal > 0 (separating).
+ *     enemyImpulseDx,
+ *     enemyImpulseDy:         velocity delta the wrapper adds to the
+ *                             enemy's velocity. Zero on separating-pair
+ *                             or if the wrapper destroyed the enemy
+ *                             (wrapper-side gate per legacy line 1791).
+ *     separationDx,
+ *     separationDy:           position delta the wrapper adds to
+ *                             `player.x` / `player.y` to move the ship
+ *                             clear of the enemy. Zero if no overlap.
+ *     enemySeparationDx,
+ *     enemySeparationDy:      position delta the wrapper adds to
+ *                             `enemy.x` / `enemy.y` (negative of the
+ *                             player separation — moves enemy AWAY from
+ *                             player). Wrapper applies if !destroyed.
+ *   }
+ */
+export function detectPlayerEnemyHits(players, enemies, ctx, events) {
+    if (!players || !enemies) return;
+    if (players.length === 0 || enemies.length === 0) return;
+
+    for (let i = 0; i < players.length; i++) {
+        const player = players[i];
+        if (!player || !player.active) continue;
+
+        const playerRadius = player.radius || 0;
+        const playerVel = entityVel(player);
+        const playerMass = entityMass(player, 'player');
+        const pId = entityId(player);
+
+        for (let j = 0; j < enemies.length; j++) {
+            const enemy = enemies[j];
+            if (!enemy || !enemy.active) continue;
+            if (enemy.warping) continue;
+
+            // Death-flash gate — accept either the new sim field name
+            // (`deathFlash`) or the legacy underscore-prefix
+            // (`_deathFlash`). Live `Enemy` instances use the legacy
+            // name; future `EnemyState` will use the new one.
+            const dF = enemy.deathFlash !== undefined
+                ? enemy.deathFlash
+                : enemy._deathFlash;
+            if (dF && dF > 0) continue;
+
+            // Circle-circle overlap check.
+            const dx = player.x - enemy.x;
+            const dy = player.y - enemy.y;
+            const sumR = playerRadius + (enemy.radius || 0);
+            const distSq = dx * dx + dy * dy;
+            if (distSq >= sumR * sumR) continue;
+
+            // ── Hit detected — compute impulse + separation ──
+
+            const enemyVel = entityVel(enemy);
+            // Enemies have no special radius-to-mass formula in the live
+            // game; the `Enemy` class assigns `mass` directly per type.
+            // When `mass` isn't set on the state object we fall back to
+            // the same circle-disk formula `entityMass(., 'player')`
+            // uses, which is a sane default for any ship-like body.
+            const enemyMass = (enemy.mass !== undefined && enemy.mass !== null)
+                ? enemy.mass
+                : entityMass(enemy, 'player');
+
+            const distance = Math.sqrt(distSq);
+
+            // Default deltas to zero so a degenerate (distance === 0)
+            // hit still emits a well-formed event with the correct
+            // ids + damage but no nonsense math.
+            let playerImpulseDx = 0;
+            let playerImpulseDy = 0;
+            let enemyImpulseDx = 0;
+            let enemyImpulseDy = 0;
+            let separationDx = 0;
+            let separationDy = 0;
+            let enemySeparationDx = 0;
+            let enemySeparationDy = 0;
+
+            if (distance > 0) {
+                // Normalize the collision axis (enemy → player).
+                const nx = dx / distance;
+                const ny = dy / distance;
+
+                // Relative velocity, projected onto the normal.
+                const relVx = playerVel.x - enemyVel.x;
+                const relVy = playerVel.y - enemyVel.y;
+                const velAlongNormal = relVx * nx + relVy * ny;
+
+                // Only apply impulse when bodies are approaching (the
+                // textbook "do not resolve separating velocities"
+                // guard). Mirrors legacy line 1771: `if
+                // (velAlongNormal > 0) return;`. NOTE the asymmetry
+                // with the asteroid pair: the asteroid path NEVER
+                // gates here, it always applies the jittered knockback.
+                if (velAlongNormal <= 0) {
+                    const totalMass = playerMass + enemyMass;
+                    if (totalMass > 0) {
+                        const impulseScalar =
+                            -(1 + BOUNCE_RESTITUTION) * velAlongNormal / totalMass;
+                        const impulseX = impulseScalar * nx;
+                        const impulseY = impulseScalar * ny;
+
+                        playerImpulseDx = impulseX * enemyMass * BOUNCE_FORCE_MULTIPLIER;
+                        playerImpulseDy = impulseY * enemyMass * BOUNCE_FORCE_MULTIPLIER;
+                        enemyImpulseDx = -impulseX * playerMass * BOUNCE_FORCE_MULTIPLIER;
+                        enemyImpulseDy = -impulseY * playerMass * BOUNCE_FORCE_MULTIPLIER;
+                    }
+                }
+
+                // Separation push — applied independent of the
+                // velAlongNormal gate (legacy splits the position
+                // resolution out from the bounce; see lines 1796-1806).
+                const overlap = sumR - distance;
+                if (overlap > 0) {
+                    const separationForce = overlap * OVERLAP_SEPARATION_RATIO;
+                    separationDx = nx * separationForce;
+                    separationDy = ny * separationForce;
+                    enemySeparationDx = -nx * separationForce;
+                    enemySeparationDy = -ny * separationForce;
+                }
+            }
+
+            events.push({
+                type: 'player_hit_enemy',
+                playerId: pId,
+                enemyId: enemy.id,
+                damageToEnemy: PLAYER_ENEMY_COLLISION_DAMAGE,
+                playerImpulseDx,
+                playerImpulseDy,
+                enemyImpulseDx,
+                enemyImpulseDy,
+                separationDx,
+                separationDy,
+                enemySeparationDx,
+                enemySeparationDy,
+            });
+        }
+    }
+}

--- a/tests/unit/sim/collision.test.js
+++ b/tests/unit/sim/collision.test.js
@@ -32,6 +32,8 @@ import {
     detectBulletEnemyHits,
     BULLET_ENEMY_KNOCKBACK,
     BULLET_ENEMY_HIT_FLASH_FRAMES,
+    detectPlayerEnemyHits,
+    PLAYER_ENEMY_COLLISION_DAMAGE,
 } from '../../../js/sim/collision.js';
 import {
     freshAsteroidState,
@@ -970,5 +972,366 @@ describe('detectBulletEnemyHits — damage propagation', () => {
         const events = [];
         detectBulletEnemyHits([b], [e], ctx, events);
         expect(events[0].damage).toBe(1);
+    });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// Player-vs-enemy pair (Phase 2.5 — dispatch 4).
+// ═════════════════════════════════════════════════════════════════════
+//
+// `detectPlayerEnemyHits` is the fourth pure-step pair extracted from the
+// legacy `handlePlayerEnemyCollision` in `js/modules/combat/collision-system.js`
+// (lines 1657-1819). The legacy path bundles damage + visuals + audio +
+// camera kicks + tank consumption + boss-rage triggers; the pure step
+// reports only the mechanical deltas — impulse + separation deltas for
+// BOTH bodies — that the wrapper applies to live state.
+//
+// IMPORTANT — math is DIFFERENT from the asteroid pair:
+//   - Asteroid pair: jittered atan2-knockback × ASTEROID_KNOCKBACK_MULTIPLIER
+//     (22.0), separation = overlap + SEPARATION_BUFFER, plus OVERLAP_PUSH_FORCE
+//     velocity nudge. The asteroid path ALWAYS applies the knockback.
+//   - Enemy pair: textbook restitution impulse model with `-(1 + R) · vN /
+//     totalMass`, BOUNCE_FORCE_MULTIPLIER (12.0), separation =
+//     overlap × OVERLAP_SEPARATION_RATIO split between both bodies, NO
+//     velocity push-force nudge. The enemy path BAILS on velAlongNormal > 0
+//     (separating velocities) — only the geometric overlap is emitted in
+//     that case (and the wrapper still applies damage).
+//
+// The tests below pin:
+//   - the damage constant (5, vs 2 for asteroids)
+//   - geometry overlap (circle-circle)
+//   - all event payload fields (impulse + separation for BOTH bodies)
+//   - skip gates (inactive / warping / death-flash on enemy side)
+//   - multiple enemies in one tick
+//   - bounce direction (eastbound player off a westward enemy ⇒ westbound impulse)
+//   - separating velocities bail-out (no impulse, but separation still applies)
+//   - defensive empty / null inputs
+
+// ---------------------------------------------------------------------
+// Helpers — build player + enemy pairs. `makePlayer` and `enemyWithRadius`
+// are already defined for earlier dispatches; reuse them here. Enemy
+// needs a `mass` field set for the impulse math (live `Enemy` instances
+// assign mass directly per type).
+// ---------------------------------------------------------------------
+
+/** Build an enemy with explicit radius + mass + velocity. Default mass=200
+ *  matches a small-to-medium enemy ship in the live game. */
+function makeEnemy(id, x, y, overrides = {}) {
+    const e = enemyWithRadius(id, x, y, overrides.radius || 18, {
+        active: overrides.active,
+        warping: overrides.warping,
+        deathFlash: overrides.deathFlash,
+        _deathFlash: overrides._deathFlash,
+        vx: overrides.vx,
+        vy: overrides.vy,
+    });
+    e.mass = overrides.mass !== undefined ? overrides.mass : 200;
+    return e;
+}
+
+// ---------------------------------------------------------------------
+// Constants — pinned to the legacy COLLISION_CONFIG block.
+// ---------------------------------------------------------------------
+
+describe('player-enemy collision constants', () => {
+    test('PLAYER_ENEMY_COLLISION_DAMAGE is 5 (verbatim from collision-system.js)', () => {
+        expect(PLAYER_ENEMY_COLLISION_DAMAGE).toBe(5);
+    });
+    // Reused constants — pinned here as a defensive parity guard for the
+    // enemy pair specifically. They were already pinned for the asteroid
+    // pair above, but if those constants ever drift the enemy pair tests
+    // will catch the breakage independently.
+    test('BOUNCE_RESTITUTION still 0.9 (consumed by player-enemy bounce)', () => {
+        expect(BOUNCE_RESTITUTION).toBe(0.9);
+    });
+    test('BOUNCE_FORCE_MULTIPLIER still 12.0 (consumed by player-enemy bounce)', () => {
+        expect(BOUNCE_FORCE_MULTIPLIER).toBe(12.0);
+    });
+    test('OVERLAP_SEPARATION_RATIO still 0.6 (consumed by player-enemy separation)', () => {
+        expect(OVERLAP_SEPARATION_RATIO).toBe(0.6);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — single overlapping pair emits one fully-populated event.
+// ---------------------------------------------------------------------
+
+describe('detectPlayerEnemyHits — single hit', () => {
+    test('overlapping player + enemy emits one event with all 12 fields', () => {
+        // Player radius 15, enemy radius 18 ⇒ sumR = 33.
+        // Place player and enemy 20 px apart on x-axis ⇒ overlap = 13.
+        // Player moving east (vx=8), enemy still ⇒ approaching (vAN < 0).
+        const p = makePlayer('p1', 100, 100, { vx: 8, vy: 0 });
+        const e = makeEnemy(10, 120, 100, { vx: 0, vy: 0 });
+        const events = [];
+        detectPlayerEnemyHits([p], [e], ctx, events);
+
+        expect(events).toHaveLength(1);
+        const ev = events[0];
+        expect(ev.type).toBe('player_hit_enemy');
+        expect(ev.playerId).toBe('p1');
+        expect(ev.enemyId).toBe(10);
+        expect(ev.damageToEnemy).toBe(PLAYER_ENEMY_COLLISION_DAMAGE);
+        expect(ev.damageToEnemy).toBe(5);
+        // All eight numeric delta fields must be defined and finite.
+        const deltaFields = [
+            'playerImpulseDx', 'playerImpulseDy',
+            'enemyImpulseDx', 'enemyImpulseDy',
+            'separationDx', 'separationDy',
+            'enemySeparationDx', 'enemySeparationDy',
+        ];
+        for (const f of deltaFields) {
+            expect(typeof ev[f]).toBe('number');
+            expect(Number.isFinite(ev[f])).toBe(true);
+        }
+        // Field-key guard — exactly 12 keys, none silently dropped.
+        expect(Object.keys(ev).sort()).toEqual([
+            'damageToEnemy', 'enemyId', 'enemyImpulseDx', 'enemyImpulseDy',
+            'enemySeparationDx', 'enemySeparationDy',
+            'playerId', 'playerImpulseDx', 'playerImpulseDy',
+            'separationDx', 'separationDy', 'type',
+        ].sort());
+        // Geometry overlapped ⇒ separation must be nonzero on the
+        // collision axis (x here). Player gets pushed west (negative).
+        expect(ev.separationDx).toBeLessThan(0);
+        expect(ev.separationDy).toBe(0);
+        // Enemy separation is the mirror image — enemy gets pushed east.
+        expect(ev.enemySeparationDx).toBeGreaterThan(0);
+        expect(ev.enemySeparationDx).toBeCloseTo(-ev.separationDx, 10);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — geometry miss.
+// ---------------------------------------------------------------------
+
+describe('detectPlayerEnemyHits — geometry miss', () => {
+    test('player outside (player.r + enemy.r) emits no event', () => {
+        const p = makePlayer('p1', 0, 0);
+        // 200 ≫ sumR=33 → clearly no overlap.
+        const e = makeEnemy(10, 200, 0);
+        const events = [];
+        detectPlayerEnemyHits([p], [e], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+
+    test('player just outside boundary (sumR + 1) emits no event', () => {
+        const p = makePlayer('p1', 0, 0, { radius: 15 });
+        // sumR = 33; place enemy center 34 px away → just outside.
+        const e = makeEnemy(10, 34, 0, { radius: 18 });
+        const events = [];
+        detectPlayerEnemyHits([p], [e], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — one player overlapping multiple enemies ⇒ multiple events.
+// ---------------------------------------------------------------------
+
+describe('detectPlayerEnemyHits — multiple enemies in one tick', () => {
+    test('player caught between two enemies emits two events', () => {
+        const p = makePlayer('p1', 100, 100, { vx: 0, vy: 0 });
+        // Place enemies east + west, both close enough to overlap
+        // (sumR=33, place them 20 px out).
+        const east = makeEnemy(10, 120, 100);
+        const west = makeEnemy(20,  80, 100);
+        const events = [];
+        detectPlayerEnemyHits([p], [east, west], ctx, events);
+        expect(events).toHaveLength(2);
+        const ids = events.map(e => e.enemyId).sort((a, b) => a - b);
+        expect(ids).toEqual([10, 20]);
+        for (const ev of events) {
+            expect(ev.playerId).toBe('p1');
+            expect(ev.type).toBe('player_hit_enemy');
+            expect(ev.damageToEnemy).toBe(5);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — skip gates (inactive / warping / death-flash on enemy side).
+// ---------------------------------------------------------------------
+
+describe('detectPlayerEnemyHits — skipped pairs', () => {
+    test('inactive player → no event', () => {
+        const p = makePlayer('p1', 100, 100, { active: false });
+        const e = makeEnemy(10, 120, 100);
+        const events = [];
+        detectPlayerEnemyHits([p], [e], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+
+    test('inactive enemy → no event', () => {
+        const p = makePlayer('p1', 100, 100);
+        const e = makeEnemy(10, 120, 100, { active: false });
+        const events = [];
+        detectPlayerEnemyHits([p], [e], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+
+    test('warping enemy → no event', () => {
+        const p = makePlayer('p1', 100, 100);
+        const e = makeEnemy(10, 120, 100, { warping: true });
+        const events = [];
+        detectPlayerEnemyHits([p], [e], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+
+    test('enemy mid death-flash (new field name) → no event', () => {
+        const p = makePlayer('p1', 100, 100);
+        const e = makeEnemy(10, 120, 100, { deathFlash: 5 });
+        const events = [];
+        detectPlayerEnemyHits([p], [e], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+
+    test('enemy mid death-flash (legacy _deathFlash) → no event', () => {
+        const p = makePlayer('p1', 100, 100);
+        // Live Enemy instances use the underscore-prefix name; the pure
+        // step honors both for round-trip parity with the legacy module.
+        const e = { id: 10, x: 120, y: 100, radius: 18, mass: 200,
+                    active: true, warping: false, _deathFlash: 5,
+                    vx: 0, vy: 0 };
+        const events = [];
+        detectPlayerEnemyHits([p], [e], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — bounce direction. Player moving east into an enemy east of it
+// should get deflected back west (negative dx on player impulse).
+// ---------------------------------------------------------------------
+
+describe('detectPlayerEnemyHits — bounce direction', () => {
+    test('eastbound player ramming a westward enemy gets impulse pushing west', () => {
+        // Geometry:
+        //   - Player at (100, 100), radius 15, moving east (vx=10).
+        //   - Enemy 20 px east at (120, 100), radius 18, moving west
+        //     (vx=-2). distance=20, sumR=33 ⇒ overlap=13.
+        //
+        // Normal (enemy → player) = (-1, 0).
+        // relVx = 10 - (-2) = 12, dot normal = -12 < 0 ⇒ APPROACHING
+        // (impulse fires).
+        //
+        // impulseScalar = -(1+0.9) · (-12) / (playerMass + enemyMass)
+        //               = +22.8 / totalMass     → POSITIVE
+        // impulseX      = +22.8 / totalMass · (-1) → NEGATIVE
+        // playerImpulseDx = impulseX · enemyMass · 12.0 → NEGATIVE
+        //                 = (player gets shoved WEST, away from enemy).
+        // enemyImpulseDx  = -impulseX · playerMass · 12.0 → POSITIVE
+        //                 = (enemy gets shoved EAST, away from player).
+        const p = makePlayer('p1', 100, 100, { vx: 10, vy: 0 });
+        const e = makeEnemy(10, 120, 100, { vx: -2, vy: 0 });
+        const events = [];
+        detectPlayerEnemyHits([p], [e], ctx, events);
+        expect(events).toHaveLength(1);
+        const ev = events[0];
+        // Player gets pushed west.
+        expect(ev.playerImpulseDx).toBeLessThan(0);
+        expect(ev.playerImpulseDy).toBeCloseTo(0, 10);
+        // Enemy gets pushed east (opposite direction).
+        expect(ev.enemyImpulseDx).toBeGreaterThan(0);
+        expect(ev.enemyImpulseDy).toBeCloseTo(0, 10);
+        // Newton's third law (within the multiplier asymmetry): the
+        // ratio of impulses equals enemyMass/playerMass.
+        // |playerImpulseDx| · playerMass ≈ |enemyImpulseDx| · enemyMass.
+        const playerMass = Math.PI * 15 * 15 * 0.5; // entityMass fallback
+        const enemyMass = 200; // explicit
+        // Left side: |player Δv| · mP. Right side: |enemy Δv| · mE.
+        const lhs = Math.abs(ev.playerImpulseDx) * playerMass;
+        const rhs = Math.abs(ev.enemyImpulseDx) * enemyMass;
+        // These should be exactly equal under the bounce-force formula.
+        expect(lhs).toBeCloseTo(rhs, 6);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — separating velocities. Bodies overlap but their relative
+// velocity already points outward ⇒ impulse must be zero, but the
+// separation push and the damage event still fire (matches legacy
+// line 1771 bail-out behavior + the wrapper still damaging on graze).
+// ---------------------------------------------------------------------
+
+describe('detectPlayerEnemyHits — separating velocities', () => {
+    test('player moving away from enemy still overlaps: damage + separation fire, impulse is zero', () => {
+        // Geometry: player + enemy still overlap (distance=20, sumR=33).
+        // But player is moving AWAY from the enemy now (player westbound,
+        // enemy stationary). Normal points (-1, 0); relVx = -5 (player
+        // westbound), velAlongNormal = (-5)·(-1) = +5 > 0 ⇒ separating.
+        const p = makePlayer('p1', 100, 100, { vx: -5, vy: 0 });
+        const e = makeEnemy(10, 120, 100, { vx: 0, vy: 0 });
+        const events = [];
+        detectPlayerEnemyHits([p], [e], ctx, events);
+        expect(events).toHaveLength(1);
+        const ev = events[0];
+        // Damage still applies (graze frame).
+        expect(ev.damageToEnemy).toBe(5);
+        // Impulse is zero on both bodies (the bail-out branch).
+        expect(ev.playerImpulseDx).toBe(0);
+        expect(ev.playerImpulseDy).toBe(0);
+        expect(ev.enemyImpulseDx).toBe(0);
+        expect(ev.enemyImpulseDy).toBe(0);
+        // But separation still moves them apart (overlap > 0 path).
+        expect(ev.separationDx).toBeLessThan(0);
+        expect(ev.enemySeparationDx).toBeGreaterThan(0);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — separation magnitude follows OVERLAP_SEPARATION_RATIO.
+// ---------------------------------------------------------------------
+
+describe('detectPlayerEnemyHits — separation magnitude', () => {
+    test('separation = overlap × OVERLAP_SEPARATION_RATIO along (enemy → player) normal', () => {
+        // Player at (100, 100), radius 15; enemy at (120, 100), radius 18.
+        // distance = 20, sumR = 33 ⇒ overlap = 13.
+        // Normal points west (-1, 0).
+        // separationForce = 13 · 0.6 = 7.8.
+        // separation = (-1, 0) · 7.8 = (-7.8, 0).
+        const p = makePlayer('p1', 100, 100);
+        const e = makeEnemy(10, 120, 100);
+        const events = [];
+        detectPlayerEnemyHits([p], [e], ctx, events);
+        expect(events).toHaveLength(1);
+        const ev = events[0];
+        expect(ev.separationDx).toBeCloseTo(-13 * OVERLAP_SEPARATION_RATIO, 5);
+        expect(ev.separationDy).toBeCloseTo(0, 5);
+        // Enemy separation is the negative mirror.
+        expect(ev.enemySeparationDx).toBeCloseTo(13 * OVERLAP_SEPARATION_RATIO, 5);
+        expect(ev.enemySeparationDy).toBeCloseTo(0, 5);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — empty / null inputs defensive guards.
+// ---------------------------------------------------------------------
+
+describe('detectPlayerEnemyHits — empty inputs', () => {
+    test('empty players → no events', () => {
+        const events = [];
+        detectPlayerEnemyHits([], [makeEnemy(10, 0, 0)], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('empty enemies → no events', () => {
+        const events = [];
+        detectPlayerEnemyHits([makePlayer('p1', 0, 0)], [], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('both empty → no events', () => {
+        const events = [];
+        detectPlayerEnemyHits([], [], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('null players → no events (defensive)', () => {
+        const events = [];
+        detectPlayerEnemyHits(null, [makeEnemy(10, 0, 0)], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('null enemies → no events (defensive)', () => {
+        const events = [];
+        detectPlayerEnemyHits([makePlayer('p1', 0, 0)], null, ctx, events);
+        expect(events).toHaveLength(0);
     });
 });


### PR DESCRIPTION
## Summary
Phase 2.5 dispatch — 4th collision pair on JS side. Adds `detectPlayerEnemyHits` to `js/sim/collision.js`. Legacy `collision-system.js` remains untouched.

## 🚨 CRITICAL FINDING — math diverges from player-vs-asteroid

The legacy `handlePlayerEnemyCollision` does NOT use the asteroid pair's jittered atan2 + `ASTEROID_KNOCKBACK_MULTIPLIER × 22` formula. Instead it runs a **textbook restitution impulse model**:

- `impulseScalar = -(1 + BOUNCE_RESTITUTION) · velAlongNormal / (playerMass + enemyMass)`
- Player gets `× enemyMass × BOUNCE_FORCE_MULTIPLIER (12.0)`
- Enemy gets `× playerMass × 12.0` (negated)
- **Bails on separating velocities** (`velAlongNormal > 0`) — asteroid pair never bails
- **No random jitter** — fully deterministic without `rngFloat`
- **Separation: `overlap × OVERLAP_SEPARATION_RATIO (0.6)`** split between both bodies — asteroid uses `overlap + SEPARATION_BUFFER` on player only
- **No `OVERLAP_PUSH_FORCE` nudge** — asteroid-only

All differences documented in JSDoc + IMPORTANT header + test banner.

The damage block runs UNCONDITIONALLY on overlap while the bounce block GATES on separating-vs-approaching — preserved by emitting `damageToEnemy=5` even on graze frames where impulses are zero.

## Constants
- **NEW**: `PLAYER_ENEMY_COLLISION_DAMAGE = 5` (collision-system.js:17; vs 2 for asteroids)
- **Reused** (from player-asteroid block): `BOUNCE_RESTITUTION (0.9)`, `BOUNCE_FORCE_MULTIPLIER (12.0)`, `OVERLAP_SEPARATION_RATIO (0.6)`
- **NOT reused** (asteroid-only): `ASTEROID_KNOCKBACK_MULTIPLIER`, `SEPARATION_BUFFER`, `OVERLAP_PUSH_FORCE`

## Event shape (12 fields — both-body symmetric)
```js
{ type: 'player_hit_enemy',
  playerId, enemyId, damageToEnemy,
  playerImpulseDx, playerImpulseDy,
  enemyImpulseDx, enemyImpulseDy,
  separationDx, separationDy,           // player side
  enemySeparationDx, enemySeparationDy  // enemy side (mirror)
}
```

## Side effects stay in wrapper
Boss-rage trigger, `notifyBossDeath`, `onEnemyKill`, drops/XP/kill streak, audio/FX/hit-stop/screen shake, mission/combo hooks.

## Test plan
- [x] 21 new tests (>6 required; added more to cover math-divergence cases)
- [x] `collision.test.js`: 90 tests pass (69 existing + 21 new)
- [x] Full unit suite: 423/423 across 18 suites
- [x] `collision-system.js` UNTOUCHED

## Phase 2.5 progress (task #46)
- ✓ bullet-asteroid JS + Rust (merged)
- ✓ player-asteroid JS + Rust (merged)
- ✓ bullet-enemy JS (merged) + Rust ⏳ (sibling subagent in flight)
- ✓ player-enemy JS (this PR) + Rust ⬜
- ⬜ enemy-asteroid, player-enemy-bullet, drops pickup, power-weapon, defense-skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)