### PR TITLE
mp/sim: js/sim/collision.js player-vs-enemy-bullet pure step (Phase 2.5)

### DIFF
--- a/js/sim/collision.js
+++ b/js/sim/collision.js
@@ -1458,3 +1458,185 @@ export function detectEnemyAsteroidHits(enemies, asteroids, ctx, events) {
         }
     }
 }
+
+// =====================================================================
+// PLAYER ↔ ENEMY-BULLET — Phase 2.5 dispatch (this PR)
+// =====================================================================
+//
+// Enemy bullets damage the player on overlap. Unlike the prior five
+// pairs, the pure step here is the SIMPLEST so far:
+//
+//   - NO bounce / restitution. Bullets are massless points relative to
+//     a ship; they don't push the player around. (Knockback / camera
+//     kick are wrapper-only FX concerns.)
+//   - NO position separation. The wrapper despawns the bullet anyway;
+//     there's nothing to push apart.
+//   - NO impulse to the player. Enemy bullets are presentation+damage
+//     only on the physics side.
+//   - NO mass-aware math.
+//
+// What the pure step DOES emit (per detected overlap):
+//   - A `player_hit_by_enemy_bullet` event with the bullet's damage
+//     value, the bullet's id (so the wrapper can despawn it), and the
+//     bullet's position + velocity (so the wrapper can localize the
+//     hit-flash and orient any shrapnel particles).
+//
+// What stays in the wrapper (legacy `handlePlayerEnemyBulletCollision`
+// at `js/modules/combat/collision-system.js:1821-1896`):
+//   - Player invincibility / phase-dash check (line 1832)
+//   - Effective-shield damage reduction (line 1825)
+//   - Bulwark damage reduction (lines 1827-1830)
+//   - Rounding + final damage application to `player.health` (1835-1836)
+//   - Hit-flash visuals, damage numbers, screen shake (1837-1843)
+//   - Stat tracking (`totalDamageTaken`) (line 1842)
+//   - Kill-streak break (line 1847)
+//   - XP grant for surviving a hit (line 1850)
+//   - Tank-based hit model (5.88.0 — line 1853)
+//   - Hitstop + screen shake juice (lines 1862-1864)
+//   - Per-pattern hit SFX (line 1866) — needs `bullet.firingPattern`
+//     which is presentation-only metadata
+//   - Explosion + hit particles (lines 1872-1892)
+//   - Hit-flash timer (`player._hitFlashTimer = 5`) (line 1895)
+//   - Despawning the bullet (`bullet.active = false`) — caller side
+//
+// The pure step intentionally reports ONLY the geometric hit. The
+// wrapper is the single place where the damage-reduction policy lives
+// (shield, bulwark, phase-dash, tanks) — keeping that out of the
+// detection step avoids baking gameplay tuning into the deterministic
+// sim/Rust mirror.
+//
+// Source-of-truth lines in `js/modules/combat/collision-system.js`:
+//   - Function:                              1821-1896
+//   - Damage application:                    1822-1836 (wrapper)
+//   - Default damage = 15:                   1823 (wrapper-side default;
+//                                                  this module uses 1 as
+//                                                  the safer geometric
+//                                                  default — tests pin it)
+//
+// What stays the same as prior pairs:
+//   - Circle-circle geometry check.
+//   - Inactive-side skip gates.
+//   - Pure-step discipline: emit one event per overlap, never mutate
+//     either side directly. The wrapper applies the reported damage and
+//     despawns the bullet.
+//
+// NOTE: There are NO `warping` / `deathFlash` gates on enemy bullets —
+// these are NOT entities in the warping-in/death-flash sense. A bullet
+// either is active (in flight, can hit) or inactive (despawned). The
+// player also has no warping/death-flash gate of its own (matches the
+// player-vs-enemy pair upstream).
+
+// ─── Player-vs-enemy-bullet pair detection ──────────────────────────
+
+/**
+ * Detect player-vs-enemy-bullet collisions for one tick.
+ *
+ * Pure step: reads player + enemy-bullet positions / radii, decides
+ * which pairs overlap, and emits one `player_hit_by_enemy_bullet`
+ * event per detected hit. Does NOT mutate player or bullet — every
+ * effect is reported in the event payload for the wrapper / Rust
+ * mirror to apply downstream.
+ *
+ * Co-op ready: takes an array of players. The solo wrapper passes
+ * `[player]`; future co-op sessions will pass the full ship roster.
+ * Each player is scanned against every active enemy bullet; a single
+ * player can emit multiple events per tick if it overlaps multiple
+ * bullets simultaneously (e.g. caught in a barrage).
+ *
+ * Geometry:
+ *   Circle-circle overlap: `hypot(dx, dy) < player.radius + bullet.radius`.
+ *   Identical to the legacy `collision()` helper.
+ *
+ * Damage passthrough:
+ *   Reports `bullet.damage` verbatim (defaults to 1 if falsy). The
+ *   wrapper applies all damage-reduction policy (shield, bulwark,
+ *   phase-dash, tanks) on top of this number — see the legacy
+ *   `handlePlayerEnemyBulletCollision` for the reduction pipeline.
+ *
+ * Skipped pairs (no event emitted):
+ *   - Inactive player    (`!player.active`)
+ *   - Inactive bullet    (`!bullet.active`)
+ *
+ * NO warping or death-flash gates on either side. Enemy bullets are
+ * simple flight-or-despawned entities; the player has no warping/death-
+ * flash state of its own (matches the player-vs-enemy pair upstream).
+ *
+ * NO invincibility / phase-dash / shield check — those are wrapper
+ * concerns. The pure step always emits on geometric overlap; the
+ * wrapper decides whether the damage actually lands.
+ *
+ * NO despawn flag in the event (`bulletWillDespawn`) — every enemy-
+ * bullet hit is a despawn-after-hit, so the wrapper always despawns
+ * unconditionally after consuming the event. We could redundantly
+ * report `bulletWillDespawn: true` but it adds no information.
+ *
+ * @param {Array<Object>} players   active player ships. Each treated as
+ *                                  having `{x, y, radius, active, id OR
+ *                                  player}`. Compatible with both the
+ *                                  `ShipState` typedef and the live
+ *                                  `Player` instance shape.
+ * @param {Array<Object>} bullets   active enemy bullets. Each treated as
+ *                                  having `{x, y, vx, vy, radius, damage,
+ *                                  active, id}`. Compatible with both
+ *                                  enemy-side `BulletState` (kind=enemy)
+ *                                  and the live `EnemyBullet` instance
+ *                                  shape.
+ * @param {Object} ctx              per-tick context bag (currently
+ *                                  unused; reserved for future use).
+ * @param {Array<Object>} events    out-buffer. Pushes objects with the
+ *                                  shape documented below.
+ *
+ * Event shape (one event per detected hit — exactly 7 fields):
+ *   {
+ *     type: 'player_hit_by_enemy_bullet',
+ *     playerId:               id of the hit ship
+ *     bulletId:               id of the bullet that hit
+ *     damage:                 bullet.damage (defaults to 1)
+ *     bulletX, bulletY:       impact point — used by the wrapper to
+ *                             localize hit-flash + spawn particles
+ *     bulletVx, bulletVy:     bullet velocity at impact — used by the
+ *                             wrapper to orient shrapnel / camera kick
+ *   }
+ */
+export function detectPlayerEnemyBulletHits(players, bullets, ctx, events) {
+    if (!players || !bullets) return;
+    if (players.length === 0 || bullets.length === 0) return;
+
+    for (let i = 0; i < players.length; i++) {
+        const player = players[i];
+        if (!player || !player.active) continue;
+
+        const playerRadius = player.radius || 0;
+        const pId = entityId(player);
+
+        for (let j = 0; j < bullets.length; j++) {
+            const bullet = bullets[j];
+            if (!bullet || !bullet.active) continue;
+
+            // Circle-circle overlap check.
+            const dx = player.x - bullet.x;
+            const dy = player.y - bullet.y;
+            const sumR = playerRadius + (bullet.radius || 0);
+            const distSq = dx * dx + dy * dy;
+            if (distSq >= sumR * sumR) continue;
+
+            // Damage passthrough — default 1 if the bullet has no
+            // damage attribute or it's zero/falsy. The wrapper applies
+            // its own default (15) at the legacy site, but we pick a
+            // safe geometric-default of 1 here so the event always
+            // carries a positive integer.
+            const damage = bullet.damage || 1;
+
+            events.push({
+                type: 'player_hit_by_enemy_bullet',
+                playerId: pId,
+                bulletId: bullet.id,
+                damage,
+                bulletX: bullet.x,
+                bulletY: bullet.y,
+                bulletVx: bullet.vx || 0,
+                bulletVy: bullet.vy || 0,
+            });
+        }
+    }
+}

--- a/tests/unit/sim/collision.test.js
+++ b/tests/unit/sim/collision.test.js
@@ -37,6 +37,7 @@ import {
     detectEnemyAsteroidHits,
     ENEMY_ASTEROID_PUSH,
     ASTEROID_ENEMY_PUSH,
+    detectPlayerEnemyBulletHits,
 } from '../../../js/sim/collision.js';
 import {
     freshAsteroidState,
@@ -1656,6 +1657,258 @@ describe('detectEnemyAsteroidHits — empty inputs', () => {
     test('null asteroids → no events (defensive)', () => {
         const events = [];
         detectEnemyAsteroidHits([enemyWithRadius(7, 0, 0)], null, ctx, events);
+        expect(events).toHaveLength(0);
+    });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// Player-vs-enemy-bullet pair (Phase 2.5 — dispatch 6).
+// ═════════════════════════════════════════════════════════════════════
+//
+// `detectPlayerEnemyBulletHits` is the sixth pure-step pair, extracted
+// from `handlePlayerEnemyBulletCollision` in
+// `js/modules/combat/collision-system.js` (lines 1821-1896). This pair
+// is the SIMPLEST so far:
+//
+//   - NO bounce / restitution / impulse on either side.
+//   - NO position separation.
+//   - NO mass-aware math.
+//   - The pure step only emits a damage event with bullet metadata
+//     (position + velocity) for the wrapper to localize FX. The wrapper
+//     applies damage (with shield / bulwark / phase-dash / tanks
+//     policy), despawns the bullet, and runs all the presentation /
+//     audio / particle effects.
+//
+// Event shape: exactly 7 fields including `type`. The wrapper consumes
+// `damage` + `playerId` to apply HP loss and `bulletId` to despawn.
+//
+// The tests below pin:
+//   - single hit happy path (all 7 fields populated correctly)
+//   - geometry miss (no event)
+//   - multiple bullets in one tick (one event per overlap)
+//   - skip gates (inactive player, inactive bullet)
+//   - damage passthrough (bullet.damage = 7 → event.damage = 7;
+//     bullet.damage = 0 → event.damage = 1 default)
+//   - defensive empty / null inputs
+
+// ---------------------------------------------------------------------
+// Helpers — reuse `makePlayer` from the player-asteroid block. Build
+// enemy bullets with `freshBulletState(id, 'enemy', ...)`. Default
+// radius=9 matches the live `EnemyBullet` constructor.
+// ---------------------------------------------------------------------
+
+function enemyBullet(id, x, y, overrides = {}) {
+    return freshBulletState(id, 'enemy', {
+        x, y, radius: 9, baseRadius: 9, damage: 2, ...overrides,
+    });
+}
+
+// ---------------------------------------------------------------------
+// (No new constants for this pair — damage value comes from the bullet.
+// The default-damage fallback of 1 is an implementation detail of
+// detectPlayerEnemyBulletHits and is verified directly by the damage
+// passthrough tests below.)
+// ---------------------------------------------------------------------
+
+// ---------------------------------------------------------------------
+// Test — single hit happy path (all 7 event fields populated).
+// ---------------------------------------------------------------------
+
+describe('detectPlayerEnemyBulletHits — single hit', () => {
+    test('overlapping player + enemy bullet emits one event with all 7 fields', () => {
+        // Player radius 15 + bullet radius 9 = sumR = 24. Place bullet
+        // 10 px east of player → overlap = 14 (clear hit).
+        const p = makePlayer('p1', 100, 100);
+        const b = enemyBullet(42, 110, 100, { vx: -3, vy: 1, damage: 4 });
+        const events = [];
+        detectPlayerEnemyBulletHits([p], [b], ctx, events);
+
+        expect(events).toHaveLength(1);
+        const ev = events[0];
+        expect(ev.type).toBe('player_hit_by_enemy_bullet');
+        expect(ev.playerId).toBe('p1');
+        expect(ev.bulletId).toBe(42);
+        expect(ev.damage).toBe(4);
+        expect(ev.bulletX).toBe(110);
+        expect(ev.bulletY).toBe(100);
+        expect(ev.bulletVx).toBe(-3);
+        expect(ev.bulletVy).toBe(1);
+
+        // Explicit field-count guard — exactly 8 keys (type + 7
+        // non-type fields). If a future change adds a separation /
+        // impulse field (bullets shouldn't push the player), this
+        // catches it.
+        expect(Object.keys(ev).sort()).toEqual([
+            'bulletId', 'bulletVx', 'bulletVy', 'bulletX', 'bulletY',
+            'damage', 'playerId', 'type',
+        ].sort());
+
+        // Defensive: confirm there is NO impulse / separation field on
+        // this pair. Bullets are massless on the physics side.
+        expect(ev.playerImpulseDx).toBeUndefined();
+        expect(ev.playerImpulseDy).toBeUndefined();
+        expect(ev.bulletImpulseDx).toBeUndefined();
+        expect(ev.bulletImpulseDy).toBeUndefined();
+        expect(ev.separationDx).toBeUndefined();
+        expect(ev.separationDy).toBeUndefined();
+        // Defensive: no despawn flag — enemy bullets always despawn on
+        // hit, so the wrapper handles it unconditionally.
+        expect(ev.bulletWillDespawn).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — geometry miss.
+// ---------------------------------------------------------------------
+
+describe('detectPlayerEnemyBulletHits — geometry miss', () => {
+    test('bullet outside (player.r + bullet.r) emits no event', () => {
+        const p = makePlayer('p1', 0, 0);
+        // 200 ≫ sumR=24 → clearly no overlap.
+        const b = enemyBullet(42, 200, 0);
+        const events = [];
+        detectPlayerEnemyBulletHits([p], [b], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+
+    test('bullet just outside boundary (sumR + 1) emits no event', () => {
+        const p = makePlayer('p1', 0, 0, { radius: 15 });
+        // sumR = 15 + 9 = 24; place bullet center 25 px away → just
+        // outside.
+        const b = enemyBullet(42, 25, 0, { radius: 9 });
+        const events = [];
+        detectPlayerEnemyBulletHits([p], [b], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — multiple bullets in one tick.
+// ---------------------------------------------------------------------
+
+describe('detectPlayerEnemyBulletHits — multiple bullets in one tick', () => {
+    test('player caught in a barrage emits one event per overlapping bullet', () => {
+        // Player at (100, 100). Place three bullets that all overlap
+        // (sumR=24): two close (east + west), and one further away
+        // that misses. Verify the two overlapping bullets emit events
+        // and the third does not.
+        const p = makePlayer('p1', 100, 100);
+        const east = enemyBullet(10, 115, 100); // dx=15, sumR=24 ⇒ overlap
+        const west = enemyBullet(20,  85, 100); // dx=-15, sumR=24 ⇒ overlap
+        const far  = enemyBullet(30, 200, 100); // dx=100 ≫ sumR ⇒ miss
+        const events = [];
+        detectPlayerEnemyBulletHits([p], [east, west, far], ctx, events);
+        expect(events).toHaveLength(2);
+        const ids = events.map(e => e.bulletId).sort((a, b) => a - b);
+        expect(ids).toEqual([10, 20]);
+        for (const ev of events) {
+            expect(ev.playerId).toBe('p1');
+            expect(ev.type).toBe('player_hit_by_enemy_bullet');
+        }
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — skip gates (inactive player, inactive bullet).
+// ---------------------------------------------------------------------
+
+describe('detectPlayerEnemyBulletHits — skipped pairs', () => {
+    test('inactive player → no event', () => {
+        const p = makePlayer('p1', 100, 100, { active: false });
+        const b = enemyBullet(42, 110, 100);
+        const events = [];
+        detectPlayerEnemyBulletHits([p], [b], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+
+    test('inactive bullet → no event', () => {
+        const p = makePlayer('p1', 100, 100);
+        const b = enemyBullet(42, 110, 100, { active: false });
+        const events = [];
+        detectPlayerEnemyBulletHits([p], [b], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+
+    test('both inactive → no event', () => {
+        const p = makePlayer('p1', 100, 100, { active: false });
+        const b = enemyBullet(42, 110, 100, { active: false });
+        const events = [];
+        detectPlayerEnemyBulletHits([p], [b], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — damage passthrough. Bullet damage value is reported verbatim
+// in the event, with a default of 1 if the bullet has no damage or it's
+// falsy. The wrapper applies shield/bulwark/phase-dash on top.
+// ---------------------------------------------------------------------
+
+describe('detectPlayerEnemyBulletHits — damage passthrough', () => {
+    test('bullet.damage = 7 → event.damage = 7 (verbatim)', () => {
+        const p = makePlayer('p1', 100, 100);
+        const b = enemyBullet(42, 110, 100, { damage: 7 });
+        const events = [];
+        detectPlayerEnemyBulletHits([p], [b], ctx, events);
+        expect(events).toHaveLength(1);
+        expect(events[0].damage).toBe(7);
+    });
+
+    test('bullet.damage = 0 → event.damage = 1 (default fallback)', () => {
+        // The pure step's geometric-default of 1 ensures the event
+        // always carries a positive integer when the wrapper consumes
+        // it. (The legacy wrapper has its own default of 15 if .damage
+        // is missing, but it applies that at the wrapper boundary — the
+        // pure step picks the safer geometric default.)
+        const p = makePlayer('p1', 100, 100);
+        const b = enemyBullet(42, 110, 100, { damage: 0 });
+        const events = [];
+        detectPlayerEnemyBulletHits([p], [b], ctx, events);
+        expect(events).toHaveLength(1);
+        expect(events[0].damage).toBe(1);
+    });
+
+    test('bullet.damage = 25 (explosive-style high damage) → event.damage = 25', () => {
+        // EnemyBullet sets damage=3 for explosive, but the wrapper may
+        // bump it higher per pattern. Verify the pure step passes any
+        // positive value through unchanged.
+        const p = makePlayer('p1', 100, 100);
+        const b = enemyBullet(42, 110, 100, { damage: 25 });
+        const events = [];
+        detectPlayerEnemyBulletHits([p], [b], ctx, events);
+        expect(events).toHaveLength(1);
+        expect(events[0].damage).toBe(25);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Test — empty / null inputs defensive guards.
+// ---------------------------------------------------------------------
+
+describe('detectPlayerEnemyBulletHits — empty inputs', () => {
+    test('empty players → no events', () => {
+        const events = [];
+        detectPlayerEnemyBulletHits([], [enemyBullet(42, 0, 0)], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('empty bullets → no events', () => {
+        const events = [];
+        detectPlayerEnemyBulletHits([makePlayer('p1', 0, 0)], [], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('both empty → no events', () => {
+        const events = [];
+        detectPlayerEnemyBulletHits([], [], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('null players → no events (defensive)', () => {
+        const events = [];
+        detectPlayerEnemyBulletHits(null, [enemyBullet(42, 0, 0)], ctx, events);
+        expect(events).toHaveLength(0);
+    });
+    test('null bullets → no events (defensive)', () => {
+        const events = [];
+        detectPlayerEnemyBulletHits([makePlayer('p1', 0, 0)], null, ctx, events);
         expect(events).toHaveLength(0);
     });
 });


### PR DESCRIPTION
## Summary
Phase 2.5 dispatch — 6th collision pair on JS side. Enemy bullets hitting the player. Pure geometric overlap → emit damage event; wrapper applies invincibility/shield/HP + visuals. Legacy `collision-system.js` UNTOUCHED.

## New function
```js
detectPlayerEnemyBulletHits(players, bullets, ctx, events)
```
- Pure step: emits one damage event per overlap
- Skip-gates: `!player.active`, `!bullet.active`
- No new constants — damage comes from `bullet.damage`

## Event shape (8 keys)
```js
{ type: 'player_hit_by_enemy_bullet',
  playerId, bulletId, damage,
  bulletX, bulletY, bulletVx, bulletVy }
```

**Damage default = 1** (not 15 like legacy wrapper default) — pure step picks safer geometric default; the wrapper's 15-default is policy.

## Design decisions
- **No `warping`/`deathFlash` skip-gates**: enemy bullets are flight-or-despawned (no warp/death state); player has no warping state.
- **No `bulletWillDespawn` field**: every enemy-bullet hit despawns unconditionally; the flag would carry no info.

## Wrapper-side concerns (NOT in pure step, documented in JSDoc)
- Invincibility / phase-dash check
- Effective-shield damage reduction (`damage * (1 - shield/100)`)
- Bulwark / IRON_WILL reduction
- HP application + tank consumption (5.88.0 health tanks)
- Damage numbers, hit-flash, screen shake, hitstop
- Stat tracking, kill-streak break, XP grant
- Per-pattern hit SFX
- Explosion + hit particle spawning
- Bullet despawn

## Tests added: 15 across 6 describe blocks
Single hit (1), geometry miss (2), multiple bullets (1), skip-gates (3), damage passthrough (3 — including 0→1 default), empty/null defensive (5).

## Test plan
- [x] `collision.test.js`: 126 tests pass (111 existing + 15 new)
- [x] `collision-system.js` UNTOUCHED

## Phase 2.5 progress (task #46)
- ✓ bullet-asteroid JS + Rust
- ✓ player-asteroid JS + Rust
- ✓ bullet-enemy JS + Rust
- ✓ player-enemy JS + Rust
- ✓ enemy-asteroid JS + Rust ⏳ (sibling Rust PR open)
- ✓ player-enemy-bullet JS (this PR) + Rust ⬜
- ⬜ drops pickup, power-weapon (5 weapons), defense-skill (2 skills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)