### PR TITLE
mp/net: TickBuffer scaffolding for client prediction (Phase 3)

### DIFF
--- a/js/net/tick-buffer.js
+++ b/js/net/tick-buffer.js
@@ -1,0 +1,179 @@
+/**
+ * TickBuffer — ring buffer of recent server snapshots keyed by tick number.
+ *
+ * Part of the Phase 3 client prediction / interpolation work. For multiplayer
+ * the client needs to:
+ *   1. Store recent server snapshots (each tagged with a tick number).
+ *   2. Interpolate between adjacent snapshots when rendering between tick
+ *      boundaries (this class handles 1 + 2).
+ *   3. Predict ahead locally — run sim past the latest received snapshot
+ *      (handled by `js/net/prediction.js`).
+ *   4. Reconcile when a server snapshot arrives confirming / refuting
+ *      prediction (also `prediction.js`).
+ *
+ * Each entry is `{ tick: number, state: object }`. The buffer is sorted
+ * ascending by tick number and evicts the oldest entry when capacity is
+ * reached. Snapshots are typically appended in monotonic tick order, but
+ * out-of-order inserts are tolerated (sorted internally on insert).
+ *
+ * Interpolation is delegated to a user-supplied `interpolate(s1, s2, t)`
+ * function passed to the constructor — this keeps TickBuffer state-shape
+ * agnostic. The same buffer can hold ShipState, AsteroidState, full
+ * GameState, or any structure whose interpolation rule the caller defines.
+ *
+ * This is intentionally a thin data structure. It does NOT:
+ *   - know about the wire format (callers decode bytes first).
+ *   - know about wall-clock time (lookups are in tick units only).
+ *   - allocate per-frame (interpolate fn owns its own allocation strategy).
+ */
+
+const DEFAULT_CAPACITY = 32;
+
+export class TickBuffer {
+    /**
+     * @param {object} [options]
+     * @param {number} [options.capacity=32] — max number of snapshots kept.
+     * @param {((s1: object, s2: object, t: number) => object) | null} [options.interpolate=null]
+     *        — pure fn returning an interpolated state for `t ∈ [0, 1]`. If
+     *        null, `getInterpolated()` always returns null.
+     */
+    constructor({ capacity = DEFAULT_CAPACITY, interpolate = null } = {}) {
+        if (!Number.isFinite(capacity) || capacity < 1) {
+            throw new RangeError(`TickBuffer: capacity must be ≥ 1, got ${capacity}`);
+        }
+        this.capacity = capacity | 0;
+        this.interpolate = interpolate;
+        /** @type {Array<{tick: number, state: object}>} sorted ascending by tick */
+        this._entries = [];
+    }
+
+    /**
+     * Insert a snapshot. If the buffer is already at capacity, the oldest
+     * entry (lowest tick) is evicted. If `tick` matches an existing entry
+     * the existing state is replaced (latest write wins) — useful when a
+     * later, more authoritative version of the same tick arrives.
+     *
+     * @param {number} tick - integer tick number (server-assigned).
+     * @param {object} state - opaque snapshot payload.
+     */
+    insert(tick, state) {
+        if (!Number.isFinite(tick)) {
+            throw new TypeError(`TickBuffer.insert: tick must be a finite number, got ${tick}`);
+        }
+        const t = tick | 0;
+        const entries = this._entries;
+
+        // Fast path: append at the end (monotonic insert).
+        if (entries.length === 0 || t > entries[entries.length - 1].tick) {
+            entries.push({ tick: t, state });
+        } else {
+            // Find insertion index via linear scan from the right (capacity is small).
+            let i = entries.length - 1;
+            while (i >= 0 && entries[i].tick > t) i--;
+            if (i >= 0 && entries[i].tick === t) {
+                // Replace existing entry for this tick.
+                entries[i] = { tick: t, state };
+            } else {
+                entries.splice(i + 1, 0, { tick: t, state });
+            }
+        }
+
+        // Evict oldest while over capacity.
+        while (entries.length > this.capacity) entries.shift();
+    }
+
+    /**
+     * Exact lookup by tick. Returns the stored state or null if no entry
+     * matches.
+     *
+     * @param {number} tick
+     * @returns {object | null}
+     */
+    getByTick(tick) {
+        if (!Number.isFinite(tick)) return null;
+        const t = tick | 0;
+        const entries = this._entries;
+        // Linear scan; capacity is small (~32). Walk from the right since
+        // recent ticks are queried most often.
+        for (let i = entries.length - 1; i >= 0; i--) {
+            if (entries[i].tick === t) return entries[i].state;
+            if (entries[i].tick < t) return null; // sorted; past it
+        }
+        return null;
+    }
+
+    /**
+     * Most-recent entry (highest tick), or null if buffer is empty.
+     *
+     * @returns {{tick: number, state: object} | null}
+     */
+    getLatest() {
+        const entries = this._entries;
+        if (entries.length === 0) return null;
+        const last = entries[entries.length - 1];
+        return { tick: last.tick, state: last.state };
+    }
+
+    /**
+     * Interpolated state at a (possibly fractional) tick.
+     *
+     * Returns null when:
+     *   - no `interpolate` fn was provided at construction, OR
+     *   - the buffer is empty, OR
+     *   - `tick` falls outside the buffered range (`< oldest` or `> newest`).
+     *
+     * If `tick` exactly matches a buffered entry, the stored state is
+     * returned directly (no call to `interpolate`).
+     *
+     * Otherwise the two entries `a, b` bracketing `tick` are located and
+     * `interpolate(a.state, b.state, (tick - a.tick) / (b.tick - a.tick))`
+     * is returned. The fraction is computed in floating point so `tick`
+     * may be non-integer (e.g. a render-time interpolation between server
+     * ticks).
+     *
+     * @param {number} tick - may be fractional.
+     * @returns {object | null}
+     */
+    getInterpolated(tick) {
+        if (this.interpolate == null) return null;
+        if (!Number.isFinite(tick)) return null;
+        const entries = this._entries;
+        if (entries.length === 0) return null;
+
+        const oldest = entries[0];
+        const newest = entries[entries.length - 1];
+        if (tick < oldest.tick || tick > newest.tick) return null;
+
+        // Locate bracketing pair (a, b) with a.tick <= tick <= b.tick.
+        // Linear scan from the right is fine at this capacity.
+        for (let i = entries.length - 1; i > 0; i--) {
+            const b = entries[i];
+            const a = entries[i - 1];
+            if (a.tick <= tick && tick <= b.tick) {
+                if (tick === a.tick) return a.state;
+                if (tick === b.tick) return b.state;
+                const span = b.tick - a.tick;
+                // span == 0 is impossible here because tick values are
+                // unique within the buffer and a.tick !== b.tick (the
+                // exact-match short-circuits above already handled it),
+                // but guard anyway for safety.
+                if (span === 0) return a.state;
+                const t = (tick - a.tick) / span;
+                return this.interpolate(a.state, b.state, t);
+            }
+        }
+        // Only one entry total and it didn't match exactly — already
+        // caught by the range check, but be defensive.
+        return null;
+    }
+
+    /** Drop all buffered entries. */
+    clear() {
+        this._entries.length = 0;
+    }
+
+    /** Current number of buffered entries. */
+    size() {
+        return this._entries.length;
+    }
+}

--- a/tests/unit/net/tick-buffer.test.js
+++ b/tests/unit/net/tick-buffer.test.js
@@ -1,0 +1,215 @@
+/**
+ * tests/unit/net/tick-buffer.test.js — unit tests for the client-side
+ * snapshot ring buffer.
+ *
+ * TickBuffer is a thin data structure that powers Phase 3 of the
+ * multiplayer client work: storing recent server snapshots by tick number
+ * and interpolating between adjacent ticks for smooth rendering. These
+ * tests cover insertion, eviction, exact lookup, interpolation, and edge
+ * cases (out-of-order inserts, missing interpolate fn, out-of-range
+ * queries). Prediction and reconciliation are handled separately in
+ * `js/net/prediction.js`.
+ */
+
+import { describe, expect, jest, test } from '@jest/globals';
+
+import { TickBuffer } from '../../../js/net/tick-buffer.js';
+
+// Simple 1-D linear interpolator for tests. State shape is `{x: number}`.
+const lerpX = (s1, s2, t) => ({ x: s1.x + (s2.x - s1.x) * t });
+
+describe('TickBuffer', () => {
+    test('new buffer is empty', () => {
+        const buf = new TickBuffer();
+        expect(buf.size()).toBe(0);
+        expect(buf.getLatest()).toBeNull();
+        expect(buf.getByTick(0)).toBeNull();
+    });
+
+    test('default capacity is 32 and can be overridden', () => {
+        const def = new TickBuffer();
+        expect(def.capacity).toBe(32);
+        const custom = new TickBuffer({ capacity: 8 });
+        expect(custom.capacity).toBe(8);
+    });
+
+    test('constructor rejects non-positive capacity', () => {
+        expect(() => new TickBuffer({ capacity: 0 })).toThrow(RangeError);
+        expect(() => new TickBuffer({ capacity: -3 })).toThrow(RangeError);
+        expect(() => new TickBuffer({ capacity: NaN })).toThrow(RangeError);
+    });
+
+    test('insert one entry — size and getLatest', () => {
+        const buf = new TickBuffer();
+        const state = { x: 10 };
+        buf.insert(5, state);
+        expect(buf.size()).toBe(1);
+        const latest = buf.getLatest();
+        expect(latest).not.toBeNull();
+        expect(latest.tick).toBe(5);
+        expect(latest.state).toBe(state);
+    });
+
+    test('insert beyond capacity evicts the oldest entry', () => {
+        const buf = new TickBuffer({ capacity: 3 });
+        buf.insert(1, { x: 1 });
+        buf.insert(2, { x: 2 });
+        buf.insert(3, { x: 3 });
+        buf.insert(4, { x: 4 }); // evicts tick=1
+        expect(buf.size()).toBe(3);
+        expect(buf.getByTick(1)).toBeNull();
+        expect(buf.getByTick(2)).toEqual({ x: 2 });
+        expect(buf.getByTick(4)).toEqual({ x: 4 });
+        expect(buf.getLatest().tick).toBe(4);
+    });
+
+    test('getByTick — exact match returns stored state', () => {
+        const buf = new TickBuffer();
+        const s7 = { x: 70 };
+        buf.insert(7, s7);
+        buf.insert(8, { x: 80 });
+        expect(buf.getByTick(7)).toBe(s7);
+    });
+
+    test('getByTick — miss returns null', () => {
+        const buf = new TickBuffer();
+        buf.insert(10, { x: 100 });
+        buf.insert(12, { x: 120 });
+        expect(buf.getByTick(11)).toBeNull();
+        expect(buf.getByTick(99)).toBeNull();
+        expect(buf.getByTick(-1)).toBeNull();
+    });
+
+    test('getInterpolated — exact tick match returns state without calling interpolate', () => {
+        const interpolate = jest.fn(lerpX);
+        const buf = new TickBuffer({ interpolate });
+        const s5 = { x: 50 };
+        buf.insert(4, { x: 40 });
+        buf.insert(5, s5);
+        buf.insert(6, { x: 60 });
+        const out = buf.getInterpolated(5);
+        expect(out).toBe(s5);
+        expect(interpolate).not.toHaveBeenCalled();
+    });
+
+    test('getInterpolated — between adjacent ticks lerps with correct t', () => {
+        const interpolate = jest.fn(lerpX);
+        const buf = new TickBuffer({ interpolate });
+        buf.insert(10, { x: 0 });
+        buf.insert(20, { x: 100 });
+        const out = buf.getInterpolated(13);
+        // t = (13 - 10) / (20 - 10) = 0.3 → x = 0 + 0.3*(100-0) = 30
+        expect(out).toEqual({ x: 30 });
+        expect(interpolate).toHaveBeenCalledTimes(1);
+        const [a, b, t] = interpolate.mock.calls[0];
+        expect(a).toEqual({ x: 0 });
+        expect(b).toEqual({ x: 100 });
+        expect(t).toBeCloseTo(0.3);
+    });
+
+    test('getInterpolated — fractional tick between adjacent integers', () => {
+        const buf = new TickBuffer({ interpolate: lerpX });
+        buf.insert(0, { x: 0 });
+        buf.insert(1, { x: 100 });
+        expect(buf.getInterpolated(0.25)).toEqual({ x: 25 });
+        expect(buf.getInterpolated(0.5)).toEqual({ x: 50 });
+        expect(buf.getInterpolated(0.75)).toEqual({ x: 75 });
+    });
+
+    test('getInterpolated — outside buffered range returns null', () => {
+        const buf = new TickBuffer({ interpolate: lerpX });
+        buf.insert(10, { x: 100 });
+        buf.insert(20, { x: 200 });
+        expect(buf.getInterpolated(9)).toBeNull();
+        expect(buf.getInterpolated(21)).toBeNull();
+        expect(buf.getInterpolated(1000)).toBeNull();
+    });
+
+    test('getInterpolated — without interpolate fn returns null', () => {
+        const buf = new TickBuffer(); // no interpolate
+        buf.insert(1, { x: 1 });
+        buf.insert(2, { x: 2 });
+        // Even with a valid bracketing tick, no interpolate fn → null.
+        expect(buf.getInterpolated(1.5)).toBeNull();
+        // And exact match also returns null when no interpolate fn is set —
+        // callers should use getByTick for that path.
+        expect(buf.getInterpolated(1)).toBeNull();
+    });
+
+    test('getInterpolated — empty buffer returns null', () => {
+        const buf = new TickBuffer({ interpolate: lerpX });
+        expect(buf.getInterpolated(0)).toBeNull();
+        expect(buf.getInterpolated(5)).toBeNull();
+    });
+
+    test('clear empties the buffer', () => {
+        const buf = new TickBuffer();
+        buf.insert(1, { x: 1 });
+        buf.insert(2, { x: 2 });
+        buf.insert(3, { x: 3 });
+        expect(buf.size()).toBe(3);
+        buf.clear();
+        expect(buf.size()).toBe(0);
+        expect(buf.getLatest()).toBeNull();
+        expect(buf.getByTick(2)).toBeNull();
+    });
+
+    test('out-of-order inserts are sorted by tick', () => {
+        const buf = new TickBuffer({ interpolate: lerpX });
+        buf.insert(20, { x: 200 });
+        buf.insert(10, { x: 100 });
+        buf.insert(30, { x: 300 });
+        buf.insert(15, { x: 150 });
+
+        expect(buf.size()).toBe(4);
+        // Latest should be tick=30.
+        expect(buf.getLatest().tick).toBe(30);
+        // Internal order: 10, 15, 20, 30 — interpolating tick=17.5 should
+        // bracket between 15 and 20.
+        const out = buf.getInterpolated(17.5);
+        // t = (17.5 - 15) / (20 - 15) = 0.5 → x = 150 + 0.5*(200-150) = 175
+        expect(out).toEqual({ x: 175 });
+    });
+
+    test('inserting at an existing tick replaces the stored state (latest-write-wins)', () => {
+        const buf = new TickBuffer();
+        buf.insert(5, { x: 50, v: 'old' });
+        buf.insert(5, { x: 55, v: 'new' });
+        expect(buf.size()).toBe(1);
+        expect(buf.getByTick(5)).toEqual({ x: 55, v: 'new' });
+    });
+
+    test('eviction order is FIFO by tick after out-of-order inserts', () => {
+        const buf = new TickBuffer({ capacity: 3 });
+        buf.insert(10, { x: 10 });
+        buf.insert(30, { x: 30 });
+        buf.insert(20, { x: 20 });
+        // Buffer now holds {10,20,30}. Adding 40 evicts tick=10 (oldest).
+        buf.insert(40, { x: 40 });
+        expect(buf.size()).toBe(3);
+        expect(buf.getByTick(10)).toBeNull();
+        expect(buf.getByTick(20)).toEqual({ x: 20 });
+        expect(buf.getByTick(30)).toEqual({ x: 30 });
+        expect(buf.getByTick(40)).toEqual({ x: 40 });
+    });
+
+    test('insert rejects non-finite ticks', () => {
+        const buf = new TickBuffer();
+        expect(() => buf.insert(NaN, {})).toThrow(TypeError);
+        expect(() => buf.insert(Infinity, {})).toThrow(TypeError);
+        expect(() => buf.insert(-Infinity, {})).toThrow(TypeError);
+    });
+
+    test('getInterpolated picks the correct bracket among many entries', () => {
+        const interpolate = jest.fn(lerpX);
+        const buf = new TickBuffer({ interpolate });
+        for (let i = 0; i < 10; i++) buf.insert(i, { x: i * 10 });
+        const out = buf.getInterpolated(6.5);
+        // Brackets 6 and 7: t=0.5 → x = 60 + 0.5*(70-60) = 65
+        expect(out).toEqual({ x: 65 });
+        const [a, b, t] = interpolate.mock.calls[0];
+        expect(a).toEqual({ x: 60 });
+        expect(b).toEqual({ x: 70 });
+        expect(t).toBeCloseTo(0.5);
+    });
+});


### PR DESCRIPTION
## Summary
**First Phase 3 piece** (task #31). Creates `js/net/tick-buffer.js` with `TickBuffer` class — a ring buffer storing recent server snapshots keyed by tick number, with interpolation between adjacent ticks. **No wiring** into existing code; pure data structure with Jest tests.

## API
```js
new TickBuffer({ capacity = 32, interpolate = null })
buffer.insert(tick, state)
buffer.getByTick(tick)            // exact lookup or null
buffer.getLatest()                // { tick, state } or null
buffer.getInterpolated(tick)      // calls interpolate(s1, s2, t)
buffer.clear()
buffer.size()
```

## Implementation
- Internal Array sorted by tick (out-of-order inserts tolerated)
- Capacity overflow evicts lowest-tick entry (FIFO by tick)
- Duplicate tick: latest-write-wins
- Non-finite ticks rejected
- Exact-match `getInterpolated` skips interpolate fn call
- State-shape-agnostic via user-supplied `interpolate(s1, s2, t)`

## Tests
19 Jest tests covering construction, insert/size/getLatest, capacity eviction, getByTick exact/miss, interpolation (exact/lerp/fractional/out-of-range/no-fn/empty/multi-bracket), clear, out-of-order sorting, latest-write-wins, FIFO order, non-finite rejection.

## Test plan
- [x] `tick-buffer.test.js`: 19 passed
- [x] Full unit suite: 442/442 across 19 suites

## Architectural notes for next Phase 3 work
**Existing scaffolding discovered**:
- `js/net/interpolation.js::Interpolator` — 4-snapshot server-time-keyed ring, render-ready remote-entity smoother (ships/enemies/asteroids/drops with x/y/vx/vy lerp)
- `js/net/prediction.js::Predictor` — skeleton with `setBaseline`, `applyLocalInput`, `onSnapshot`(reconciliation); depends on `updateShip` callback (waiting on Phase 1 sim — already done)

**Next pieces** (separate sessions):
1. Wire `Predictor.updateShip` to `js/sim/ship.js`
2. (Optional refactor) Make `Interpolator` compose `TickBuffer` with its `lerpSnapshot` as the interpolate fn
3. End-to-end prediction + interpolation wiring in `EngineDriver`

## Phase 3 progress (task #31): 1 piece landed (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)