### PR TITLE
mp/sim-rs: Rust mirror of player-vs-enemy-bullet collision (Phase 2.5)

### DIFF
--- a/server/src/sim/collision.rs
+++ b/server/src/sim/collision.rs
@@ -462,6 +462,19 @@ pub enum CollisionEvent {
         asteroid_impulse_dx: f32,
         asteroid_impulse_dy: f32,
     },
+    /// Mirrors `{ type: 'player_hit_by_enemy_bullet', ... }` in
+    /// `js/sim/collision.js`. Simplest pair — enemy bullets damage the
+    /// player on overlap only. No impulse, no separation, no piercing
+    /// budget. Damage default 1 if `bullet.damage <= 0`.
+    PlayerHitByEnemyBullet {
+        player_id: u32,
+        bullet_id: u32,
+        damage: f32,
+        bullet_x: f32,
+        bullet_y: f32,
+        bullet_vx: f32,
+        bullet_vy: f32,
+    },
 }
 
 // ─── Bullet-vs-asteroid pair detection ──────────────────────────────
@@ -1524,6 +1537,116 @@ pub fn detect_enemy_asteroid_hits(
                 enemy_impulse_dy,
                 asteroid_impulse_dx,
                 asteroid_impulse_dy,
+            });
+        }
+    }
+}
+
+// ── PLAYER ↔ ENEMY-BULLET — Phase 2.5 ──────
+//
+// `detect_player_enemy_bullet_hits` is the 6th pure-step pair. Enemy
+// bullets damage the player on geometric overlap. Simplest pair so far:
+//   - NO impulse to either side
+//   - NO separation
+//   - NO piercing budget (enemy bullets are never piercing)
+//   - NO warping/death-flash skip-gates (bullets are flight-or-despawned;
+//     players have no such state in the sim layer)
+//
+// What the pure step DOES: circle-circle overlap + emit one
+// `PlayerHitByEnemyBullet` event per detected hit, carrying `damage`
+// (default 1 if `bullet.damage <= 0`, mirroring JS `bullet.damage || 1`),
+// `bullet_id` for wrapper-side despawn, and bullet position + velocity
+// at impact for wrapper-side hit-flash localization + shrapnel.
+//
+// What stays in the wrapper:
+//   - Invincibility / phase-dash check
+//   - Effective-shield reduction (damage · (1 - shield/100))
+//   - Bulwark / IRON_WILL reduction (0.5× / 0.65×)
+//   - Final HP application + tank consumption
+//   - Damage numbers, hit-flash visuals, screen shake, hitstop
+//   - Stat tracking, kill-streak break, XP grant
+//   - Per-pattern hit SFX
+//   - Bullet despawn (every enemy-bullet hit despawns; no flag needed)
+//
+// Reference: `js/sim/collision.js::detectPlayerEnemyBulletHits` (PR #47).
+
+/// Minimal enemy-bullet view for collision detection. Separate from
+/// `CollisionBullet` (which represents player bullets with piercing
+/// state) — enemy bullets are simpler with no piercing.
+#[derive(Debug, Clone, Copy)]
+pub struct CollisionEnemyBullet {
+    pub id: u32,
+    pub x: f32,
+    pub y: f32,
+    pub vx: f32,
+    pub vy: f32,
+    pub radius: f32,
+    pub damage: f32,
+    pub active: bool,
+}
+
+impl CollisionEnemyBullet {
+    /// Construct a fresh enemy bullet at the origin with live-game defaults.
+    pub fn fresh(id: u32) -> Self {
+        Self {
+            id,
+            x: 0.0,
+            y: 0.0,
+            vx: 0.0,
+            vy: 0.0,
+            radius: 9.0,
+            damage: 2.0,
+            active: true,
+        }
+    }
+}
+
+/// Detect player-vs-enemy-bullet collisions for one tick.
+///
+/// Pure step: emits one `PlayerHitByEnemyBullet` event per overlap.
+/// Co-op ready: scans every active player against every active bullet.
+///
+/// Skip-gates: `!player.active`, `!bullet.active`. No warping or
+/// death-flash gates. Damage default = 1 if `bullet.damage <= 0`.
+pub fn detect_player_enemy_bullet_hits(
+    players: &[CollisionPlayer],
+    bullets: &[CollisionEnemyBullet],
+    _ctx: &CollisionContext,
+    events: &mut Vec<CollisionEvent>,
+) {
+    if players.is_empty() || bullets.is_empty() {
+        return;
+    }
+
+    for player in players.iter() {
+        if !player.active {
+            continue;
+        }
+
+        let player_radius = player.radius;
+
+        for bullet in bullets.iter() {
+            if !bullet.active {
+                continue;
+            }
+
+            let dx = player.x - bullet.x;
+            let dy = player.y - bullet.y;
+            let sum_r = player_radius + bullet.radius;
+            if dx * dx + dy * dy >= sum_r * sum_r {
+                continue;
+            }
+
+            let damage = if bullet.damage > 0.0 { bullet.damage } else { 1.0 };
+
+            events.push(CollisionEvent::PlayerHitByEnemyBullet {
+                player_id: player.id,
+                bullet_id: bullet.id,
+                damage,
+                bullet_x: bullet.x,
+                bullet_y: bullet.y,
+                bullet_vx: bullet.vx,
+                bullet_vy: bullet.vy,
             });
         }
     }

--- a/server/tests/parity_collision.rs
+++ b/server/tests/parity_collision.rs
@@ -40,11 +40,12 @@
 
 use rainboids_server::sim::collision::{
     detect_bullet_asteroid_hits, detect_bullet_enemy_hits, detect_enemy_asteroid_hits,
-    detect_player_asteroid_hits, detect_player_enemy_hits, CollisionAsteroid, CollisionBullet,
-    CollisionContext, CollisionEnemy, CollisionEvent, CollisionPlayer,
-    ASTEROID_ENEMY_PUSH, ASTEROID_KNOCKBACK_MULTIPLIER, BOUNCE_FORCE_MULTIPLIER,
-    BOUNCE_RESTITUTION, ENEMY_ASTEROID_PUSH, OVERLAP_PUSH_FORCE, OVERLAP_SEPARATION_RATIO,
-    PLAYER_ASTEROID_COLLISION_DAMAGE, PLAYER_ENEMY_COLLISION_DAMAGE, SEPARATION_BUFFER,
+    detect_player_asteroid_hits, detect_player_enemy_bullet_hits, detect_player_enemy_hits,
+    CollisionAsteroid, CollisionBullet, CollisionContext, CollisionEnemy, CollisionEnemyBullet,
+    CollisionEvent, CollisionPlayer, ASTEROID_ENEMY_PUSH, ASTEROID_KNOCKBACK_MULTIPLIER,
+    BOUNCE_FORCE_MULTIPLIER, BOUNCE_RESTITUTION, ENEMY_ASTEROID_PUSH, OVERLAP_PUSH_FORCE,
+    OVERLAP_SEPARATION_RATIO, PLAYER_ASTEROID_COLLISION_DAMAGE, PLAYER_ENEMY_COLLISION_DAMAGE,
+    SEPARATION_BUFFER,
 };
 
 // ─── Helpers ─────────────────────────────────────────────────────────
@@ -1954,5 +1955,167 @@ fn enemy_asteroid_no_damage_no_separation_pin() {
             "regression: enemy-asteroid path emitted a non-EnemyHitAsteroid event: {:?}",
             events[0]
         );
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Player-vs-enemy-bullet fixtures (Phase 2.5 dispatch — this PR).
+// ═════════════════════════════════════════════════════════════════════
+
+fn make_enemy_bullet(id: u32, x: f32, y: f32) -> CollisionEnemyBullet {
+    CollisionEnemyBullet {
+        id,
+        x,
+        y,
+        vx: 0.0,
+        vy: 0.0,
+        radius: 9.0,
+        damage: 2.0,
+        active: true,
+    }
+}
+
+#[test]
+fn player_enemy_bullet_single_hit() {
+    let players = vec![make_player(1, 100.0, 100.0)];
+    let bullets = vec![make_enemy_bullet(101, 105.0, 100.0)]; // overlap
+
+    let mut events = Vec::new();
+    let ctx = CollisionContext;
+    detect_player_enemy_bullet_hits(&players, &bullets, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1);
+    match events[0] {
+        CollisionEvent::PlayerHitByEnemyBullet {
+            player_id,
+            bullet_id,
+            damage,
+            bullet_x,
+            bullet_y,
+            bullet_vx,
+            bullet_vy,
+        } => {
+            assert_eq!(player_id, 1);
+            assert_eq!(bullet_id, 101);
+            approx_eq(damage, 2.0, "damage");
+            approx_eq(bullet_x, 105.0, "bullet_x");
+            approx_eq(bullet_y, 100.0, "bullet_y");
+            approx_eq(bullet_vx, 0.0, "bullet_vx");
+            approx_eq(bullet_vy, 0.0, "bullet_vy");
+        }
+        _ => panic!("expected PlayerHitByEnemyBullet event"),
+    }
+}
+
+#[test]
+fn player_enemy_bullet_geometry_miss() {
+    let players = vec![make_player(1, 100.0, 100.0)];
+    let bullets = vec![make_enemy_bullet(101, 300.0, 100.0)]; // 200 px apart
+
+    let mut events = Vec::new();
+    let ctx = CollisionContext;
+    detect_player_enemy_bullet_hits(&players, &bullets, &ctx, &mut events);
+
+    assert_eq!(events.len(), 0);
+}
+
+#[test]
+fn player_enemy_bullet_multiple_bullets() {
+    let players = vec![make_player(1, 100.0, 100.0)];
+    let bullets = vec![
+        make_enemy_bullet(101, 105.0, 100.0),  // hit
+        make_enemy_bullet(102, 95.0, 100.0),   // hit
+        make_enemy_bullet(103, 500.0, 500.0),  // miss
+    ];
+
+    let mut events = Vec::new();
+    let ctx = CollisionContext;
+    detect_player_enemy_bullet_hits(&players, &bullets, &ctx, &mut events);
+
+    assert_eq!(events.len(), 2);
+}
+
+#[test]
+fn player_enemy_bullet_skip_gates() {
+    // inactive player
+    let players = vec![CollisionPlayer { active: false, ..make_player(1, 100.0, 100.0) }];
+    let bullets = vec![make_enemy_bullet(101, 105.0, 100.0)];
+    let mut events = Vec::new();
+    let ctx = CollisionContext;
+    detect_player_enemy_bullet_hits(&players, &bullets, &ctx, &mut events);
+    assert_eq!(events.len(), 0, "inactive player should skip");
+
+    // inactive bullet
+    let players = vec![make_player(1, 100.0, 100.0)];
+    let bullets = vec![CollisionEnemyBullet { active: false, ..make_enemy_bullet(101, 105.0, 100.0) }];
+    let mut events = Vec::new();
+    detect_player_enemy_bullet_hits(&players, &bullets, &ctx, &mut events);
+    assert_eq!(events.len(), 0, "inactive bullet should skip");
+
+    // empty inputs
+    let mut events = Vec::new();
+    detect_player_enemy_bullet_hits(&[], &bullets, &ctx, &mut events);
+    assert_eq!(events.len(), 0, "empty players should emit nothing");
+    detect_player_enemy_bullet_hits(&players, &[], &ctx, &mut events);
+    assert_eq!(events.len(), 0, "empty bullets should emit nothing");
+}
+
+#[test]
+fn player_enemy_bullet_damage_passthrough() {
+    let players = vec![make_player(1, 100.0, 100.0)];
+    // damage = 7 — pure passthrough
+    let bullets = vec![CollisionEnemyBullet { damage: 7.0, ..make_enemy_bullet(101, 105.0, 100.0) }];
+
+    let mut events = Vec::new();
+    let ctx = CollisionContext;
+    detect_player_enemy_bullet_hits(&players, &bullets, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1);
+    if let CollisionEvent::PlayerHitByEnemyBullet { damage, .. } = events[0] {
+        approx_eq(damage, 7.0, "damage passthrough");
+    } else {
+        panic!("expected PlayerHitByEnemyBullet");
+    }
+
+    // damage = 25 — also pure passthrough
+    let bullets = vec![CollisionEnemyBullet { damage: 25.0, ..make_enemy_bullet(102, 105.0, 100.0) }];
+    let mut events = Vec::new();
+    detect_player_enemy_bullet_hits(&players, &bullets, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1);
+    if let CollisionEvent::PlayerHitByEnemyBullet { damage, .. } = events[0] {
+        approx_eq(damage, 25.0, "damage passthrough 25");
+    } else {
+        panic!("expected PlayerHitByEnemyBullet");
+    }
+}
+
+#[test]
+fn player_enemy_bullet_damage_default() {
+    let players = vec![make_player(1, 100.0, 100.0)];
+
+    // damage = 0 — defaults to 1
+    let bullets = vec![CollisionEnemyBullet { damage: 0.0, ..make_enemy_bullet(101, 105.0, 100.0) }];
+    let mut events = Vec::new();
+    let ctx = CollisionContext;
+    detect_player_enemy_bullet_hits(&players, &bullets, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1);
+    if let CollisionEvent::PlayerHitByEnemyBullet { damage, .. } = events[0] {
+        approx_eq(damage, 1.0, "damage 0 → default 1");
+    } else {
+        panic!("expected PlayerHitByEnemyBullet");
+    }
+
+    // damage = -3 — also defaults to 1
+    let bullets = vec![CollisionEnemyBullet { damage: -3.0, ..make_enemy_bullet(102, 105.0, 100.0) }];
+    let mut events = Vec::new();
+    detect_player_enemy_bullet_hits(&players, &bullets, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1);
+    if let CollisionEvent::PlayerHitByEnemyBullet { damage, .. } = events[0] {
+        approx_eq(damage, 1.0, "damage -3 → default 1");
+    } else {
+        panic!("expected PlayerHitByEnemyBullet");
     }
 }


### PR DESCRIPTION
## Summary
Rust mirror of PR #47's `detectPlayerEnemyBulletHits`. **Simplest pair so far** — enemy bullets damage the player on geometric overlap only. NO impulse, NO separation, NO piercing budget.

## New types
- `CollisionEvent::PlayerHitByEnemyBullet` (8 keys: player_id, bullet_id, damage, bullet_x, bullet_y, bullet_vx, bullet_vy)
- `CollisionEnemyBullet` struct (separate from `CollisionBullet` — enemy bullets are simpler, no piercing state)

## Pure function
```rust
detect_player_enemy_bullet_hits(
    players: &[CollisionPlayer],
    bullets: &[CollisionEnemyBullet],
    _ctx: &CollisionContext,
    events: &mut Vec<CollisionEvent>,
)
```

Mirrors JS exactly: skip-gates `!player.active`/`!bullet.active`, circle-circle overlap, damage default = 1 if `bullet.damage <= 0` (matches JS `bullet.damage || 1`).

## 6 parity fixtures (all passing)
| Test | Scenario |
|---|---|
| `player_enemy_bullet_single_hit` | Overlapping → 1 event with all 7 fields |
| `player_enemy_bullet_geometry_miss` | 200 px gap → 0 events |
| `player_enemy_bullet_multiple_bullets` | 2 hits + 1 miss → 2 events |
| `player_enemy_bullet_skip_gates` | Inactive player, inactive bullet, empty inputs |
| `player_enemy_bullet_damage_passthrough` | damage=7 verbatim, damage=25 verbatim |
| `player_enemy_bullet_damage_default` | damage=0 → 1, damage=-3 → 1 |

## Test plan
- [x] `parity_collision`: 32 passed (26 existing + 6 new)
- [x] All workspace tests green; build clean

## Note on origin
Written by the orchestrator instead of a subagent because the original parallel-dispatch subagent worked from stale-master base — the merge produced 4 conflict blocks in collision.rs and parity_collision.rs that couldn't be cleanly auto-resolved. Salvaged the design; reimplemented directly on top of current origin/master.

## Phase 2.5 progress (task #46)
- ✓ bullet-asteroid JS + Rust
- ✓ player-asteroid JS + Rust
- ✓ bullet-enemy JS + Rust
- ✓ player-enemy JS + Rust
- ✓ enemy-asteroid JS + Rust
- ✓ player-enemy-bullet JS + Rust (this PR)
- ⏳ drops pickup JS (sibling PR #50 open) + Rust ⬜
- ⬜ power-weapon (5 weapons), defense-skill (2 skills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)