### PR TITLE
mp/net: wire Predictor.updateShip to js/sim/ship.js (Phase 3)

### DIFF
--- a/js/net/prediction.js
+++ b/js/net/prediction.js
@@ -3,36 +3,63 @@
 // Every input frame we apply locally and remember in a pending buffer.
 // When a server snapshot arrives, we drop any pending inputs whose
 // tick is ≤ the snapshot's tick, then replay the remaining buffer
-// against the snapshot's authoritative ship state. With fixed-point
+// against the snapshot's authoritative ship state. With deterministic
 // physics on both sides, the replayed state should equal the locally
-// predicted state byte-for-byte.
+// predicted state byte-for-byte (today: f32; Fxp migration is a later
+// session, see `docs/Multiplayer Rust Client Engine – 2026-05-07.md`).
 //
 // Design contract (cf. `Multiplayer Rust Client Engine` plan §"Reconciliation
 // strategy"): if `predictionDivergence` ever fires in the field, the
 // parity harness has a hole. Log loudly and fix the harness.
+//
+// ── Wiring (2026-05-11) ─────────────────────────────────────────────────────
+// The default `updateShip` callback now delegates to the pure ship-physics
+// step at `js/sim/ship.js::updateShip`. That function has the signature
+//   updateShip(ship, input, dt, rng, events)
+// and **mutates `ship` in place**. The Predictor's internal contract was
+// 3-arg (`ship, input, dt`) and a returned ship value. To bridge:
+//
+//   1. The default callback supplies `null` for `rng` and a fresh array
+//      for `events` (the ship step emits no events today; the slot is
+//      reserved for future bullet-spawn migration).
+//   2. `applyLocalInput` calls the callback over the live `localShipState`
+//      object and accepts the (mutated) return — fine since `localShipState`
+//      is owned by the Predictor.
+//   3. `onSnapshot`'s replay path clones the server ship before the loop
+//      (so the server snapshot reference passed in by the caller is never
+//      mutated), then mutates that clone tick-by-tick through the callback.
+//
+// Callers that want to inject a different physics step (cross-language
+// parity harness, deterministic Fxp variant, mocked updates in tests) can
+// still pass `{ updateShip: myFn }` to the constructor — the only contract
+// is "(ship, input, dt, rng, events) → mutates and returns ship".
 
-import { Fxp } from '../sim/fxp.js';
+import { updateShip as pureUpdateShip } from '../sim/ship.js';
 
 /**
- * Pure ship-update step. Mirror of `server/src/sim/ship.rs::update_ship`.
- * For v1 this lives in this file as a placeholder; once the engine
- * refactor extracts ship physics into `js/sim/ship.js` we'll import
- * it from there.
+ * Default ship-update callback. Wraps the pure step in
+ * `js/sim/ship.js` with a no-op rng + empty events array. Mirrors
+ * `server/src/sim/ship.rs::update_ship` (modulo language).
  *
- * @param {{x: Fxp, y: Fxp, vx: Fxp, vy: Fxp, angle: number}} ship
- * @param {{moveX: number, moveY: number, aimX: number, aimY: number}} input
- * @param {Fxp} dt
- * @returns new ship state
+ * @param {import('../sim/state.js').ShipState} ship
+ * @param {import('../sim/state.js').InputFrame} input
+ * @param {number} dt   seconds (1/60 typical); current physics ignores dt
+ *                      but the slot is plumbed for forward compatibility.
+ * @returns {import('../sim/state.js').ShipState} the (mutated) ship
  */
 function defaultUpdateShip(ship, input, dt) {
-    // Stub: until `js/sim/ship.js` is extracted from game-engine.js, the
-    // predictor calls back into a wired-up update function. The default
-    // no-op keeps the predictor wireable in tests without depending on
-    // game-engine internals.
-    return ship;
+    return pureUpdateShip(ship, input, dt, null, []);
 }
 
 export class Predictor {
+    /**
+     * @param {object} [opts]
+     * @param {(ship, input, dt) => object} [opts.updateShip] - physics step;
+     *     defaults to `js/sim/ship.js::updateShip` wrapped with a null rng
+     *     and an empty events buffer.
+     * @param {number} [opts.dt] - seconds per tick (typically 1/60). Passed
+     *     to the physics step; today's `updateShip` ignores it.
+     */
     constructor({ updateShip = defaultUpdateShip, dt } = {}) {
         this.updateShip = updateShip;
         this.dt = dt;
@@ -41,46 +68,76 @@ export class Predictor {
         this.tick = 0;
         /** @type {object|null} Local predicted ship state. */
         this.localShipState = null;
-        /** Diagnostics counters. */
+        /** Diagnostics counter — incremented when a server snapshot
+         * disagrees with our locally-predicted state after replay. */
         this.divergenceCount = 0;
     }
 
-    /** Establish baseline ship state from the server's RoomJoined snapshot. */
+    /**
+     * Establish baseline ship state from the server's RoomJoined snapshot
+     * (or, in tests, from a known starting position). Replaces any prior
+     * local state and resets the tick counter.
+     *
+     * @param {object} ship - ShipState shape (see `js/sim/state.js`).
+     *     Cloned so subsequent mutation does not alias the caller's copy.
+     * @param {number} tick - server tick this baseline is anchored on.
+     */
     setBaseline(ship, tick) {
-        this.localShipState = ship;
+        this.localShipState = cloneShip(ship);
         this.tick = tick | 0;
     }
 
-    /** Apply one local input, advance prediction one tick. */
+    /**
+     * Apply one local input, advance prediction one tick. Mutates
+     * `localShipState` in place via the physics callback.
+     *
+     * @param {import('../sim/state.js').InputFrame} input
+     */
     applyLocalInput(input) {
         this.tick = (this.tick + 1) | 0;
         this.pending.push({ tick: this.tick, input });
         if (this.localShipState != null) {
-            this.localShipState = this.updateShip(this.localShipState, input, this.dt);
+            // `updateShip` mutates in place and returns the same ref. We
+            // re-assign defensively in case a custom callback returns a
+            // fresh object instead.
+            this.localShipState = this.updateShip(
+                this.localShipState,
+                input,
+                this.dt,
+            );
         }
     }
 
     /**
-     * Receive an authoritative ship state from the server. Replay any
-     * pending inputs whose tick > serverTick to derive the predicted
-     * state from this baseline; compare against our locally predicted
-     * state and warn loudly on divergence.
+     * Receive an authoritative ship state from the server. Drops any
+     * pending inputs whose tick ≤ serverTick, replays the remaining
+     * buffer against the snapshot's authoritative ship state to derive
+     * the predicted state from this baseline, compares against our
+     * locally-predicted state, and warns loudly on divergence.
+     *
+     * On divergence, the reconciled (server-anchored + replayed) state
+     * replaces the local prediction — i.e. the server wins, as it must
+     * for an authoritative-server topology.
      *
      * @param {number} serverTick
-     * @param {object} serverShip - authoritative ShipState
+     * @param {object} serverShip - authoritative ShipState. NOT mutated;
+     *     we clone before replay.
      */
     onSnapshot(serverTick, serverShip) {
         // Drop already-acknowledged inputs.
         while (this.pending.length && this.pending[0].tick <= serverTick) {
             this.pending.shift();
         }
-        // Replay pending inputs starting from the server's authoritative state.
+        // Replay pending inputs starting from the server's authoritative
+        // state. Clone first so the caller's `serverShip` ref stays
+        // untouched (the pure ship step mutates in place).
         let s = cloneShip(serverShip);
         for (const p of this.pending) {
             s = this.updateShip(s, p.input, this.dt);
         }
 
-        // Compare. Mismatch is a parity-harness escape; track it.
+        // Compare. Mismatch is a parity-harness escape; track it and
+        // snap local state to the server-anchored replay.
         if (this.localShipState && !shipsBitEqual(s, this.localShipState)) {
             this.divergenceCount++;
             // eslint-disable-next-line no-console
@@ -96,23 +153,35 @@ export class Predictor {
 }
 
 function cloneShip(s) {
-    // Shallow copy — fields are primitives or Fxp instances which are
-    // value-like (raw is i32). Fxp.add/sub/mul return fresh Fxps so
-    // mutating updateShip outputs won't alias.
+    // Shallow copy — prediction-relevant fields are primitives. The
+    // `field` reference is shared by design (immutable per-room bounds).
+    // If/when Fxp lands, `.raw` is still an i32 primitive so shallow
+    // copy stays correct.
+    if (s == null) return s;
     return { ...s };
 }
 
 function shipsBitEqual(a, b) {
     // Compare prediction-relevant fields bit-for-bit. f32 fields and the
-    // Fxp `.raw` int both compare via ===.
+    // future Fxp `.raw` int both compare via ===. Today `js/sim/ship.js`
+    // writes x, y, vx, vy, and angle each tick; all five participate in
+    // the parity check.
     if (a == null || b == null) return false;
+    // Fxp-backed shape (forward compat — not used today).
     if (a.x != null && a.x.raw !== undefined) {
         return (
             a.x.raw === b.x.raw &&
             a.y.raw === b.y.raw &&
             a.vx.raw === b.vx.raw &&
-            a.vy.raw === b.vy.raw
+            a.vy.raw === b.vy.raw &&
+            a.angle === b.angle
         );
     }
-    return a.x === b.x && a.y === b.y && a.vx === b.vx && a.vy === b.vy;
+    return (
+        a.x === b.x &&
+        a.y === b.y &&
+        a.vx === b.vx &&
+        a.vy === b.vy &&
+        a.angle === b.angle
+    );
 }

--- a/tests/unit/net/prediction.test.js
+++ b/tests/unit/net/prediction.test.js
@@ -1,0 +1,438 @@
+// tests/unit/net/prediction.test.js — unit tests for the client-side
+// prediction wrapper (`js/net/prediction.js::Predictor`).
+//
+// Predictor was scaffolded in the Phase 1 multiplayer work; this file
+// pins behavior after it was wired to the pure ship-physics step
+// (`js/sim/ship.js::updateShip`) in the Phase 3 wiring session.
+//
+// Coverage:
+//   - Baseline / no-input identity (pure-step ship is not mutated when
+//     no movement keys are pressed and the ship is at rest at center,
+//     so the predicted state for a 1-tick no-input step is reachable
+//     from a known baseline).
+//   - Single-tick directional thrust matches the underlying pure-step
+//     output exactly (proves the bridge passes input through).
+//   - Multi-tick advance (N=60) accumulates velocity then caps, then
+//     advances position monotonically.
+//   - Sequenced varied inputs over 5 ticks reproduce the canonical
+//     pure-step result (regression vector).
+//   - `setBaseline` replaces local state with a clone (caller's ref
+//     is not aliased — mutating the original after setBaseline is a
+//     no-op on the predictor).
+//   - `onSnapshot` with converged state: no divergence, local state
+//     follows the (server-anchored, replayed) prediction.
+//   - `onSnapshot` with diverged state: divergence counter increments
+//     and local state snaps to the server-anchored replay (server
+//     wins, as it must for authoritative-server topology).
+
+import { describe, expect, test, jest } from '@jest/globals';
+import { Predictor } from '../../../js/net/prediction.js';
+import { updateShip } from '../../../js/sim/ship.js';
+import { freshShipState } from '../../../js/sim/state.js';
+
+// Same constants the ship test uses (`tests/unit/sim/ship.test.js`).
+// Kept here so any tuning change in GAME_CONFIG is caught.
+const TICK_SCALE = 30 / 60; // 0.5
+const FRICTION = Math.pow(0.5, TICK_SCALE); // ≈ 0.7071067811865476
+const MAX_V = 7 * TICK_SCALE; // 3.5
+const VEL_EPS = 0.05;
+const BOUNCE_DAMP = 0.8;
+const THRUST_POWER = 2.0 * TICK_SCALE; // 1.0
+
+function freshInput(overrides = {}) {
+    return {
+        up: false,
+        down: false,
+        left: false,
+        right: false,
+        aimX: 100,
+        aimY: 0,
+        thrustPower: THRUST_POWER,
+        speedMult: 1,
+        thrustersDisabled: false,
+        maxV: MAX_V,
+        friction: FRICTION,
+        velEpsilon: VEL_EPS,
+        bounceDamp: BOUNCE_DAMP,
+        ...overrides,
+    };
+}
+
+// Convenience: aim straight east from a centered ship (matches the
+// `freshShipState` default x = field.width/2 = 960).
+const AIM_EAST = { aimX: 2000, aimY: 540 };
+
+describe('Predictor — setBaseline', () => {
+    test('clones the provided ship so caller mutation does not bleed in', () => {
+        const ship = freshShipState(0, { x: 100, y: 200, vx: 1, vy: 2 });
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(ship, 42);
+        // Mutate the original after setBaseline — predictor's copy
+        // should be unaffected.
+        ship.x = -999;
+        ship.vx = -999;
+        expect(p.localShipState.x).toBe(100);
+        expect(p.localShipState.vx).toBe(1);
+        expect(p.tick).toBe(42);
+    });
+
+    test('replaces prior state on second call', () => {
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(freshShipState(0, { x: 100 }), 1);
+        p.setBaseline(freshShipState(0, { x: 500 }), 2);
+        expect(p.localShipState.x).toBe(500);
+        expect(p.tick).toBe(2);
+    });
+});
+
+describe('Predictor — applyLocalInput (no input)', () => {
+    test('1 tick with no-movement input on a ship at rest mutates only aim angle', () => {
+        const baseline = freshShipState(0, {
+            x: 500,
+            y: 500,
+            vx: 0,
+            vy: 0,
+            field: null,
+        });
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(baseline, 0);
+        p.applyLocalInput(freshInput({ ...AIM_EAST, aimX: 600, aimY: 500 }));
+
+        // No movement keys → no velocity contribution. Friction on 0 = 0.
+        // Position unchanged. Aim angle = atan2(0, 100) = 0.
+        expect(p.localShipState.x).toBe(500);
+        expect(p.localShipState.y).toBe(500);
+        expect(p.localShipState.vx).toBe(0);
+        expect(p.localShipState.vy).toBe(0);
+        expect(p.localShipState.angle).toBeCloseTo(0, 10);
+        // Pending buffer holds the one applied input.
+        expect(p.pending).toHaveLength(1);
+        expect(p.pending[0].tick).toBe(1);
+        expect(p.tick).toBe(1);
+    });
+});
+
+describe('Predictor — applyLocalInput (directional thrust)', () => {
+    test('60 ticks of right-thrust → vx positive, x advanced past start', () => {
+        const baseline = freshShipState(0, {
+            x: 500,
+            y: 500,
+            vx: 0,
+            vy: 0,
+            field: null,
+        });
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(baseline, 0);
+
+        for (let i = 0; i < 60; i++) {
+            p.applyLocalInput(freshInput({ right: true, aimX: 600, aimY: 500 }));
+        }
+
+        // After many ticks of east thrust we expect velocity at the cap
+        // (effectiveMaxV = MAX_V * 1 = 3.5 with speedMult=1) and x
+        // advanced far past the start. Equilibrium analysis:
+        //   v_next = (v + 1.0) * friction
+        //   steady-state v* satisfies v* = (v* + 1.0) * friction
+        //   → v* = friction / (1 - friction) ≈ 2.4142 (below cap 3.5)
+        // so the speed cap won't bind; we'll asymptote to v ≈ 2.4142.
+        const expectedSteady = FRICTION / (1 - FRICTION);
+        expect(p.localShipState.vx).toBeGreaterThan(0);
+        expect(p.localShipState.vx).toBeCloseTo(expectedSteady, 5);
+        expect(p.localShipState.vy).toBe(0);
+        expect(p.localShipState.x).toBeGreaterThan(500);
+        // x has advanced by sum of vx over 60 ticks; lower-bound it by
+        // 30 * vx_steady (very loose, since early ticks are below
+        // steady-state).
+        expect(p.localShipState.x - 500).toBeGreaterThan(30 * expectedSteady);
+        expect(p.pending).toHaveLength(60);
+        expect(p.tick).toBe(60);
+    });
+
+    test('1 tick right-thrust matches pure-step output exactly', () => {
+        // Independently compute the expected post-tick state by
+        // calling `js/sim/ship.js::updateShip` directly. Predictor
+        // wiring should be byte-equivalent.
+        const reference = freshShipState(0, {
+            x: 500,
+            y: 500,
+            vx: 0,
+            vy: 0,
+            field: null,
+        });
+        updateShip(
+            reference,
+            freshInput({ right: true, aimX: 600, aimY: 500 }),
+            1 / 60,
+            null,
+            [],
+        );
+
+        const baseline = freshShipState(0, {
+            x: 500,
+            y: 500,
+            vx: 0,
+            vy: 0,
+            field: null,
+        });
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(baseline, 0);
+        p.applyLocalInput(freshInput({ right: true, aimX: 600, aimY: 500 }));
+
+        expect(p.localShipState.x).toBeCloseTo(reference.x, 12);
+        expect(p.localShipState.y).toBeCloseTo(reference.y, 12);
+        expect(p.localShipState.vx).toBeCloseTo(reference.vx, 12);
+        expect(p.localShipState.vy).toBeCloseTo(reference.vy, 12);
+        expect(p.localShipState.angle).toBeCloseTo(reference.angle, 12);
+    });
+});
+
+describe('Predictor — sequenced inputs reproduce pure-step output', () => {
+    test('5 ticks of varying inputs match a direct updateShip loop', () => {
+        const inputs = [
+            freshInput({ right: true, aimX: 700, aimY: 500 }),
+            freshInput({ right: true, down: true, aimX: 700, aimY: 600 }),
+            freshInput({ down: true, aimX: 500, aimY: 700 }),
+            freshInput({ left: true, down: true, aimX: 300, aimY: 700 }),
+            freshInput({ left: true, aimX: 300, aimY: 500 }),
+        ];
+
+        // Reference: drive a ship directly through `updateShip`.
+        const reference = freshShipState(0, {
+            x: 500,
+            y: 500,
+            vx: 0,
+            vy: 0,
+            field: null,
+        });
+        for (const input of inputs) updateShip(reference, input, 1 / 60, null, []);
+
+        // Predictor: same inputs, same starting state.
+        const baseline = freshShipState(0, {
+            x: 500,
+            y: 500,
+            vx: 0,
+            vy: 0,
+            field: null,
+        });
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(baseline, 0);
+        for (const input of inputs) p.applyLocalInput(input);
+
+        expect(p.localShipState.x).toBeCloseTo(reference.x, 12);
+        expect(p.localShipState.y).toBeCloseTo(reference.y, 12);
+        expect(p.localShipState.vx).toBeCloseTo(reference.vx, 12);
+        expect(p.localShipState.vy).toBeCloseTo(reference.vy, 12);
+        expect(p.localShipState.angle).toBeCloseTo(reference.angle, 12);
+        expect(p.tick).toBe(5);
+        expect(p.pending).toHaveLength(5);
+    });
+});
+
+describe('Predictor — onSnapshot (no divergence)', () => {
+    test('server snapshot matches local prediction → no warning, no divergence', () => {
+        // Set up: baseline → apply 3 inputs locally.
+        const baseline = freshShipState(0, {
+            x: 500,
+            y: 500,
+            vx: 0,
+            vy: 0,
+            field: null,
+        });
+        const inputs = [
+            freshInput({ right: true, aimX: 700, aimY: 500 }),
+            freshInput({ right: true, aimX: 700, aimY: 500 }),
+            freshInput({ right: true, aimX: 700, aimY: 500 }),
+        ];
+
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(baseline, 0);
+        for (const i of inputs) p.applyLocalInput(i);
+
+        // Server has caught up to tick 1: replay inputs from tick 2..3.
+        // The "authoritative" state at tick 1 must equal what
+        // applyLocalInput produced after tick 1 — compute it
+        // independently using the pure step.
+        const serverAtTick1 = freshShipState(0, {
+            x: 500,
+            y: 500,
+            vx: 0,
+            vy: 0,
+            field: null,
+        });
+        updateShip(serverAtTick1, inputs[0], 1 / 60, null, []);
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            p.onSnapshot(1, serverAtTick1);
+        } finally {
+            warnSpy.mockRestore();
+        }
+
+        expect(p.divergenceCount).toBe(0);
+        expect(warnSpy).not.toHaveBeenCalled();
+        // Pending should be trimmed to inputs with tick > 1 — i.e. 2 left.
+        expect(p.pending).toHaveLength(2);
+        expect(p.pending[0].tick).toBe(2);
+        expect(p.pending[1].tick).toBe(3);
+    });
+
+    test('caller-supplied serverShip is not mutated', () => {
+        const baseline = freshShipState(0, {
+            x: 500,
+            y: 500,
+            field: null,
+        });
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(baseline, 0);
+        p.applyLocalInput(freshInput({ right: true, aimX: 600, aimY: 500 }));
+        p.applyLocalInput(freshInput({ right: true, aimX: 600, aimY: 500 }));
+
+        const serverShip = freshShipState(0, {
+            x: 500,
+            y: 500,
+            vx: 0,
+            vy: 0,
+            field: null,
+        });
+        const frozenX = serverShip.x;
+        const frozenVx = serverShip.vx;
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            p.onSnapshot(1, serverShip);
+        } finally {
+            warnSpy.mockRestore();
+        }
+
+        // The caller's object must not have been mutated.
+        expect(serverShip.x).toBe(frozenX);
+        expect(serverShip.vx).toBe(frozenVx);
+    });
+});
+
+describe('Predictor — onSnapshot (divergence → reconciliation)', () => {
+    test('diverged server state snaps local prediction to server-anchored replay', () => {
+        // Set up: baseline at origin, apply 2 right-thrust inputs.
+        const baseline = freshShipState(0, {
+            x: 500,
+            y: 500,
+            vx: 0,
+            vy: 0,
+            field: null,
+        });
+        const inputs = [
+            freshInput({ right: true, aimX: 700, aimY: 500 }),
+            freshInput({ right: true, aimX: 700, aimY: 500 }),
+        ];
+
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(baseline, 0);
+        for (const i of inputs) p.applyLocalInput(i);
+        const localBefore = { ...p.localShipState };
+
+        // Server reports an unexpected state at tick 1 — e.g. the
+        // player was hit and pushed somewhere different. Simulate by
+        // handing in a baseline at (1000, 500) rather than the
+        // expected post-tick-1 position.
+        const divergentServerShip = freshShipState(0, {
+            x: 1000,
+            y: 500,
+            vx: 0,
+            vy: 0,
+            field: null,
+        });
+
+        // Compute the expected reconciled state by hand: clone the
+        // server ship, then apply inputs[1] (the only pending input
+        // after tick 1 is consumed).
+        const expectedAfter = freshShipState(0, {
+            x: 1000,
+            y: 500,
+            vx: 0,
+            vy: 0,
+            field: null,
+        });
+        updateShip(expectedAfter, inputs[1], 1 / 60, null, []);
+
+        // Silence the divergence warning during the test (it's an
+        // expected branch we're exercising). We don't assert on the
+        // call shape because the test environment (`allure-jest/node`)
+        // may wrap `console.warn` and shadow the spy; the contract we
+        // care about is `divergenceCount` + the reconciled state below.
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            p.onSnapshot(1, divergentServerShip);
+        } finally {
+            warnSpy.mockRestore();
+        }
+
+        expect(p.divergenceCount).toBe(1);
+        // Local state was snapped to the server-anchored replay.
+        expect(p.localShipState.x).toBeCloseTo(expectedAfter.x, 12);
+        expect(p.localShipState.y).toBeCloseTo(expectedAfter.y, 12);
+        expect(p.localShipState.vx).toBeCloseTo(expectedAfter.vx, 12);
+        expect(p.localShipState.vy).toBeCloseTo(expectedAfter.vy, 12);
+        // Sanity: pre-reconciliation local x was nowhere near 1000.
+        expect(Math.abs(localBefore.x - p.localShipState.x)).toBeGreaterThan(100);
+        // Pending shrinks to inputs with tick > 1 → just tick=2 left.
+        expect(p.pending).toHaveLength(1);
+        expect(p.pending[0].tick).toBe(2);
+    });
+
+    test('snapshot acknowledging all pending inputs leaves pending empty', () => {
+        const baseline = freshShipState(0, {
+            x: 500,
+            y: 500,
+            field: null,
+        });
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(baseline, 0);
+        p.applyLocalInput(freshInput({ right: true, aimX: 600, aimY: 500 }));
+        p.applyLocalInput(freshInput({ right: true, aimX: 600, aimY: 500 }));
+        expect(p.pending).toHaveLength(2);
+
+        // Server acks tick 2 → both inputs dropped, no replay needed.
+        // Hand-compute the "converged" state by running both inputs
+        // through the pure step.
+        const convergedServerShip = freshShipState(0, {
+            x: 500,
+            y: 500,
+            vx: 0,
+            vy: 0,
+            field: null,
+        });
+        updateShip(convergedServerShip, freshInput({ right: true, aimX: 600, aimY: 500 }), 1 / 60, null, []);
+        updateShip(convergedServerShip, freshInput({ right: true, aimX: 600, aimY: 500 }), 1 / 60, null, []);
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            p.onSnapshot(2, convergedServerShip);
+        } finally {
+            warnSpy.mockRestore();
+        }
+
+        expect(p.pending).toHaveLength(0);
+        expect(p.divergenceCount).toBe(0);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe('Predictor — custom updateShip callback', () => {
+    test('callers can inject a mock physics step (forward compat with parity harness)', () => {
+        // Use the wiring's bridge contract: a custom callback that
+        // increments x by 10 per tick regardless of input. Proves
+        // `Predictor.applyLocalInput` calls through to whatever
+        // function the constructor was given.
+        const mockUpdate = jest.fn((ship, _input, _dt) => {
+            ship.x += 10;
+            return ship;
+        });
+        const p = new Predictor({ updateShip: mockUpdate, dt: 1 / 60 });
+        p.setBaseline(freshShipState(0, { x: 0 }), 0);
+        p.applyLocalInput(freshInput());
+        p.applyLocalInput(freshInput());
+        p.applyLocalInput(freshInput());
+        expect(p.localShipState.x).toBe(30);
+        expect(mockUpdate).toHaveBeenCalledTimes(3);
+    });
+});


### PR DESCRIPTION
## Summary
**Phase 3 milestone.** Wires existing `js/net/prediction.js::Predictor` to use the production pure step `js/sim/ship.js::updateShip`. The Predictor was scaffolded earlier with `setBaseline` + `applyLocalInput` + reconciliation skeleton, but its `updateShip` callback was a stub waiting on Phase 1 sim extraction (which landed in 5.84.0). Phase 3 unblocks.

## Changes in `js/net/prediction.js`
- Replaced `defaultUpdateShip` stub with real bridge to `updateShip(ship, input, dt, null, [])` — adapts the 3-arg Predictor callback contract to the 5-arg pure-step signature.
- `setBaseline` now clones the incoming ship (was aliasing — caller mutations could bleed in).
- `cloneShip` helper documented + null-safe.
- `shipsBitEqual` now also compares `angle` (was just x,y,vx,vy); pure step writes angle each tick.
- Removed unused `Fxp` import.

## Bridge details
- Predictor callback contract: `updateShip(ship, input, dt) → ship`
- Pure step signature: `updateShip(ship, input, dt, rng, events)` — mutates in place
- Default adapter: `pureUpdateShip(ship, input, dt, null, [])`
- Callers can still inject custom `updateShip` via constructor options (parity harness, Fxp variants, mocked physics in tests).

## 11 new tests in `tests/unit/net/prediction.test.js`
1. setBaseline clones (no aliasing)
2. setBaseline replaces prior state
3. applyLocalInput no-input → only aim mutates
4. 60 ticks right-thrust → vx steady state ≈ 2.41 (analytic equilibrium)
5. 1-tick right-thrust matches direct updateShip call exactly (bridge passthrough)
6. 5 varied inputs reproduce direct updateShip loop
7. onSnapshot converged → no divergence
8. onSnapshot doesn't mutate caller's serverShip
9. onSnapshot divergent → divergenceCount++, local snaps to server-anchored replay
10. onSnapshot acknowledging all pending → pending empty, no warn
11. Custom updateShip callback honored (parity-harness seam)

## Test plan
- [x] `prediction.test.js`: 11 passed
- [x] Full unit suite: 489/489 across 20 suites
- [x] `js/sim/ship.js` UNTOUCHED

## Public surface unchanged
`setBaseline`, `applyLocalInput`, `onSnapshot`, `tick`, `localShipState`, `pending`, `divergenceCount`, `{updateShip, dt}` constructor options — all preserved. Only semantic change: `setBaseline` clones (verified no caller exists yet via grep).

## Phase 3 progress (task #31)
- ✓ TickBuffer scaffolding (PR #43)
- ✓ Predictor.updateShip wired to js/sim/ship.js (this PR)

## Still stubbed / next-session work
- `dt` plumbed but ignored by pure step (per-tick model)
- `shipsBitEqual` is f32-equality; tolerance comparator needed for Rust↔JS cross-language parity
- TickBuffer integration with Predictor.onSnapshot for late-arrival snapshots
- Wire Predictor into `engine-driver.js` / `ws-client.js` (next major Phase 3 piece)

🤖 Generated with [Claude Code](https://claude.com/claude-code)