### PR TITLE
mp/sim-rs: Rust mirror of player-vs-enemy collision (Phase 2.5)

### DIFF
--- a/server/src/sim/collision.rs
+++ b/server/src/sim/collision.rs
@@ -393,6 +393,47 @@ pub enum CollisionEvent {
         /// `true` ↔ wrapper should remove the bullet from the pool.
         bullet_will_despawn: bool,
     },
+    /// Mirrors `{ type: 'player_hit_enemy', ... }` in `js/sim/collision.js`.
+    ///
+    /// IMPORTANT: math model is DIFFERENT from `PlayerHitAsteroid`. The
+    /// player-vs-enemy path uses a textbook restitution-based impulse model
+    /// (mirrors lines 1753–1794 of `collision-system.js`):
+    ///
+    ///   impulseScalar  = -(1 + BOUNCE_RESTITUTION) · velAlongNormal
+    ///                    / (playerMass + enemyMass)
+    ///   playerImpulse  = impulseScalar · normal · enemyMass  · BOUNCE_FORCE_MULTIPLIER
+    ///   enemyImpulse   = -impulseScalar · normal · playerMass · BOUNCE_FORCE_MULTIPLIER
+    ///
+    /// The path BAILS on separating velocities (`velAlongNormal > 0`):
+    /// impulse deltas are zero on graze frames, but damage and separation
+    /// still fire. Separation is `overlap × OVERLAP_SEPARATION_RATIO` SPLIT
+    /// between both bodies (player + enemy each get a mirror-image push).
+    /// There is NO `OVERLAP_PUSH_FORCE` velocity nudge — that constant is
+    /// asteroid-pair only. There is NO atan2 jitter — fully deterministic.
+    ///
+    /// Velocity deltas the wrapper applies:
+    ///   - `player.vel.x += player_impulse_dx; player.vel.y += player_impulse_dy`
+    ///   - `enemy.vel.x  += enemy_impulse_dx;  enemy.vel.y  += enemy_impulse_dy`
+    /// Position deltas the wrapper applies:
+    ///   - `player.x += separation_dx;       player.y += separation_dy`
+    ///   - `enemy.x  += enemy_separation_dx; enemy.y  += enemy_separation_dy`
+    ///     (wrapper applies enemy-side only if the enemy wasn't destroyed
+    ///     by the damage application earlier in the legacy handler).
+    PlayerHitEnemy {
+        player_id: u32,
+        enemy_id: u32,
+        damage_to_enemy: f32,
+        player_impulse_dx: f32,
+        player_impulse_dy: f32,
+        enemy_impulse_dx: f32,
+        enemy_impulse_dy: f32,
+        /// Player-side position delta (mirror of enemy_separation_*).
+        separation_dx: f32,
+        separation_dy: f32,
+        /// Enemy-side position delta (mirror of player separation_*).
+        enemy_separation_dx: f32,
+        enemy_separation_dy: f32,
+    },
 }
 
 // ─── Bullet-vs-asteroid pair detection ──────────────────────────────
@@ -810,6 +851,15 @@ pub struct CollisionEnemy {
     pub vx: f32,
     pub vy: f32,
     pub radius: f32,
+    /// Optional explicit mass. Consumed by the player-vs-enemy pair to
+    /// scale impulse magnitudes via the textbook restitution formula.
+    /// When `None`, the JS code falls back to the same ship-disk formula
+    /// used for players (`π · r² · 0.5`), NOT the asteroid `(4/3)π r³`
+    /// formula — see `js/sim/collision.js:1131–1133`. The live `Enemy`
+    /// class assigns `mass` directly per type, so production code sets
+    /// this explicitly; the fallback is for tests and defensive coverage.
+    /// Bullet-vs-enemy ignores this field.
+    pub mass: Option<f32>,
     /// Current hit points. Unused by the pair-detection step (the wrapper
     /// applies damage); carried for parity.
     pub hp: f32,
@@ -834,6 +884,7 @@ impl CollisionEnemy {
             vx: 0.0,
             vy: 0.0,
             radius: 18.0,
+            mass: None,
             hp: 1.0,
             active: true,
             warping: false,
@@ -980,6 +1031,276 @@ pub fn detect_bullet_enemy_hits(
             if will_despawn {
                 break;
             }
+        }
+    }
+}
+
+// ── PLAYER ↔ ENEMY — Phase 2.5 ─────────
+//
+// IMPORTANT: This pair uses DIFFERENT math than `detect_player_asteroid_hits`.
+// The legacy `handlePlayerEnemyCollision` (collision-system.js:1657–1819)
+// does NOT use the heavier `ASTEROID_KNOCKBACK_MULTIPLIER` + jittered-atan2
+// path. Instead it runs a textbook restitution-based impulse model:
+//
+//   1. Normalize collision direction (player.x - enemy.x, ...) / distance
+//   2. relativeVel = player.vel - enemy.vel
+//   3. velAlongNormal = relativeVel · normal
+//   4. IF velAlongNormal > 0 (separating) → BAIL, no impulse applied
+//   5. impulseScalar = -(1 + BOUNCE_RESTITUTION) · velAlongNormal
+//                      / (playerMass + enemyMass)
+//   6. impulse = impulseScalar · normal
+//   7. player.vel += impulse · enemyMass · BOUNCE_FORCE_MULTIPLIER
+//   8. enemy.vel  -= impulse · playerMass · BOUNCE_FORCE_MULTIPLIER
+//
+// Separation uses `OVERLAP_SEPARATION_RATIO × overlap` SPLIT between the
+// two bodies (both move, ratio rather than full overlap + buffer); NO
+// `OVERLAP_PUSH_FORCE` velocity nudge is applied (asteroid-pair only).
+// NO atan2 jitter — fully deterministic.
+//
+// What stays the same as player-vs-asteroid:
+//   - Circle-circle geometry check.
+//   - Inactive-side / warping / death-flash skip gates (enemy-side
+//     `_deathFlash` is the legacy name; collapsed to `death_flash` in
+//     this mirror).
+//   - Pure-step discipline: emit one event per hit, never mutate either
+//     side's HP / vel / position directly. The wrapper applies the
+//     reported deltas.
+//
+// What does NOT live in this module at all (stays in the wrapper):
+//   - Damage application to player.hp / enemy.hp (legacy: takeDamage)
+//   - Shield / Bulwark / Phase-Dash damage reduction
+//   - Tank consumption / death handling on player HP ≤ 0
+//   - Enemy death-flash trigger (_deathFlash = 8) and drops / XP / kills
+//   - Boss-rage enrage trigger              (legacy: boss reactive logic)
+//   - Hit-flash visuals, hit-stop, camera kick, screen shake, audio
+//   - Damage numbers, sparks, post-hit invincibility
+//
+// Source-of-truth lines in `js/modules/combat/collision-system.js`:
+//   - Player-side damage block:      1658–1731
+//   - Enemy.takeDamage + death-flash:1733–1751
+//   - Bounce / impulse model:        1753–1794
+//   - Separation push:               1796–1806
+//   - Impact particles:              1809–1815  (presentation only)
+//
+// JS reference: `js/sim/collision.js::detectPlayerEnemyHits` (lines
+// 1089–1209 in PR #40 / current master).
+
+/// Damage dealt to enemy when player collides with it. Mirrors
+/// `PLAYER_ENEMY_COLLISION_DAMAGE = 5` in `js/sim/collision.js` (line 957)
+/// and `COLLISION_CONFIG.PLAYER_ENEMY_COLLISION_DAMAGE = 5` in
+/// `js/modules/combat/collision-system.js` (line 17).
+///
+/// Higher than the asteroid equivalent (2) but still tiny relative to enemy
+/// HP, by design: ramming enemies is intentionally a *bad* strategy — the
+/// player gets bounced off (see `BOUNCE_FORCE_MULTIPLIER`) while only
+/// chipping the enemy. Killing via collision takes many rams, each
+/// costing the player health.
+pub const PLAYER_ENEMY_COLLISION_DAMAGE: f32 = 5.0;
+
+// NOTE: `BOUNCE_RESTITUTION` (0.9), `BOUNCE_FORCE_MULTIPLIER` (12.0), and
+// `OVERLAP_SEPARATION_RATIO` (0.6) — all consumed by this pair — are
+// already declared as `pub const` in the player-vs-asteroid block above.
+// We reuse them directly rather than re-exporting under enemy-specific
+// aliases; the wrapper / JS mirror uses the same constant values for the
+// bounce-pair path regardless of which pair it dispatches. JS mirrors
+// this same scoping decision (`js/sim/collision.js` lines 959–964).
+
+/// Detect player-vs-enemy collisions for one tick.
+///
+/// Pure step: reads player + enemy positions / radii / velocities,
+/// decides which pairs overlap, and pushes one `PlayerHitEnemy` event per
+/// detected hit with the velocity + position *deltas* the wrapper applies
+/// to the live state. Does NOT mutate player or enemy — every effect is
+/// reported in the event payload for the wrapper / JS mirror to apply
+/// downstream.
+///
+/// Co-op ready: takes a slice of players. The solo wrapper passes a
+/// one-element slice; future co-op sessions will pass the full ship
+/// roster. Each player is scanned against every active enemy; one player
+/// can emit multiple events per tick if it overlaps multiple enemies
+/// simultaneously (e.g. caught in a swarm).
+///
+/// Geometry:
+///   Circle-circle overlap: `(dx² + dy²) < (player.r + enemy.r)²`.
+///   JS line refs: `js/sim/collision.js:1117–1121`.
+///
+/// Bounce / impulse model (mirrors JS lines 1149–1178):
+///
+///   nx, ny         = (player.x - enemy.x, player.y - enemy.y) / distance
+///   relVx, relVy   = (player.vx - enemy.vx, player.vy - enemy.vy)
+///   velAlongNormal = relVx · nx + relVy · ny
+///
+///   IF velAlongNormal > 0  (separating)  →  BAIL — geometry overlap is
+///      reported in the event but impulse deltas are all zero. The wrapper
+///      still applies damage on these "graze" frames; this matches the
+///      legacy behavior where the damage block runs unconditionally on
+///      overlap and the bounce block gates on `velAlongNormal > 0`.
+///
+///   impulseScalar  = -(1 + BOUNCE_RESTITUTION) · velAlongNormal
+///                    / (playerMass + enemyMass)
+///   impulseX, impulseY = impulseScalar · (nx, ny)
+///
+///   playerImpulseDx = impulseX · enemyMass  · BOUNCE_FORCE_MULTIPLIER
+///   playerImpulseDy = impulseY · enemyMass  · BOUNCE_FORCE_MULTIPLIER
+///   enemyImpulseDx  = -impulseX · playerMass · BOUNCE_FORCE_MULTIPLIER
+///   enemyImpulseDy  = -impulseY · playerMass · BOUNCE_FORCE_MULTIPLIER
+///
+/// Determinism:
+///   This pair is fully deterministic — NO atan2 jitter, NO RNG
+///   consumption, NO `OVERLAP_PUSH_FORCE` velocity nudge. The asteroid
+///   pair has all three of those; this pair has none.
+///
+/// Separation push (mirrors JS lines 1183–1190):
+///   If `overlap = sumR - distance > 0`:
+///     - separationForce = overlap · OVERLAP_SEPARATION_RATIO
+///     - Player position delta: +(nx, ny) · separationForce
+///     - Enemy  position delta: -(nx, ny) · separationForce  (mirror)
+///   Both bodies move; ratio rather than `overlap + SEPARATION_BUFFER`.
+///
+/// Enemy damage:
+///   Constant `PLAYER_ENEMY_COLLISION_DAMAGE = 5`. The wrapper subtracts
+///   this from `enemy.hp` and handles death-flash + drops + kill streak.
+///   The pure step just reports the number. Damage runs unconditionally
+///   on geometric overlap, even on graze frames (separating velocities).
+///
+/// Skipped pairs (no event emitted):
+///   - Inactive player    (`!player.active`)
+///   - Inactive enemy     (`!enemy.active`)
+///   - Warping enemy      (`enemy.warping`)
+///   - Enemy mid-death    (`enemy.death_flash > 0`)
+///
+/// NOTE: Unlike asteroids, players themselves have no `_deathFlash` /
+/// `warping` gate on the player side — the legacy path only checks
+/// `player.active` (and the wrapper handles `player.invincible` as a
+/// damage-reduction layer, not a collision skip). The pure step matches
+/// that: invincibility is a wrapper concern, not a geometry concern.
+pub fn detect_player_enemy_hits(
+    players: &[CollisionPlayer],
+    enemies: &[CollisionEnemy],
+    _ctx: &CollisionContext,
+    events: &mut Vec<CollisionEvent>,
+) {
+    if players.is_empty() || enemies.is_empty() {
+        return;
+    }
+
+    for player in players.iter() {
+        // 1. Active-guard (JS collision.js:1095).
+        if !player.active {
+            continue;
+        }
+
+        let player_radius = player.radius;
+        let player_vx = player.vx;
+        let player_vy = player.vy;
+        let player_mass = player
+            .mass
+            .unwrap_or_else(|| player_mass_fallback(player_radius));
+
+        for enemy in enemies.iter() {
+            // 2. Enemy gating (JS collision.js:1104–1114).
+            if !enemy.active {
+                continue;
+            }
+            if enemy.warping {
+                continue;
+            }
+            if enemy.death_flash > 0 {
+                continue;
+            }
+
+            // 3. Circle-circle overlap (JS collision.js:1117–1121).
+            let dx = player.x - enemy.x;
+            let dy = player.y - enemy.y;
+            let sum_r = player_radius + enemy.radius;
+            let dist_sq = dx * dx + dy * dy;
+            if dist_sq >= sum_r * sum_r {
+                continue;
+            }
+
+            // ── Hit detected — compute impulse + separation ──
+
+            // 4. Enemy mass — explicit when set, else the same ship-disk
+            //    formula used for players (JS collision.js:1131–1133).
+            //    Note that the JS code falls back to `entityMass(., 'player')`
+            //    for enemies without explicit mass, NOT the asteroid formula.
+            let enemy_mass = enemy
+                .mass
+                .unwrap_or_else(|| player_mass_fallback(enemy.radius));
+
+            let distance = dist_sq.sqrt();
+
+            // Default deltas to zero so a degenerate (distance == 0) hit
+            // still emits a well-formed event with the correct ids +
+            // damage but no nonsense math.
+            let mut player_impulse_dx: f32 = 0.0;
+            let mut player_impulse_dy: f32 = 0.0;
+            let mut enemy_impulse_dx: f32 = 0.0;
+            let mut enemy_impulse_dy: f32 = 0.0;
+            let mut separation_dx: f32 = 0.0;
+            let mut separation_dy: f32 = 0.0;
+            let mut enemy_separation_dx: f32 = 0.0;
+            let mut enemy_separation_dy: f32 = 0.0;
+
+            if distance > 0.0 {
+                // 5. Normalize the collision axis (enemy → player).
+                let nx = dx / distance;
+                let ny = dy / distance;
+
+                // 6. Relative velocity, projected onto the normal
+                //    (JS collision.js:1155–1157).
+                let rel_vx = player_vx - enemy.vx;
+                let rel_vy = player_vy - enemy.vy;
+                let vel_along_normal = rel_vx * nx + rel_vy * ny;
+
+                // 7. Only apply impulse when bodies are approaching (the
+                //    textbook "do not resolve separating velocities"
+                //    guard). Mirrors JS `if (velAlongNormal <= 0)` at
+                //    line 1165. NOTE the asymmetry with the asteroid
+                //    pair: the asteroid path NEVER gates here, it always
+                //    applies the jittered knockback.
+                if vel_along_normal <= 0.0 {
+                    let total_mass = player_mass + enemy_mass;
+                    if total_mass > 0.0 {
+                        let impulse_scalar =
+                            -(1.0 + BOUNCE_RESTITUTION) * vel_along_normal / total_mass;
+                        let impulse_x = impulse_scalar * nx;
+                        let impulse_y = impulse_scalar * ny;
+
+                        player_impulse_dx = impulse_x * enemy_mass * BOUNCE_FORCE_MULTIPLIER;
+                        player_impulse_dy = impulse_y * enemy_mass * BOUNCE_FORCE_MULTIPLIER;
+                        enemy_impulse_dx = -impulse_x * player_mass * BOUNCE_FORCE_MULTIPLIER;
+                        enemy_impulse_dy = -impulse_y * player_mass * BOUNCE_FORCE_MULTIPLIER;
+                    }
+                }
+
+                // 8. Separation push — applied independent of the
+                //    velAlongNormal gate (JS collision.js:1183–1190).
+                //    Both bodies move; ratio rather than overlap + buffer.
+                let overlap = sum_r - distance;
+                if overlap > 0.0 {
+                    let separation_force = overlap * OVERLAP_SEPARATION_RATIO;
+                    separation_dx = nx * separation_force;
+                    separation_dy = ny * separation_force;
+                    enemy_separation_dx = -nx * separation_force;
+                    enemy_separation_dy = -ny * separation_force;
+                }
+            }
+
+            // 9. Emit the event (JS collision.js:1193–1206).
+            events.push(CollisionEvent::PlayerHitEnemy {
+                player_id: player.id,
+                enemy_id: enemy.id,
+                damage_to_enemy: PLAYER_ENEMY_COLLISION_DAMAGE,
+                player_impulse_dx,
+                player_impulse_dy,
+                enemy_impulse_dx,
+                enemy_impulse_dy,
+                separation_dx,
+                separation_dy,
+                enemy_separation_dx,
+                enemy_separation_dy,
+            });
         }
     }
 }

--- a/server/tests/parity_collision.rs
+++ b/server/tests/parity_collision.rs
@@ -40,9 +40,10 @@
 
 use rainboids_server::sim::collision::{
     detect_bullet_asteroid_hits, detect_bullet_enemy_hits, detect_player_asteroid_hits,
-    CollisionAsteroid, CollisionBullet, CollisionContext, CollisionEnemy, CollisionEvent,
-    CollisionPlayer, ASTEROID_KNOCKBACK_MULTIPLIER, OVERLAP_PUSH_FORCE,
-    PLAYER_ASTEROID_COLLISION_DAMAGE, SEPARATION_BUFFER,
+    detect_player_enemy_hits, CollisionAsteroid, CollisionBullet, CollisionContext, CollisionEnemy,
+    CollisionEvent, CollisionPlayer, ASTEROID_KNOCKBACK_MULTIPLIER, BOUNCE_FORCE_MULTIPLIER,
+    BOUNCE_RESTITUTION, OVERLAP_PUSH_FORCE, OVERLAP_SEPARATION_RATIO,
+    PLAYER_ASTEROID_COLLISION_DAMAGE, PLAYER_ENEMY_COLLISION_DAMAGE, SEPARATION_BUFFER,
 };
 
 // ─── Helpers ─────────────────────────────────────────────────────────
@@ -985,5 +986,506 @@ fn bullet_enemy_pierced_set_distinct_from_asteroid() {
     assert_eq!(
         bullets[0].pierced_enemies, 2,
         "shared pierced_enemies counter increments per pierce regardless of type"
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Player-vs-enemy fixtures (Phase 2.5 dispatch 4 — this PR).
+// ═════════════════════════════════════════════════════════════════════
+//
+// Mirrors `js/sim/collision.js::detectPlayerEnemyHits` and the Jest suite
+// at `tests/unit/sim/collision.test.js` (the player-enemy describe block).
+//
+// IMPORTANT: math model is DIFFERENT from the asteroid pair. The
+// player-vs-enemy path uses a textbook restitution-based impulse model
+// (`-(1 + R) · vN / totalMass`) gated on `velAlongNormal > 0`, with
+// `BOUNCE_FORCE_MULTIPLIER = 12.0`, separation =
+// `overlap × OVERLAP_SEPARATION_RATIO` SPLIT between both bodies, NO
+// `OVERLAP_PUSH_FORCE` velocity nudge, NO atan2 jitter — fully
+// deterministic. Damage is unconditional on overlap; bounce gates on
+// approach.
+//
+// Coverage:
+//   15. `player_enemy_single_hit_approaching`
+//       — both-body impulse + separation when approaching; damage=5.
+//   16. `player_enemy_geometry_miss`
+//       — 200 px gap → 0 events.
+//   17. `player_enemy_graze_separating`
+//       — overlapping with velAlongNormal > 0 → damage-only event
+//         (zero impulses, zero separations on the bounce; but separation
+//         still applies because overlap > 0). Actually the JS code applies
+//         separation independent of the bail-out — so impulses zero,
+//         separations nonzero. Pin this asymmetry exactly.
+//   18. `player_enemy_multiple_hits`
+//       — player overlapping 2 enemies → 2 events.
+//   19. `player_enemy_skip_gates`
+//       — inactive player/enemy, warping, death_flash → 0 events.
+//   20. `player_enemy_textbook_restitution_pin`
+//       — zero-velocity player + zero-velocity enemy at known positions
+//         → zero impulses (no jitter, no OVERLAP_PUSH_FORCE); damage
+//         still emitted; separation matches `overlap × ratio` formula.
+
+// ---------------------------------------------------------------------
+// Helpers — build minimal player/enemy pairs. `make_player` is already
+// defined for earlier dispatches; reuse it here. The enemy helper for
+// the player-enemy pair sets an explicit `mass` field (the JS test suite
+// pins mass=200 via `makeEnemy`).
+// ---------------------------------------------------------------------
+
+/// Build an enemy at (x, y) with explicit `mass = 200` (JS default in
+/// `makeEnemy`). The bullet-enemy `make_enemy` helper above leaves mass
+/// unset; the player-enemy pair needs mass explicit so the textbook
+/// impulse math has a stable reference point.
+fn make_enemy_with_mass(id: u32, x: f32, y: f32) -> CollisionEnemy {
+    let mut e = CollisionEnemy::fresh(id);
+    e.x = x;
+    e.y = y;
+    e.mass = Some(200.0);
+    e
+}
+
+// ---------------------------------------------------------------------
+// Fixture 15 — single overlapping player + enemy emits one event with
+// both-body impulses + separations populated when bodies are approaching.
+//
+// Mirrors `tests/unit/sim/collision.test.js::"overlapping player + enemy
+// emits one event with all 12 fields"`.
+//
+// Geometry:
+//   - Player at (100, 100), radius 15, vx=8 (eastbound).
+//   - Enemy at (120, 100), radius 18, mass 200, vx=0 (still).
+//   - distance=20, sum_r=33 ⇒ overlap=13.
+//   - Normal (enemy → player) = (-1, 0).
+//   - relVx = 8 - 0 = 8, dot normal = -8 < 0 ⇒ APPROACHING ⇒ impulse fires.
+//
+// Expected sign / shape:
+//   - Player impulse pushes west (negative dx).
+//   - Enemy impulse pushes east (positive dx; mirror).
+//   - Separation pushes player west, enemy east, both with magnitude
+//     overlap × OVERLAP_SEPARATION_RATIO = 13 × 0.6 = 7.8.
+// ---------------------------------------------------------------------
+
+#[test]
+fn player_enemy_single_hit_approaching() {
+    let mut player = make_player(1, 100.0, 100.0);
+    player.vx = 8.0;
+    player.vy = 0.0;
+
+    let enemy = make_enemy_with_mass(10, 120.0, 100.0);
+
+    let players = vec![player];
+    let enemies = vec![enemy];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_player_enemy_hits(&players, &enemies, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1, "expected exactly one player-hit-enemy event");
+
+    match events[0] {
+        CollisionEvent::PlayerHitEnemy {
+            player_id,
+            enemy_id,
+            damage_to_enemy,
+            player_impulse_dx,
+            player_impulse_dy,
+            enemy_impulse_dx,
+            enemy_impulse_dy,
+            separation_dx,
+            separation_dy,
+            enemy_separation_dx,
+            enemy_separation_dy,
+        } => {
+            assert_eq!(player_id, 1, "player_id");
+            assert_eq!(enemy_id, 10, "enemy_id");
+            assert!(
+                (damage_to_enemy - PLAYER_ENEMY_COLLISION_DAMAGE).abs() < 1e-6,
+                "damage_to_enemy = PLAYER_ENEMY_COLLISION_DAMAGE = 5"
+            );
+            assert!(
+                (damage_to_enemy - 5.0).abs() < 1e-6,
+                "damage_to_enemy = 5 (verbatim)"
+            );
+
+            // All eight numeric delta fields must be finite.
+            assert!(player_impulse_dx.is_finite(), "player_impulse_dx finite");
+            assert!(player_impulse_dy.is_finite(), "player_impulse_dy finite");
+            assert!(enemy_impulse_dx.is_finite(), "enemy_impulse_dx finite");
+            assert!(enemy_impulse_dy.is_finite(), "enemy_impulse_dy finite");
+            assert!(separation_dx.is_finite(), "separation_dx finite");
+            assert!(separation_dy.is_finite(), "separation_dy finite");
+            assert!(enemy_separation_dx.is_finite(), "enemy_separation_dx finite");
+            assert!(enemy_separation_dy.is_finite(), "enemy_separation_dy finite");
+
+            // Approaching bodies ⇒ impulses fire.
+            // Player gets pushed west (negative dx); enemy gets pushed east.
+            assert!(
+                player_impulse_dx < 0.0,
+                "player gets shoved west, got dx={}",
+                player_impulse_dx
+            );
+            assert!(
+                enemy_impulse_dx > 0.0,
+                "enemy gets shoved east, got dx={}",
+                enemy_impulse_dx
+            );
+            // Both on the x-axis ⇒ y-components ≈ 0.
+            approx_eq(player_impulse_dy, 0.0, "player_impulse_dy");
+            approx_eq(enemy_impulse_dy, 0.0, "enemy_impulse_dy");
+
+            // Separation:
+            //   overlap = 13, ratio = 0.6 ⇒ separationForce = 7.8.
+            //   Player goes west: separation_dx = -7.8.
+            //   Enemy goes east: enemy_separation_dx = +7.8.
+            let expected_sep_force = 13.0 * OVERLAP_SEPARATION_RATIO; // 7.8
+            approx_eq(separation_dx, -expected_sep_force, "separation_dx");
+            approx_eq(separation_dy, 0.0, "separation_dy");
+            approx_eq(
+                enemy_separation_dx,
+                expected_sep_force,
+                "enemy_separation_dx",
+            );
+            approx_eq(enemy_separation_dy, 0.0, "enemy_separation_dy");
+
+            // Newton's-law sanity: enemy separation mirrors player.
+            approx_eq(
+                enemy_separation_dx,
+                -separation_dx,
+                "enemy_separation_dx mirrors -separation_dx",
+            );
+        }
+        ev => panic!("expected PlayerHitEnemy, got {:?}", ev),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture 16 — geometry miss: centers further than sum_r apart emits no
+// event.
+//
+// Mirrors `tests/unit/sim/collision.test.js::"player outside (player.r +
+// enemy.r) emits no event"`.
+// ---------------------------------------------------------------------
+
+#[test]
+fn player_enemy_geometry_miss() {
+    let player = make_player(1, 0.0, 0.0);
+    // 200 px ≫ sum_r=33 ⇒ no overlap.
+    let enemy = make_enemy_with_mass(10, 200.0, 0.0);
+
+    let players = vec![player];
+    let enemies = vec![enemy];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_player_enemy_hits(&players, &enemies, &ctx, &mut events);
+
+    assert!(
+        events.is_empty(),
+        "player outside sum-of-radii should emit no event, got {:?}",
+        events
+    );
+}
+
+// ---------------------------------------------------------------------
+// Fixture 17 — separating velocities (graze frame). Bodies overlap but
+// their relative velocity already points outward ⇒ bounce impulses must
+// be zero. Damage event STILL fires; separation STILL applies (overlap
+// > 0 path runs independent of the bail-out — matches legacy lines
+// 1796–1806).
+//
+// Mirrors `tests/unit/sim/collision.test.js::"player moving away from
+// enemy still overlaps: damage + separation fire, impulse is zero"`.
+//
+// Geometry: player + enemy overlap (distance=20, sum_r=33). But player
+// is moving AWAY now (player westbound vx=-5, enemy stationary). Normal
+// = (-1, 0); relVx = -5, velAlongNormal = (-5) · (-1) = +5 > 0 ⇒
+// separating ⇒ bail.
+// ---------------------------------------------------------------------
+
+#[test]
+fn player_enemy_graze_separating() {
+    let mut player = make_player(1, 100.0, 100.0);
+    player.vx = -5.0;
+    player.vy = 0.0;
+
+    let enemy = make_enemy_with_mass(10, 120.0, 100.0);
+
+    let players = vec![player];
+    let enemies = vec![enemy];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_player_enemy_hits(&players, &enemies, &ctx, &mut events);
+
+    assert_eq!(
+        events.len(),
+        1,
+        "graze still emits an event (damage path runs unconditionally on overlap)"
+    );
+
+    match events[0] {
+        CollisionEvent::PlayerHitEnemy {
+            damage_to_enemy,
+            player_impulse_dx,
+            player_impulse_dy,
+            enemy_impulse_dx,
+            enemy_impulse_dy,
+            separation_dx,
+            separation_dy,
+            enemy_separation_dx,
+            enemy_separation_dy,
+            ..
+        } => {
+            // Damage still applies on graze.
+            assert!(
+                (damage_to_enemy - 5.0).abs() < 1e-6,
+                "damage still applied on graze frame"
+            );
+            // Impulses zero on both bodies — the bail-out branch.
+            approx_eq(player_impulse_dx, 0.0, "player_impulse_dx (separating)");
+            approx_eq(player_impulse_dy, 0.0, "player_impulse_dy (separating)");
+            approx_eq(enemy_impulse_dx, 0.0, "enemy_impulse_dx (separating)");
+            approx_eq(enemy_impulse_dy, 0.0, "enemy_impulse_dy (separating)");
+            // But separation STILL applies — overlap > 0 path runs
+            // independent of the velAlongNormal bail-out. Pin
+            // the EXACT formula (overlap × ratio).
+            let expected_sep_force = 13.0 * OVERLAP_SEPARATION_RATIO; // 7.8
+            approx_eq(separation_dx, -expected_sep_force, "separation_dx (graze)");
+            approx_eq(separation_dy, 0.0, "separation_dy (graze)");
+            approx_eq(
+                enemy_separation_dx,
+                expected_sep_force,
+                "enemy_separation_dx (graze)",
+            );
+            approx_eq(enemy_separation_dy, 0.0, "enemy_separation_dy (graze)");
+        }
+        ev => panic!("expected PlayerHitEnemy, got {:?}", ev),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture 18 — one player overlapping two enemies in the same tick ⇒
+// two events.
+//
+// Mirrors `tests/unit/sim/collision.test.js::"player caught between two
+// enemies emits two events"`.
+//
+// Geometry: player at (100, 100), enemies at east (120, 100) + west
+// (80, 100). sum_r=33, each enemy 20 px out ⇒ both overlap.
+// ---------------------------------------------------------------------
+
+#[test]
+fn player_enemy_multiple_hits() {
+    let player = make_player(1, 100.0, 100.0);
+
+    let east = make_enemy_with_mass(10, 120.0, 100.0);
+    let west = make_enemy_with_mass(20, 80.0, 100.0);
+
+    let players = vec![player];
+    let enemies = vec![east, west];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_player_enemy_hits(&players, &enemies, &ctx, &mut events);
+
+    assert_eq!(events.len(), 2, "expected two events (one per overlapping enemy)");
+
+    // Both events should be for the same player.
+    let mut ids: Vec<u32> = events
+        .iter()
+        .map(|e| match *e {
+            CollisionEvent::PlayerHitEnemy {
+                player_id,
+                enemy_id,
+                damage_to_enemy,
+                ..
+            } => {
+                assert_eq!(player_id, 1, "all events should be for player 1");
+                assert!(
+                    (damage_to_enemy - 5.0).abs() < 1e-6,
+                    "damage_to_enemy must be 5 on each event"
+                );
+                enemy_id
+            }
+            ev => panic!("expected PlayerHitEnemy, got {:?}", ev),
+        })
+        .collect();
+    ids.sort();
+    assert_eq!(ids, vec![10, 20], "expected enemies 10 and 20");
+}
+
+// ---------------------------------------------------------------------
+// Fixture 19 — skip gates (inactive player / inactive enemy / warping /
+// death-flash) emit no event.
+//
+// Mirrors the four `tests/unit/sim/collision.test.js::"skip"` scenarios
+// in the player-enemy describe block. Combined into a single Rust test
+// for brevity; each sub-block constructs the smallest possible failing
+// state.
+// ---------------------------------------------------------------------
+
+#[test]
+fn player_enemy_skip_gates() {
+    let ctx = CollisionContext;
+
+    // Sub-test (a): inactive player → no event.
+    {
+        let mut player = make_player(1, 100.0, 100.0);
+        player.active = false;
+        let enemy = make_enemy_with_mass(10, 120.0, 100.0);
+        let mut events: Vec<CollisionEvent> = Vec::new();
+        detect_player_enemy_hits(&[player], &[enemy], &ctx, &mut events);
+        assert!(events.is_empty(), "inactive player must not emit event");
+    }
+
+    // Sub-test (b): inactive enemy → no event.
+    {
+        let player = make_player(1, 100.0, 100.0);
+        let mut enemy = make_enemy_with_mass(10, 120.0, 100.0);
+        enemy.active = false;
+        let mut events: Vec<CollisionEvent> = Vec::new();
+        detect_player_enemy_hits(&[player], &[enemy], &ctx, &mut events);
+        assert!(events.is_empty(), "inactive enemy must not emit event");
+    }
+
+    // Sub-test (c): warping enemy → no event.
+    {
+        let player = make_player(1, 100.0, 100.0);
+        let mut enemy = make_enemy_with_mass(10, 120.0, 100.0);
+        enemy.warping = true;
+        let mut events: Vec<CollisionEvent> = Vec::new();
+        detect_player_enemy_hits(&[player], &[enemy], &ctx, &mut events);
+        assert!(events.is_empty(), "warping enemy must not emit event");
+    }
+
+    // Sub-test (d): enemy mid-death-flash → no event.
+    {
+        let player = make_player(1, 100.0, 100.0);
+        let mut enemy = make_enemy_with_mass(10, 120.0, 100.0);
+        enemy.death_flash = 5;
+        let mut events: Vec<CollisionEvent> = Vec::new();
+        detect_player_enemy_hits(&[player], &[enemy], &ctx, &mut events);
+        assert!(
+            events.is_empty(),
+            "enemy mid-death-flash must not emit event"
+        );
+    }
+
+    // Sub-test (e): empty inputs (defensive) → no event.
+    {
+        let mut events: Vec<CollisionEvent> = Vec::new();
+        detect_player_enemy_hits(
+            &[],
+            &[make_enemy_with_mass(10, 0.0, 0.0)],
+            &ctx,
+            &mut events,
+        );
+        assert!(events.is_empty(), "empty players → no event");
+
+        let mut events2: Vec<CollisionEvent> = Vec::new();
+        detect_player_enemy_hits(&[make_player(1, 0.0, 0.0)], &[], &ctx, &mut events2);
+        assert!(events2.is_empty(), "empty enemies → no event");
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture 20 — textbook restitution pin. Zero-velocity player + zero-
+// velocity enemy at known positions ⇒ velAlongNormal = 0 (the boundary
+// case, NOT separating). With both bodies stationary, the impulse path
+// fires with `vel_along_normal == 0`:
+//   impulseScalar = -(1 + 0.9) · 0 / totalMass = 0
+//   ⇒ all impulse deltas exactly zero.
+//
+// This is the asymmetry vs the asteroid pair: the asteroid path has
+// NO impulse gate AND adds OVERLAP_PUSH_FORCE × normal to the player
+// impulse. The enemy path has NEITHER — so with zero relative velocity
+// the player impulse is exactly (0, 0), not (-5, 0) like the asteroid
+// pair's separation fixture.
+//
+// Damage and separation still fire (overlap > 0 path runs
+// unconditionally). This is the "no jitter, no OVERLAP_PUSH_FORCE"
+// determinism pin.
+//
+// Geometry: player at (100, 100) r=15; enemy at (120, 100) r=18.
+//   distance = 20, sum_r = 33 ⇒ overlap = 13.
+//   Normal (enemy → player) = (-1, 0).
+//   separationForce = 13 · 0.6 = 7.8.
+//   Player separation: (-1, 0) · 7.8 = (-7.8, 0).
+//   Enemy separation:  (+1, 0) · 7.8 = (+7.8, 0).
+// ---------------------------------------------------------------------
+
+#[test]
+fn player_enemy_textbook_restitution_pin() {
+    let player = make_player(1, 100.0, 100.0);
+    let enemy = make_enemy_with_mass(10, 120.0, 100.0);
+
+    let players = vec![player];
+    let enemies = vec![enemy];
+    let ctx = CollisionContext;
+    let mut events: Vec<CollisionEvent> = Vec::new();
+
+    detect_player_enemy_hits(&players, &enemies, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1, "expected exactly one event");
+
+    let expected_sep_force = 13.0 * OVERLAP_SEPARATION_RATIO; // 7.8
+
+    match events[0] {
+        CollisionEvent::PlayerHitEnemy {
+            damage_to_enemy,
+            player_impulse_dx,
+            player_impulse_dy,
+            enemy_impulse_dx,
+            enemy_impulse_dy,
+            separation_dx,
+            separation_dy,
+            enemy_separation_dx,
+            enemy_separation_dy,
+            ..
+        } => {
+            // Damage fires regardless.
+            assert!(
+                (damage_to_enemy - 5.0).abs() < 1e-6,
+                "damage_to_enemy = 5"
+            );
+            // Zero relative velocity ⇒ impulseScalar = 0 ⇒ all impulse
+            // deltas exactly zero. NO jitter, NO OVERLAP_PUSH_FORCE
+            // — the player-enemy pair lacks both terms.
+            approx_eq(player_impulse_dx, 0.0, "player_impulse_dx (zero v)");
+            approx_eq(player_impulse_dy, 0.0, "player_impulse_dy (zero v)");
+            approx_eq(enemy_impulse_dx, 0.0, "enemy_impulse_dx (zero v)");
+            approx_eq(enemy_impulse_dy, 0.0, "enemy_impulse_dy (zero v)");
+            // Separation still fires — overlap × ratio formula, split
+            // between both bodies.
+            approx_eq(separation_dx, -expected_sep_force, "separation_dx");
+            approx_eq(separation_dy, 0.0, "separation_dy");
+            approx_eq(
+                enemy_separation_dx,
+                expected_sep_force,
+                "enemy_separation_dx",
+            );
+            approx_eq(enemy_separation_dy, 0.0, "enemy_separation_dy");
+        }
+        ev => panic!("expected PlayerHitEnemy, got {:?}", ev),
+    }
+
+    // Constant-parity guard: the player-enemy pair consumes these three
+    // verbatim from `COLLISION_CONFIG` in the legacy module. Sanity-check
+    // they still match the JS values.
+    assert!(
+        (BOUNCE_RESTITUTION - 0.9).abs() < 1e-6,
+        "BOUNCE_RESTITUTION must mirror JS verbatim"
+    );
+    assert!(
+        (BOUNCE_FORCE_MULTIPLIER - 12.0).abs() < 1e-6,
+        "BOUNCE_FORCE_MULTIPLIER must mirror JS verbatim"
+    );
+    assert!(
+        (OVERLAP_SEPARATION_RATIO - 0.6).abs() < 1e-6,
+        "OVERLAP_SEPARATION_RATIO must mirror JS verbatim"
+    );
+    assert!(
+        (PLAYER_ENEMY_COLLISION_DAMAGE - 5.0).abs() < 1e-6,
+        "PLAYER_ENEMY_COLLISION_DAMAGE must mirror JS verbatim"
     );
 }


### PR DESCRIPTION
## Summary
Rust mirror of PR #40's `detectPlayerEnemyHits`. **Textbook restitution impulse model** (NOT player-asteroid's jittered formula). 6 new parity fixtures.

## Math model (verified against JS source)
- `impulseScalar = -(1 + BOUNCE_RESTITUTION) · velAlongNormal / (playerMass + enemyMass)`
- Player gets `× enemyMass × BOUNCE_FORCE_MULTIPLIER (12.0)`; enemy gets negated mirror
- **Bails on separating velocities** — impulse zeros BUT damage + separation STILL fire
- **Separation: `overlap × OVERLAP_SEPARATION_RATIO (0.6)` SPLIT between both bodies** (mirror deltas)
- **NO jitter, NO OVERLAP_PUSH_FORCE** — fully deterministic

## Constants
- **NEW**: `PLAYER_ENEMY_COLLISION_DAMAGE = 5.0` (vs 2 for player-asteroid)
- **Reused** (from player-asteroid section): `BOUNCE_RESTITUTION`, `BOUNCE_FORCE_MULTIPLIER`, `OVERLAP_SEPARATION_RATIO`

## Type changes
- `CollisionEnemy` extended with `mass: Option<f32>` (fallback `π·r²·0.5` mirroring JS). bullet-enemy didn't need this; player-enemy does for impulse.
- New `CollisionEvent::PlayerHitEnemy` (12 fields, both-body symmetric).

## Parity fixtures (6 new, all passing)
| Test | Scenario |
|---|---|
| `player_enemy_single_hit_approaching` | Both-body impulse + separation when approaching; verifies damage=5, sep=overlap×0.6=7.8, Newton's-law mirror |
| `player_enemy_geometry_miss` | 200 px gap → 0 events |
| `player_enemy_graze_separating` | Overlapping with velAlongNormal>0 → damage event with zero impulses but nonzero separations (pins asymmetry) |
| `player_enemy_multiple_hits` | 1 player vs 2 enemies → 2 events |
| `player_enemy_skip_gates` | 5 sub-tests (inactive/warping/death_flash/empty) |
| `player_enemy_textbook_restitution_pin` | Zero-velocity → zero impulses (confirms no jitter, no OVERLAP_PUSH_FORCE); pins all 4 constants |

## Test plan
- [x] `parity_collision`: 20 passed (14 existing + 6 new)
- [x] All workspace tests green; build clean
- [x] bullet-asteroid (4), player-asteroid (6), bullet-enemy (4) fixtures still pass

## Phase 2.5 progress (task #46)
- ✓ bullet-asteroid JS + Rust
- ✓ player-asteroid JS + Rust
- ✓ bullet-enemy JS + Rust
- ✓ player-enemy JS + Rust (this PR)
- ✓ enemy-asteroid JS ⏳ (sibling PR #44 open) + Rust ⬜
- ⬜ player-enemy-bullet, drops pickup, power-weapon, defense-skill (4 pairs remaining)

🤖 Generated with [Claude Code](https://claude.com/claude-code)