### PR TITLE
mp/sim-rs: Rust mirror of bullet-vs-enemy collision (Phase 2.5)

### DIFF
--- a/server/src/sim/collision.rs
+++ b/server/src/sim/collision.rs
@@ -183,6 +183,14 @@ pub struct CollisionBullet {
     /// Per-bullet memory of which asteroid ids have already been pierced.
     /// JS: `bullet.piercedAsteroidIds: Set<AsteroidId|number>`.
     pub pierced_asteroid_ids: HashSet<u32>,
+    /// Per-bullet memory of which enemy ids have already been pierced.
+    /// DISTINCT from `pierced_asteroid_ids` — different id spaces. A
+    /// bullet that pierced asteroid 101 can still hit enemy 101 the same
+    /// tick. The piercing BUDGET (`pierced_enemies` counter) is shared
+    /// across both Sets — mirrors legacy `bullet.onHit()` semantics
+    /// (`js/modules/player/bullet.js:404–418`). JS:
+    /// `bullet.piercedEnemyIds: Set<EnemyId|number>`.
+    pub pierced_enemy_ids: HashSet<u32>,
 }
 
 impl CollisionBullet {
@@ -202,6 +210,7 @@ impl CollisionBullet {
             pierced_enemies: 0,
             active: true,
             pierced_asteroid_ids: HashSet::new(),
+            pierced_enemy_ids: HashSet::new(),
         }
     }
 }
@@ -363,6 +372,26 @@ pub enum CollisionEvent {
         asteroid_impulse_dy: f32,
         separation_dx: f32,
         separation_dy: f32,
+    },
+    /// Mirrors `{ type: 'bullet_hit_enemy', ... }` in `js/sim/collision.js`.
+    ///
+    /// Structurally identical to `BulletHitAsteroid` (same nine fields) —
+    /// the wrapper differentiates by the `enemy_id` field key and dispatches
+    /// to enemy-specific side effects (HP damage, death-flash, drops,
+    /// boss-rage triggers) rather than the asteroid-side effects.
+    BulletHitEnemy {
+        bullet_id: u32,
+        enemy_id: u32,
+        damage: f32,
+        bullet_x: f32,
+        bullet_y: f32,
+        bullet_vx: f32,
+        bullet_vy: f32,
+        /// How many more piercing hits the bullet has after this one.
+        /// `-1` ↔ non-piercing (bullet despawns now).
+        bullet_piercing_remaining: i32,
+        /// `true` ↔ wrapper should remove the bullet from the pool.
+        bullet_will_despawn: bool,
     },
 }
 
@@ -700,6 +729,257 @@ pub fn detect_player_asteroid_hits(
                 separation_dx,
                 separation_dy,
             });
+        }
+    }
+}
+
+// ── BULLET ↔ ENEMY — Phase 2.5 dispatch (this PR) ─────────────
+//
+// Near-mirror of `detect_bullet_asteroid_hits`. Same circle-circle geometry,
+// same piercing-budget mechanics, same event-emission discipline. Key
+// differences from the asteroid pair:
+//
+//   - Target slice is `&[CollisionEnemy]` not `&[CollisionAsteroid]`.
+//   - Emits `CollisionEvent::BulletHitEnemy` instead of `BulletHitAsteroid`.
+//   - Uses a SEPARATE `pierced_enemy_ids: HashSet<u32>` on the bullet so the
+//     same bullet can pierce both asteroids and enemies independently
+//     (different id spaces — an asteroid with id=10 and an enemy with id=10
+//     are unrelated targets).
+//   - The shared piercing counter (`bullet.pierced_enemies`) IS shared
+//     across both Sets — mirrors the legacy `bullet.onHit()` semantics
+//     where the single counter increments on any pierce regardless of
+//     target type.
+//
+// Reference: `js/sim/collision.js::detectBulletEnemyHits` (lines 789–892
+// in PR #38 / current master).
+//
+// What this module does NOT touch (stays in the wrapper):
+//   - Damage application to enemy HP             (legacy: enemy.takeDamage)
+//   - Enemy death-flash trigger                  (legacy: enemy._deathFlash = 8)
+//   - Drops / coins / experience / kill streak   (legacy: dropOrbsFromEntity)
+//   - Boss-rage enrage trigger                   (legacy: boss reactive logic)
+//   - Hit-flash visuals, hit-stop, screen shake  (presentation)
+//   - Audio events                               (presentation)
+//   - Combo / mission hooks                      (game-state)
+
+/// Bullet → enemy knockback impulse multiplier. Mirrors
+/// `BULLET_ENEMY_KNOCKBACK = 0.05` in `js/sim/collision.js` (line 673).
+///
+/// Same numerical value as `BULLET_ASTEROID_KNOCKBACK` — both originate
+/// from the single `COLLISION_CONFIG.BULLET_KNOCKBACK = 0.05` constant
+/// in `js/modules/combat/collision-system.js`. Exposed as a separate
+/// name here for symmetry with the asteroid pair and to allow future
+/// per-pair tuning without renaming.
+pub const BULLET_ENEMY_KNOCKBACK: f32 = 0.05;
+
+/// Frames the enemy's hit-flash effect runs after a bullet impact.
+/// Mirrors `BULLET_ENEMY_HIT_FLASH_FRAMES = 10` in `js/sim/collision.js`
+/// (line 686). Same value as `BULLET_ASTEROID_HIT_FLASH_FRAMES` — both
+/// originate from `COLLISION_CONFIG.HIT_FLASH_FRAMES = 10` in the legacy
+/// module. Presentation concern in the strict sense, but exposed here so
+/// the wrapper can set the timer from a single source of truth.
+pub const BULLET_ENEMY_HIT_FLASH_FRAMES: u32 = 10;
+
+/// Minimal enemy view for collision detection.
+///
+/// Mirrors the JS fields read by `detectBulletEnemyHits`:
+///   `{ id, x, y, vx, vy, radius, hp, active, warping, deathFlash OR
+///      _deathFlash }`.
+///
+/// `vx` / `vy` / `hp` aren't consumed by the bullet-vs-enemy pair detector
+/// today — the pure step only emits an event with the *bullet's* velocity
+/// for downstream knockback application; enemy velocity/HP are wrapper
+/// concerns. They're carried in the struct anyway for parity with the JS
+/// shape (and for use by future pairs like player-vs-enemy and
+/// enemy-vs-asteroid that consume them).
+///
+/// The JS guards `!enemy.active`, `enemy.warping`, and
+/// `enemy.deathFlash > 0` collapse into the boolean / counter fields
+/// below — the wrapper translates from the live sim-level `Enemy` struct
+/// to this view by reading those fields directly. `death_flash`
+/// consolidates JS's dual-name (`deathFlash` and `_deathFlash`) into a
+/// single counter on the Rust side.
+#[derive(Debug, Clone, Copy)]
+pub struct CollisionEnemy {
+    pub id: u32,
+    pub x: f32,
+    pub y: f32,
+    /// Enemy velocity. Currently unused by `detect_bullet_enemy_hits`
+    /// (the bullet velocity drives knockback, not the enemy's). Carried
+    /// for parity with the JS shape and future pair-dispatch use.
+    pub vx: f32,
+    pub vy: f32,
+    pub radius: f32,
+    /// Current hit points. Unused by the pair-detection step (the wrapper
+    /// applies damage); carried for parity.
+    pub hp: f32,
+    pub active: bool,
+    /// `true` while the enemy is mid-warp-in animation (invulnerable).
+    /// JS: `enemy.warping`.
+    pub warping: bool,
+    /// Frames remaining of mid-death flash. Treated as "skip if > 0".
+    /// JS accepts either `deathFlash` or `_deathFlash`; the Rust mirror
+    /// collapses both into this single counter.
+    pub death_flash: u32,
+}
+
+impl CollisionEnemy {
+    /// Construct a fresh enemy at the origin with the live HUNTER default
+    /// radius of 18 px. Test convenience.
+    pub fn fresh(id: u32) -> Self {
+        Self {
+            id,
+            x: 0.0,
+            y: 0.0,
+            vx: 0.0,
+            vy: 0.0,
+            radius: 18.0,
+            hp: 1.0,
+            active: true,
+            warping: false,
+            death_flash: 0,
+        }
+    }
+}
+
+/// Detect bullet-vs-enemy collisions for one tick.
+///
+/// Pure step: reads bullet + enemy positions/radii, decides which pairs
+/// collided, and pushes one `BulletHitEnemy` event per detected hit. The
+/// function does NOT mutate enemy state — no damage, no death-flash, no
+/// rage trigger — every effect is reported through the event payload for
+/// the wrapper to apply downstream.
+///
+/// Mutation surface on `bullets`:
+///   - `pierced_enemy_ids` — Set is mutated; enemy id is inserted on each
+///     hit. Carried across ticks so a piercing bullet doesn't re-hit an
+///     enemy it has already passed through. DISTINCT from
+///     `pierced_asteroid_ids`: different id spaces, different Sets.
+///     JS line refs: `js/sim/collision.js:852–855`.
+///   - `pierced_enemies` — running counter SHARED with the asteroid pair.
+///     Bumped on each hit so subsequent ticks (and the asteroid pair, if
+///     it runs after) see the latest value. JS line refs:
+///     `js/sim/collision.js:862–863`.
+///
+/// Iteration order: for each bullet, scan enemies in slice order. The
+/// first hit a non-piercing bullet detects becomes its only event for
+/// the tick. A bullet with `piercing > 0` may emit up to `piercing + 1`
+/// hit events per tick (matching legacy `bullet.onHit` semantics).
+///
+/// Geometry: circle-circle overlap using squared distance to skip the
+/// sqrt. `(dx² + dy²) < (br + er)²`. JS line refs:
+/// `js/sim/collision.js:842–846`.
+///
+/// Skipped pairs (no event emitted):
+///   - Inactive bullet            (`!bullet.active`)
+///   - Inactive enemy             (`!enemy.active`)
+///   - Warping enemy              (`enemy.warping`)
+///   - Enemy mid-death-flash      (`enemy.death_flash > 0`)
+///   - Enemy already pierced      (id in `bullet.pierced_enemy_ids`)
+///   - Piercing budget exhausted  (`bullet.pierced_enemies > bullet.piercing`)
+pub fn detect_bullet_enemy_hits(
+    bullets: &mut [CollisionBullet],
+    enemies: &[CollisionEnemy],
+    _ctx: &CollisionContext,
+    events: &mut Vec<CollisionEvent>,
+) {
+    if bullets.is_empty() || enemies.is_empty() {
+        return;
+    }
+
+    for bullet in bullets.iter_mut() {
+        // 1. Active-guard (JS collision.js:795).
+        if !bullet.active {
+            continue;
+        }
+
+        // 2. Piercing-budget exhausted? (JS collision.js:800–813).
+        //    A piercing bullet that's already eaten its `piercing + 1`
+        //    targets has `pierced_enemies > piercing`. A non-piercing
+        //    bullet that's somehow active with prior hits is similarly
+        //    guarded defensively (e.g. if the asteroid pair already
+        //    consumed its single hit earlier this tick and the wrapper
+        //    hasn't flipped `active = false` yet).
+        let piercing = bullet.piercing;
+        if piercing > 0 && bullet.pierced_enemies > piercing {
+            continue;
+        }
+        if piercing == 0 && bullet.pierced_enemies > 0 {
+            continue;
+        }
+
+        let bullet_radius = bullet.radius;
+
+        for enemy in enemies.iter() {
+            // 3. Enemy gating (JS collision.js:819–830).
+            if !enemy.active {
+                continue;
+            }
+            if enemy.warping {
+                continue;
+            }
+            if enemy.death_flash > 0 {
+                continue;
+            }
+
+            // 4. Already-pierced? (JS collision.js:837–838).
+            //    DISTINCT from pierced_asteroid_ids — different id space.
+            if bullet.pierced_enemy_ids.contains(&enemy.id) {
+                continue;
+            }
+
+            // 5. Circle-circle overlap (JS collision.js:842–846).
+            let dx = bullet.x - enemy.x;
+            let dy = bullet.y - enemy.y;
+            let sum_r = bullet_radius + enemy.radius;
+            if dx * dx + dy * dy >= sum_r * sum_r {
+                continue;
+            }
+
+            // ── Hit detected ──
+
+            // 6. Update enemy-pierce tracker (JS collision.js:852–855).
+            //    Distinct Set from the asteroid pierce-tracker.
+            bullet.pierced_enemy_ids.insert(enemy.id);
+            bullet.pierced_enemies += 1;
+            let pierced_so_far = bullet.pierced_enemies;
+
+            // 7. Despawn / piercing-remaining decision
+            //    (JS collision.js:868–873).
+            let will_despawn = if piercing == 0 {
+                true
+            } else {
+                pierced_so_far > piercing
+            };
+            let piercing_remaining = if piercing == 0 {
+                -1
+            } else {
+                (piercing - pierced_so_far).max(0)
+            };
+
+            // 8. Damage default — JS `bullet.damage || 1`. We treat any
+            //    non-positive `damage` (0) as the default-1 fallback to
+            //    match JS truthy check on a number.
+            let damage = if bullet.damage > 0.0 { bullet.damage } else { 1.0 };
+
+            // 9. Emit the event (JS collision.js:875–886).
+            events.push(CollisionEvent::BulletHitEnemy {
+                bullet_id: bullet.id,
+                enemy_id: enemy.id,
+                damage,
+                bullet_x: bullet.x,
+                bullet_y: bullet.y,
+                bullet_vx: bullet.vx,
+                bullet_vy: bullet.vy,
+                bullet_piercing_remaining: piercing_remaining,
+                bullet_will_despawn: will_despawn,
+            });
+
+            // 10. Non-piercing or budget reached → stop scanning more
+            //     enemies for this bullet (JS collision.js:888–889).
+            if will_despawn {
+                break;
+            }
         }
     }
 }

--- a/server/tests/parity_collision.rs
+++ b/server/tests/parity_collision.rs
@@ -39,9 +39,10 @@
 //! PR #32 for player-asteroid).
 
 use rainboids_server::sim::collision::{
-    detect_bullet_asteroid_hits, detect_player_asteroid_hits, CollisionAsteroid, CollisionBullet,
-    CollisionContext, CollisionEvent, CollisionPlayer, ASTEROID_KNOCKBACK_MULTIPLIER,
-    OVERLAP_PUSH_FORCE, PLAYER_ASTEROID_COLLISION_DAMAGE, SEPARATION_BUFFER,
+    detect_bullet_asteroid_hits, detect_bullet_enemy_hits, detect_player_asteroid_hits,
+    CollisionAsteroid, CollisionBullet, CollisionContext, CollisionEnemy, CollisionEvent,
+    CollisionPlayer, ASTEROID_KNOCKBACK_MULTIPLIER, OVERLAP_PUSH_FORCE,
+    PLAYER_ASTEROID_COLLISION_DAMAGE, SEPARATION_BUFFER,
 };
 
 // ─── Helpers ─────────────────────────────────────────────────────────
@@ -679,5 +680,310 @@ fn player_asteroid_separation_magnitude() {
     assert!(
         (ASTEROID_KNOCKBACK_MULTIPLIER - 22.0).abs() < 1e-6,
         "ASTEROID_KNOCKBACK_MULTIPLIER must mirror JS verbatim"
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Bullet-vs-enemy fixtures (dispatch 3 — this PR).
+// ═════════════════════════════════════════════════════════════════════
+//
+// Mirrors `js/sim/collision.js::detectBulletEnemyHits` and the Jest suite
+// at `tests/unit/sim/collision.test.js` (the bullet-enemy describe block
+// added in PR #38). Coverage:
+//
+//   11. `bullet_enemy_single_hit`
+//       — basic overlap → 1 event with all 9 fields.
+//   12. `bullet_enemy_piercing_within_tick`
+//       — piercing=2 → 3 events, last has will_despawn=true.
+//   13. `bullet_enemy_geometry_miss`
+//       — 200 px apart → 0 events.
+//   14. `bullet_enemy_pierced_set_distinct_from_asteroid`
+//       — bullet has pierced_asteroid_ids={42}; same bullet still hits
+//         enemy id=42 because the Sets are distinct (different id spaces).
+
+// ---------------------------------------------------------------------
+// Helpers — build minimal bullet/enemy pairs that overlap (or not).
+// ---------------------------------------------------------------------
+
+/// Build an enemy at (x, y) with the live HUNTER default radius of 18.
+fn make_enemy(id: u32, x: f32, y: f32) -> CollisionEnemy {
+    let mut e = CollisionEnemy::fresh(id);
+    e.x = x;
+    e.y = y;
+    e
+}
+
+// ---------------------------------------------------------------------
+// Fixture 11 — single bullet hits single enemy.
+//
+// Mirrors `tests/unit/sim/collision.test.js::"overlapping bullet + enemy
+// emits one event with all 9 fields"`. JS asserts:
+//   - 1 event
+//   - bullet_id=1, enemy_id=101, damage=3
+//   - bullet velocity (vx=8, vy=-3) and position (100, 100) carried through
+//   - bullet_will_despawn=true, bullet_piercing_remaining=-1 (non-piercing)
+// ---------------------------------------------------------------------
+
+#[test]
+fn bullet_enemy_single_hit() {
+    // Bullet radius 4 + enemy radius 18 = sum_r 22. Place enemy 10 px east
+    // of bullet ⇒ overlap = 12 (clear hit).
+    let mut bullet = make_bullet(1, 100.0, 100.0);
+    bullet.vx = 8.0;
+    bullet.vy = -3.0;
+    bullet.damage = 3.0;
+
+    let enemy = make_enemy(101, 110.0, 100.0);
+
+    let mut bullets = vec![bullet];
+    let enemies = vec![enemy];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_bullet_enemy_hits(&mut bullets, &enemies, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1, "expected exactly one bullet-hit-enemy event");
+
+    match events[0] {
+        CollisionEvent::BulletHitEnemy {
+            bullet_id,
+            enemy_id,
+            damage,
+            bullet_x,
+            bullet_y,
+            bullet_vx,
+            bullet_vy,
+            bullet_piercing_remaining,
+            bullet_will_despawn,
+        } => {
+            assert_eq!(bullet_id, 1, "bullet_id");
+            assert_eq!(enemy_id, 101, "enemy_id");
+            assert!((damage - 3.0).abs() < 1e-6, "damage carries through");
+            assert!((bullet_x - 100.0).abs() < 1e-6, "bullet_x");
+            assert!((bullet_y - 100.0).abs() < 1e-6, "bullet_y");
+            assert!((bullet_vx - 8.0).abs() < 1e-6, "bullet_vx");
+            assert!((bullet_vy - (-3.0)).abs() < 1e-6, "bullet_vy");
+            assert_eq!(
+                bullet_piercing_remaining, -1,
+                "non-piercing bullet → -1 remaining"
+            );
+            assert!(bullet_will_despawn, "non-piercing bullet despawns on hit");
+        }
+        ev => panic!("expected BulletHitEnemy, got {:?}", ev),
+    }
+
+    // Bullet should now remember the pierce — but only in the enemy Set,
+    // not the asteroid Set (distinct id spaces).
+    assert!(
+        bullets[0].pierced_enemy_ids.contains(&101),
+        "pierced_enemy_ids should include the hit enemy"
+    );
+    assert!(
+        bullets[0].pierced_asteroid_ids.is_empty(),
+        "pierced_asteroid_ids should remain untouched by an enemy hit"
+    );
+    assert_eq!(
+        bullets[0].pierced_enemies, 1,
+        "pierced_enemies counter incremented"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Fixture 12 — piercing=2 bullet hits 3 overlapping enemies in same tick.
+//
+// Mirrors `tests/unit/sim/collision.test.js::"piercing=2 bullet hits 3
+// overlapping enemies in same tick"`.
+// ---------------------------------------------------------------------
+
+#[test]
+fn bullet_enemy_piercing_within_tick() {
+    let mut bullet = make_bullet(1, 100.0, 100.0);
+    bullet.piercing = 2;
+    bullet.damage = 1.0;
+
+    // All three enemies overlap (each radius 18, bullet radius 4 → sum_r
+    // 22; bullet at (100, 100), enemies within 15 px on the x-axis).
+    let e1 = make_enemy(101, 110.0, 100.0);
+    let e2 = make_enemy(102, 115.0, 100.0);
+    let e3 = make_enemy(103, 90.0, 100.0);
+
+    let mut bullets = vec![bullet];
+    let enemies = vec![e1, e2, e3];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_bullet_enemy_hits(&mut bullets, &enemies, &ctx, &mut events);
+
+    assert_eq!(
+        events.len(),
+        3,
+        "piercing=2 → 3 events (piercing + 1 targets)"
+    );
+
+    // Collect ids in event-emit order — should be array order: 101, 102, 103.
+    let ids: Vec<u32> = events
+        .iter()
+        .map(|e| match *e {
+            CollisionEvent::BulletHitEnemy { enemy_id, .. } => enemy_id,
+            ev => panic!("expected BulletHitEnemy, got {:?}", ev),
+        })
+        .collect();
+    assert_eq!(ids, vec![101, 102, 103], "enemies hit in array order");
+
+    // First two events: bullet still alive.
+    for (i, ev) in events.iter().take(2).enumerate() {
+        match *ev {
+            CollisionEvent::BulletHitEnemy {
+                bullet_will_despawn,
+                bullet_piercing_remaining,
+                ..
+            } => {
+                assert!(
+                    !bullet_will_despawn,
+                    "event[{}] should not despawn (budget remaining)",
+                    i
+                );
+                // After hit 1: remaining=1; after hit 2: remaining=0.
+                let expected = (2 - (i as i32 + 1)).max(0);
+                assert_eq!(
+                    bullet_piercing_remaining, expected,
+                    "event[{}] piercing_remaining",
+                    i
+                );
+            }
+            ev => panic!("expected BulletHitEnemy, got {:?}", ev),
+        }
+    }
+
+    // Last event: budget exhausted → despawn.
+    match events[2] {
+        CollisionEvent::BulletHitEnemy {
+            bullet_will_despawn,
+            bullet_piercing_remaining,
+            ..
+        } => {
+            assert!(bullet_will_despawn, "third hit exhausts piercing budget");
+            assert_eq!(
+                bullet_piercing_remaining, 0,
+                "piercing_remaining clamps to 0 on last hit"
+            );
+        }
+        ev => panic!("expected BulletHitEnemy, got {:?}", ev),
+    }
+
+    // All three enemy ids should now live in the bullet's pierced set.
+    assert_eq!(
+        bullets[0].pierced_enemy_ids.len(),
+        3,
+        "pierced_enemy_ids should have all three"
+    );
+    // Asteroid Set must remain untouched — distinct from enemy Set.
+    assert!(
+        bullets[0].pierced_asteroid_ids.is_empty(),
+        "pierced_asteroid_ids must NOT be modified by enemy hits"
+    );
+    assert_eq!(bullets[0].pierced_enemies, 3, "shared pierced_enemies counter");
+}
+
+// ---------------------------------------------------------------------
+// Fixture 13 — bullet outside sum-of-radii emits no event.
+// ---------------------------------------------------------------------
+
+#[test]
+fn bullet_enemy_geometry_miss() {
+    let bullet = make_bullet(1, 0.0, 0.0);
+    // dx=200, sum_r=4+18=22 → squared distance 40_000 ≫ 484 → no overlap.
+    let enemy = make_enemy(101, 200.0, 0.0);
+
+    let mut bullets = vec![bullet];
+    let enemies = vec![enemy];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_bullet_enemy_hits(&mut bullets, &enemies, &ctx, &mut events);
+
+    assert!(
+        events.is_empty(),
+        "bullet outside sum-of-radii should emit no event, got {:?}",
+        events
+    );
+    // Pierce-tracking Sets should still be empty — no hit recorded.
+    assert!(
+        bullets[0].pierced_enemy_ids.is_empty(),
+        "no enemy pierces recorded on miss"
+    );
+    assert!(
+        bullets[0].pierced_asteroid_ids.is_empty(),
+        "no asteroid pierces recorded on miss"
+    );
+    assert_eq!(bullets[0].pierced_enemies, 0, "no pierce-counter bump");
+}
+
+// ---------------------------------------------------------------------
+// Fixture 14 — pierced_enemy_ids is DISTINCT from pierced_asteroid_ids.
+//
+// Mirrors `tests/unit/sim/collision.test.js::"a bullet that pierced
+// asteroid X can still hit enemy with same id"`. Bullet has already
+// pierced asteroid id=42 (seeded into pierced_asteroid_ids) earlier
+// this tick; an enemy with id=42 still gets hit because the Sets cover
+// different id spaces. The SHARED pierced_enemies counter increments,
+// however, because the budget is one counter for both pair types.
+// ---------------------------------------------------------------------
+
+#[test]
+fn bullet_enemy_pierced_set_distinct_from_asteroid() {
+    // Pre-seed the bullet as if it had already pierced asteroid 42 in the
+    // bullet-asteroid pass earlier this tick. The shared counter reflects
+    // that prior pierce.
+    let mut bullet = make_bullet(1, 100.0, 100.0);
+    bullet.piercing = 3;
+    bullet.damage = 1.0;
+    bullet.pierced_asteroid_ids.insert(42);
+    bullet.pierced_enemies = 1; // shared counter already at 1 from the asteroid pierce
+
+    // Enemy ALSO with id=42 (different id space, different target). The
+    // detector MUST hit this enemy — its id is in pierced_asteroid_ids
+    // but NOT in pierced_enemy_ids.
+    let enemy = make_enemy(42, 110.0, 100.0);
+
+    let mut bullets = vec![bullet];
+    let enemies = vec![enemy];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_bullet_enemy_hits(&mut bullets, &enemies, &ctx, &mut events);
+
+    assert_eq!(
+        events.len(),
+        1,
+        "enemy id=42 must be hit despite asteroid id=42 already pierced"
+    );
+
+    match events[0] {
+        CollisionEvent::BulletHitEnemy { enemy_id, .. } => {
+            assert_eq!(enemy_id, 42, "the hit enemy is id=42");
+        }
+        ev => panic!("expected BulletHitEnemy, got {:?}", ev),
+    }
+
+    // Now the bullet's enemy-pierce Set is populated.
+    assert!(
+        bullets[0].pierced_enemy_ids.contains(&42),
+        "pierced_enemy_ids should now contain 42"
+    );
+    // Asteroid-pierce Set still holds the original 42 entry — untouched.
+    assert!(
+        bullets[0].pierced_asteroid_ids.contains(&42),
+        "pierced_asteroid_ids should still contain 42 (untouched by enemy pair)"
+    );
+    assert_eq!(
+        bullets[0].pierced_asteroid_ids.len(),
+        1,
+        "pierced_asteroid_ids should still have exactly one entry (42)"
+    );
+    // Shared counter ticked up by 1 — now 2 (one ast + one enemy).
+    assert_eq!(
+        bullets[0].pierced_enemies, 2,
+        "shared pierced_enemies counter increments per pierce regardless of type"
     );
 }


### PR DESCRIPTION
## Summary
Rust mirror of PR #38's `detectBulletEnemyHits`. **4 new parity fixtures, all passing at 1e-6 tolerance.**

## New types
- `CollisionEnemy` struct: id, x, y, vx, vy, radius, hp, active, warping, death_flash
- `CollisionBullet.pierced_enemy_ids: HashSet<u32>` (SEPARATE from `pierced_asteroid_ids`; SHARED `pierced_enemies` counter)
- `CollisionEvent::BulletHitEnemy` (9 fields)

## Constants (JS line refs)
- `BULLET_ENEMY_KNOCKBACK = 0.05` (js/sim/collision.js:673)
- `BULLET_ENEMY_HIT_FLASH_FRAMES = 10` (js/sim/collision.js:686)

## Parity fixtures
| Test | Scenario |
|---|---|
| `bullet_enemy_single_hit` | overlapping → 1 event with all 9 fields |
| `bullet_enemy_piercing_within_tick` | piercing=2 vs 3 enemies → 3 events, last has will_despawn |
| `bullet_enemy_geometry_miss` | 200 px apart → 0 events |
| `bullet_enemy_pierced_set_distinct_from_asteroid` | bullet with `pierced_asteroid_ids={42}` still hits enemy id=42 (separate id spaces); shared counter 1→2 after hit |

## Test plan
- [x] `parity_collision`: 14 passed (4 bullet-asteroid + 6 player-asteroid + 4 new bullet-enemy)
- [x] All 70 workspace tests green; build clean

## Phase 2.5 progress (task #46)
- ✓ bullet-asteroid JS + Rust
- ✓ player-asteroid JS + Rust
- ✓ bullet-enemy JS + Rust (this PR)
- ⏳ player-enemy JS (sibling PR open) + Rust ⬜
- ⬜ enemy-asteroid, player-enemy-bullet, drops pickup, power-weapon, defense-skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)