### PR TITLE
mp/net: Predictor snapshot history via TickBuffer (Phase 3)

### DIFF
--- a/js/net/prediction.js
+++ b/js/net/prediction.js
@@ -35,6 +35,18 @@
 // is "(ship, input, dt, rng, events) → mutates and returns ship".
 
 import { updateShip as pureUpdateShip } from '../sim/ship.js';
+import { TickBuffer } from './tick-buffer.js';
+
+/**
+ * Default capacity for the snapshot history TickBuffer.
+ *
+ * The server runs at 60 Hz; 64 snapshots covers ≈ 1 second of authoritative
+ * history. That's enough for late-arrival forensics (out-of-order packets
+ * commonly arrive within 100–300 ms) and reconciliation lookups without
+ * unbounded memory growth. Override via the `snapshotHistoryCapacity`
+ * constructor option.
+ */
+const DEFAULT_SNAPSHOT_HISTORY_CAPACITY = 64;
 
 /**
  * Default ship-update callback. Wraps the pure step in
@@ -59,8 +71,15 @@ export class Predictor {
      *     and an empty events buffer.
      * @param {number} [opts.dt] - seconds per tick (typically 1/60). Passed
      *     to the physics step; today's `updateShip` ignores it.
+     * @param {number} [opts.snapshotHistoryCapacity=64] - max number of
+     *     authoritative server snapshots retained in the snapshot history
+     *     TickBuffer. Defaults to ~1 second at 60 Hz.
      */
-    constructor({ updateShip = defaultUpdateShip, dt } = {}) {
+    constructor({
+        updateShip = defaultUpdateShip,
+        dt,
+        snapshotHistoryCapacity = DEFAULT_SNAPSHOT_HISTORY_CAPACITY,
+    } = {}) {
         this.updateShip = updateShip;
         this.dt = dt;
         /** @type {Array<{tick: number, input: object}>} */
@@ -71,6 +90,27 @@ export class Predictor {
         /** Diagnostics counter — incremented when a server snapshot
          * disagrees with our locally-predicted state after replay. */
         this.divergenceCount = 0;
+        /**
+         * Ring buffer of authoritative server snapshots keyed by server tick.
+         * Populated by `onSnapshot`. Used for historical-evidence lookups and
+         * late-arrival forensics. Interpolation is disabled (`interpolate`
+         * is null) — callers want exact tick lookups for reconciliation and
+         * divergence post-mortems, not interpolated values.
+         *
+         * @type {TickBuffer}
+         */
+        this.snapshotHistory = new TickBuffer({
+            capacity: snapshotHistoryCapacity,
+            interpolate: null,
+        });
+        /**
+         * Diagnostics counter — incremented when a server snapshot arrives
+         * for a tick older than the latest snapshot already recorded. Out-of-
+         * order arrivals are valid (UDP/WebRTC packet reordering) but worth
+         * tracking for network-quality diagnostics. Snapshots are still
+         * stored as historical evidence; no rewind is performed.
+         */
+        this.lateArrivalCount = 0;
     }
 
     /**
@@ -124,6 +164,23 @@ export class Predictor {
      *     we clone before replay.
      */
     onSnapshot(serverTick, serverShip) {
+        // Late-arrival detection — before we mutate history. Out-of-order
+        // arrivals (snapshot for tick T < latest stored tick) are valid; we
+        // still record them as historical evidence (TickBuffer.insert
+        // sorts internally) but increment a diagnostics counter so the
+        // network layer can flag pathological reordering.
+        const latest = this.snapshotHistory.getLatest();
+        if (latest != null && (serverTick | 0) < latest.tick) {
+            this.lateArrivalCount++;
+        }
+
+        // Record the authoritative snapshot in history *before* the replay
+        // loop. Clone to detach from the caller's ref so subsequent mutation
+        // (including the replay clone we make below) cannot bleed into
+        // stored history. The TickBuffer keys by integer tick and handles
+        // capacity eviction.
+        this.snapshotHistory.insert(serverTick | 0, cloneShip(serverShip));
+
         // Drop already-acknowledged inputs.
         while (this.pending.length && this.pending[0].tick <= serverTick) {
             this.pending.shift();
@@ -149,6 +206,47 @@ export class Predictor {
             });
         }
         this.localShipState = s;
+    }
+
+    /**
+     * Exact-tick lookup into the authoritative snapshot history. Returns
+     * `{tick, state}` for the snapshot stored at the requested server tick,
+     * or `null` if no snapshot for that tick is in the buffer (never
+     * received, or already evicted by capacity pressure).
+     *
+     * Used by reconciliation forensics and parity-harness post-mortems —
+     * NOT a hot path. Today the underlying TickBuffer scans linearly at
+     * capacity ≤ 64, which is fine for diagnostic queries.
+     *
+     * @param {number} tick - server tick number.
+     * @returns {{tick: number, state: object} | null}
+     */
+    getSnapshotAtTick(tick) {
+        if (!Number.isFinite(tick)) return null;
+        const t = tick | 0;
+        const state = this.snapshotHistory.getByTick(t);
+        if (state == null) return null;
+        return { tick: t, state };
+    }
+
+    /**
+     * Most-recent authoritative server snapshot (highest tick stored), or
+     * null if none have been received yet.
+     *
+     * @returns {{tick: number, state: object} | null}
+     */
+    getLatestSnapshot() {
+        return this.snapshotHistory.getLatest();
+    }
+
+    /**
+     * Number of authoritative snapshots currently buffered. Bounded by the
+     * `snapshotHistoryCapacity` constructor option (default 64).
+     *
+     * @returns {number}
+     */
+    getSnapshotHistorySize() {
+        return this.snapshotHistory.size();
     }
 }
 

--- a/tests/unit/net/prediction.test.js
+++ b/tests/unit/net/prediction.test.js
@@ -436,3 +436,211 @@ describe('Predictor — custom updateShip callback', () => {
         expect(mockUpdate).toHaveBeenCalledTimes(3);
     });
 });
+
+// ── Snapshot history (TickBuffer integration) ───────────────────────────────
+//
+// `Predictor.onSnapshot` retains each authoritative server snapshot in a
+// `TickBuffer` keyed by server tick. The history is used for late-arrival
+// forensics, divergence post-mortems, and (eventually) reconciliation
+// lookups. These tests pin the integration: every snapshot is stored,
+// capacity caps at 64 by default, late-arrivals increment a counter while
+// still being recorded, and historical entries are detached from the
+// caller's ref (clone, not alias).
+describe('Predictor — snapshot history', () => {
+    test('onSnapshot stores snapshot in history', () => {
+        const baseline = freshShipState(0, { x: 500, y: 500, field: null });
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(baseline, 0);
+
+        const serverShip = freshShipState(0, { x: 600, y: 500, field: null });
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            p.onSnapshot(7, serverShip);
+        } finally {
+            warnSpy.mockRestore();
+        }
+
+        const entry = p.getSnapshotAtTick(7);
+        expect(entry).not.toBeNull();
+        expect(entry.tick).toBe(7);
+        expect(entry.state.x).toBe(600);
+        expect(entry.state.y).toBe(500);
+    });
+
+    test('multiple snapshots build history', () => {
+        const baseline = freshShipState(0, { x: 500, y: 500, field: null });
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(baseline, 0);
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            for (let i = 1; i <= 5; i++) {
+                p.onSnapshot(
+                    i,
+                    freshShipState(0, { x: 500 + i, y: 500, field: null }),
+                );
+            }
+        } finally {
+            warnSpy.mockRestore();
+        }
+
+        expect(p.getSnapshotHistorySize()).toBe(5);
+        // Sanity-check a few exact lookups.
+        expect(p.getSnapshotAtTick(1).state.x).toBe(501);
+        expect(p.getSnapshotAtTick(3).state.x).toBe(503);
+        expect(p.getSnapshotAtTick(5).state.x).toBe(505);
+    });
+
+    test('history capacity caps at 64 (default) — oldest evicted', () => {
+        const baseline = freshShipState(0, { x: 500, y: 500, field: null });
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(baseline, 0);
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            for (let i = 1; i <= 100; i++) {
+                p.onSnapshot(
+                    i,
+                    freshShipState(0, { x: 500 + i, y: 500, field: null }),
+                );
+            }
+        } finally {
+            warnSpy.mockRestore();
+        }
+
+        expect(p.getSnapshotHistorySize()).toBe(64);
+        // Oldest 36 ticks (1..36) should have been evicted.
+        expect(p.getSnapshotAtTick(1)).toBeNull();
+        expect(p.getSnapshotAtTick(36)).toBeNull();
+        // Most-recent 64 (37..100) should be retained.
+        expect(p.getSnapshotAtTick(37)).not.toBeNull();
+        expect(p.getSnapshotAtTick(100)).not.toBeNull();
+        expect(p.getLatestSnapshot().tick).toBe(100);
+    });
+
+    test('getSnapshotAtTick miss returns null', () => {
+        const baseline = freshShipState(0, { x: 500, y: 500, field: null });
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(baseline, 0);
+
+        // No snapshots received yet.
+        expect(p.getSnapshotAtTick(0)).toBeNull();
+        expect(p.getSnapshotAtTick(42)).toBeNull();
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            p.onSnapshot(10, freshShipState(0, { x: 600, field: null }));
+        } finally {
+            warnSpy.mockRestore();
+        }
+
+        // Tick we never received → still null.
+        expect(p.getSnapshotAtTick(11)).toBeNull();
+        expect(p.getSnapshotAtTick(9)).toBeNull();
+        // And NaN / non-finite is gracefully rejected.
+        expect(p.getSnapshotAtTick(NaN)).toBeNull();
+        expect(p.getSnapshotAtTick(Infinity)).toBeNull();
+    });
+
+    test('getLatestSnapshot returns most-recent entry (and null when empty)', () => {
+        const baseline = freshShipState(0, { x: 500, y: 500, field: null });
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(baseline, 0);
+
+        // Nothing received yet.
+        expect(p.getLatestSnapshot()).toBeNull();
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            p.onSnapshot(3, freshShipState(0, { x: 503, field: null }));
+            p.onSnapshot(8, freshShipState(0, { x: 508, field: null }));
+            p.onSnapshot(5, freshShipState(0, { x: 505, field: null })); // late
+        } finally {
+            warnSpy.mockRestore();
+        }
+
+        // Highest stored tick is still 8 (TickBuffer sorts internally).
+        const latest = p.getLatestSnapshot();
+        expect(latest).not.toBeNull();
+        expect(latest.tick).toBe(8);
+        expect(latest.state.x).toBe(508);
+    });
+
+    test('late-arrival snapshot increments lateArrivalCount', () => {
+        const baseline = freshShipState(0, { x: 500, y: 500, field: null });
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(baseline, 0);
+
+        expect(p.lateArrivalCount).toBe(0);
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            // Establish a baseline at tick 100.
+            p.onSnapshot(100, freshShipState(0, { x: 600, field: null }));
+            expect(p.lateArrivalCount).toBe(0);
+
+            // Out-of-order arrival for tick 50 — older than latest stored.
+            p.onSnapshot(50, freshShipState(0, { x: 550, field: null }));
+        } finally {
+            warnSpy.mockRestore();
+        }
+
+        expect(p.lateArrivalCount).toBe(1);
+    });
+
+    test('late-arrival snapshot still stored in history', () => {
+        const baseline = freshShipState(0, { x: 500, y: 500, field: null });
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(baseline, 0);
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            p.onSnapshot(100, freshShipState(0, { x: 600, field: null }));
+            p.onSnapshot(50, freshShipState(0, { x: 550, field: null })); // late
+        } finally {
+            warnSpy.mockRestore();
+        }
+
+        // Late snapshot is retained as historical evidence.
+        const entry = p.getSnapshotAtTick(50);
+        expect(entry).not.toBeNull();
+        expect(entry.tick).toBe(50);
+        expect(entry.state.x).toBe(550);
+        // Latest is still tick=100 (TickBuffer sorts by tick).
+        expect(p.getLatestSnapshot().tick).toBe(100);
+        // And size reflects both entries.
+        expect(p.getSnapshotHistorySize()).toBe(2);
+    });
+
+    test('history snapshots are cloned, not aliased', () => {
+        const baseline = freshShipState(0, { x: 500, y: 500, field: null });
+        const p = new Predictor({ dt: 1 / 60 });
+        p.setBaseline(baseline, 0);
+
+        const serverShip = freshShipState(0, {
+            x: 600,
+            y: 500,
+            vx: 0,
+            vy: 0,
+            field: null,
+        });
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            p.onSnapshot(11, serverShip);
+        } finally {
+            warnSpy.mockRestore();
+        }
+
+        // Mutate the caller's ref AFTER onSnapshot — the stored history
+        // must be unaffected (clone, not alias).
+        serverShip.x = -999;
+        serverShip.vx = -999;
+
+        const entry = p.getSnapshotAtTick(11);
+        expect(entry).not.toBeNull();
+        expect(entry.state.x).toBe(600);
+        expect(entry.state.vx).toBe(0);
+        // And the stored state is not the same object reference.
+        expect(entry.state).not.toBe(serverShip);
+    });
+});


### PR DESCRIPTION
## Summary
Integrates `TickBuffer` (PR #43) into `Predictor` (PR #48). Each server snapshot now gets buffered keyed by server tick — supports historical lookup, late-arrival detection, and divergence forensics.

## Changes in `js/net/prediction.js`
- **New constructor option**: `snapshotHistoryCapacity` (default 64 — ~1 second at 60 Hz)
- **New instance fields**: `snapshotHistory` (TickBuffer with `interpolate=null`), `lateArrivalCount` (diagnostics)
- **New public methods**:
  - `getSnapshotAtTick(tick)` — returns `{tick, state}` or `null`; handles non-finite ticks
  - `getLatestSnapshot()` — returns `{tick, state}` or `null`
  - `getSnapshotHistorySize()` — diagnostics

## Behavior in `onSnapshot(serverTick, serverShip)`
1. **Late-arrival detection BEFORE insertion**: if `serverTick < latest stored tick`, `lateArrivalCount++`
2. `snapshotHistory.insert(serverTick|0, cloneShip(serverShip))` runs **BEFORE** pending-input trim/replay so snapshot is preserved regardless of reconciliation
3. Clone-on-insert: stored history detached from caller's `serverShip` ref and from replay clone

**NO rewind on late arrival** — only counter increment + storage. Matches the "historical evidence for late snapshots" requirement in the plan.

## API signature note
The existing `onSnapshot` is `(serverTick, serverShip)` — the plan suggested `(serverShip, ackedTick)`. Kept existing signature to avoid breaking any callers; only behavior was extended.

## 8 new tests
1. `onSnapshot stores snapshot in history`
2. `multiple snapshots build history`
3. `history capacity caps at 64 (default) — oldest evicted`
4. `getSnapshotAtTick miss returns null` (with NaN/Infinity guards)
5. `getLatestSnapshot returns most-recent (and null when empty)`
6. `late-arrival snapshot increments lateArrivalCount`
7. `late-arrival snapshot still stored in history`
8. `history snapshots are cloned, not aliased`

## Test plan
- [x] `prediction.test.js`: 19 passed (11 existing + 8 new)
- [x] Full unit suite: 482/482 across 20 suites
- [x] `tick-buffer.js`, `ship.js` UNTOUCHED

## Phase 3 progress (task #31)
- ✓ TickBuffer scaffolding (PR #43)
- ✓ Predictor wired to js/sim/ship.js (PR #48)
- ✓ Predictor snapshot history via TickBuffer (this PR)

## Still pending
- Wire Predictor into `engine-driver.js` / `ws-client.js` (end-to-end)
- Refactor Interpolator to compose TickBuffer (optional)
- f32 tolerance comparator for Rust↔JS cross-language parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)