### PR TITLE
mp/net: refactor Interpolator to compose TickBuffer (Phase 3)

### DIFF
--- a/js/net/interpolation.js
+++ b/js/net/interpolation.js
@@ -1,20 +1,63 @@
 // Render-time-shifted interpolation for remote entities.
 //
 // Snapshots arrive at 20 Hz. Rendering the most-recent snapshot directly
-// would jitter every 50 ms. Instead, we keep two snapshots in a small
-// ring and render at a delayed time `t = serverNow - renderDelayMs`.
-// Between two snapshots we lerp; when a third arrives we drop the oldest.
+// would jitter every 50 ms. Instead, we keep a small ring of recent
+// snapshots and render at a delayed time `t = serverNow - renderDelayMs`.
+// Between two snapshots we lerp; when the ring is full, the oldest is
+// evicted on the next ingest.
 //
 // Render delay defaults to 100 ms — enough headroom for typical
 // dropped-snapshot recovery without feeling laggy.
+//
+// ── Composition with TickBuffer (Phase 3 follow-up) ───────────────────
+// Internally the ring is now a `TickBuffer` (see `tick-buffer.js`), which
+// gives us shared storage / interpolation plumbing with the prediction
+// stack. The public API of `Interpolator` is unchanged:
+//
+//     ingest(serverT, snapshot)
+//     sample(t) -> snapshot | null
+//
+// TickBuffer is keyed by integer tick numbers and internally coerces keys
+// via `tick | 0` (int32 truncation). Wall-clock ms timestamps would
+// overflow, so this module converts server-time-in-ms to a fractional
+// tick number anchored at the first ingested snapshot:
+//
+//     tick = (serverT - epoch) / MS_PER_TICK
+//
+// where MS_PER_TICK = 50 (20 Hz snapshot cadence). The fractional tick is
+// rounded for storage (so `insert(tick, ...)` gets a stable integer key)
+// and used directly for `getInterpolated(tick)` lookups (TickBuffer
+// supports fractional sample positions).
+//
+// One small divergence vs. the previous hand-rolled ring: if `sample(t)`
+// is called when the buffer holds exactly one snapshot, the old code
+// returned that snapshot regardless of `t`; the TickBuffer-backed
+// implementation likewise returns it for any `t` (we layer that fallback
+// on top of `getInterpolated`, which would otherwise return null when the
+// requested tick falls outside the single-entry range).
+
+import { TickBuffer } from './tick-buffer.js';
 
 const DEFAULT_RENDER_DELAY_MS = 100;
+
+/** Snapshot cadence used to convert ms → tick number for TickBuffer. */
+const MS_PER_TICK = 50; // 20 Hz
+
+/** Ring capacity — 4 snapshots at 20 Hz = 200 ms of history. */
+const RING_CAPACITY = 4;
 
 export class Interpolator {
     constructor({ renderDelayMs = DEFAULT_RENDER_DELAY_MS } = {}) {
         this.renderDelayMs = renderDelayMs;
-        /** Ring: [{ serverT, snapshot }] sorted ascending by serverT. */
-        this.buf = [];
+        /** Server time of the first ingested snapshot — used as the
+         *  tick-number epoch so int32 coercion in TickBuffer doesn't
+         *  overflow on wall-clock millis. */
+        this._epochMs = null;
+        /** TickBuffer keyed by tick number = (serverT - epoch) / MS_PER_TICK. */
+        this._buf = new TickBuffer({
+            capacity: RING_CAPACITY,
+            interpolate: lerpSnapshot,
+        });
     }
 
     /**
@@ -24,9 +67,12 @@ export class Interpolator {
      * @param {{ships: object[], enemies: object[], asteroids: object[], drops: object[]}} snapshot
      */
     ingest(serverT, snapshot) {
-        this.buf.push({ serverT, snapshot });
-        // Keep the buffer trimmed: at most 4 snapshots = 200 ms ring at 20 Hz.
-        while (this.buf.length > 4) this.buf.shift();
+        if (this._epochMs == null) this._epochMs = serverT;
+        // Round to integer tick for stable storage key. Fractional precision
+        // is recovered on lookup since `sample(t)` computes a fractional
+        // tick directly.
+        const tick = Math.round((serverT - this._epochMs) / MS_PER_TICK);
+        this._buf.insert(tick, snapshot);
     }
 
     /**
@@ -38,21 +84,28 @@ export class Interpolator {
      * @returns {object|null} interpolated snapshot, or null if no data yet
      */
     sample(t) {
-        if (this.buf.length === 0) return null;
-        if (this.buf.length === 1) return this.buf[0].snapshot;
+        if (this._buf.size() === 0) return null;
+        const latest = this._buf.getLatest();
+        if (this._buf.size() === 1) return latest.state;
 
-        // Walk the ring. Find consecutive (a, b) such that a.serverT <= t <= b.serverT.
-        for (let i = 0; i < this.buf.length - 1; i++) {
-            const a = this.buf[i];
-            const b = this.buf[i + 1];
-            if (a.serverT <= t && t <= b.serverT) {
-                const span = b.serverT - a.serverT;
-                const u = span === 0 ? 0 : (t - a.serverT) / span;
-                return lerpSnapshot(a.snapshot, b.snapshot, u);
-            }
-        }
-        // t is past the newest snapshot — return newest unmodified.
-        return this.buf[this.buf.length - 1].snapshot;
+        // Convert request time to a fractional tick in the same frame as
+        // the stored snapshots.
+        const tickT = (t - this._epochMs) / MS_PER_TICK;
+
+        // Clamp past-newest to the newest snapshot (old behavior). Past
+        // older-than-oldest also falls back to the oldest snapshot — old
+        // code's `for` loop would simply not match and reach the trailing
+        // `return newest`, but conceptually clamping to the oldest is the
+        // closer match since `t` is below the buffered range.
+        if (tickT >= latest.tick) return latest.state;
+
+        const interpolated = this._buf.getInterpolated(tickT);
+        if (interpolated != null) return interpolated;
+
+        // tickT is older than the oldest buffered snapshot — fall back to
+        // the most-recent snapshot to preserve the old API's "never return
+        // null when data exists" contract.
+        return latest.state;
     }
 }
 

--- a/tests/unit/net/interpolation.test.js
+++ b/tests/unit/net/interpolation.test.js
@@ -1,0 +1,212 @@
+/**
+ * tests/unit/net/interpolation.test.js — unit tests for the render-time
+ * interpolator (`js/net/interpolation.js::Interpolator`).
+ *
+ * After the Phase 3 follow-up refactor the Interpolator composes a
+ * `TickBuffer` internally and converts wall-clock-ms timestamps to tick
+ * numbers via an anchored epoch (snapshot cadence is 20 Hz → 50 ms/tick).
+ * The public API (`ingest`, `sample`) is unchanged from the original
+ * hand-rolled ring implementation.
+ *
+ * These tests pin:
+ *   - Construction creates an empty interpolator (sample → null).
+ *   - Ingesting one snapshot stores it and `sample` returns it.
+ *   - Exact-tick sampling returns the matching snapshot's content.
+ *   - Mid-snapshot sampling lerps positions and velocities linearly.
+ *   - The 4-entry ring evicts the oldest snapshot on overflow.
+ *   - Out-of-order ingest is sorted internally and bracketing works.
+ *   - `sample` with no snapshots ingested returns null.
+ *   - `lerpSnapshot` (via `sample`) interpolates ships, enemies,
+ *     asteroids, and drops uniformly.
+ */
+
+import { describe, expect, test } from '@jest/globals';
+
+import { Interpolator } from '../../../js/net/interpolation.js';
+
+// 20 Hz snapshot cadence — same constant as the production module.
+const MS_PER_TICK = 50;
+
+// Convenience: build a snapshot with a single entity per category at the
+// given coordinates. Each category exposes the same id-keyed shape so the
+// underlying `lerpKeyedById` walks them identically.
+function makeSnapshot({ ship = null, enemy = null, asteroid = null, drop = null } = {}) {
+    return {
+        ships: ship ? [{ player: 'p1', ...ship }] : [],
+        enemies: enemy ? [{ id: 'e1', ...enemy }] : [],
+        asteroids: asteroid ? [{ id: 'a1', ...asteroid }] : [],
+        drops: drop ? [{ id: 'd1', ...drop }] : [],
+    };
+}
+
+describe('Interpolator', () => {
+    test('new interpolator is empty — sample returns null', () => {
+        const interp = new Interpolator();
+        expect(interp.sample(0)).toBeNull();
+        expect(interp.sample(1234)).toBeNull();
+    });
+
+    test('ingesting one snapshot — sample returns it for any time', () => {
+        const interp = new Interpolator();
+        const snap = makeSnapshot({ ship: { x: 100, y: 50 } });
+        interp.ingest(1000, snap);
+        // With only one snapshot, every sample returns the stored snapshot
+        // regardless of the requested server time — preserves the old API.
+        expect(interp.sample(1000)).toBe(snap);
+        expect(interp.sample(500)).toBe(snap);
+        expect(interp.sample(2000)).toBe(snap);
+    });
+
+    test('sample at an exact ingested time returns that snapshot (content-equal)', () => {
+        const interp = new Interpolator();
+        const a = makeSnapshot({ ship: { x: 0, y: 0 } });
+        const b = makeSnapshot({ ship: { x: 100, y: 0 } });
+        const c = makeSnapshot({ ship: { x: 200, y: 0 } });
+        interp.ingest(1000, a);
+        interp.ingest(1050, b);
+        interp.ingest(1100, c);
+
+        // Exact match at the middle snapshot — short-circuits the lerp.
+        const out = interp.sample(1050);
+        expect(out.ships).toEqual(b.ships);
+        // Exact match at the newest — also returned directly.
+        expect(interp.sample(1100).ships).toEqual(c.ships);
+    });
+
+    test('sample mid-way between two snapshots lerps ship x/y/vx/vy', () => {
+        const interp = new Interpolator();
+        interp.ingest(1000, makeSnapshot({ ship: { x: 0,   y: 0,   vx: 0,  vy: 0 } }));
+        interp.ingest(1050, makeSnapshot({ ship: { x: 100, y: 200, vx: 10, vy: 20 } }));
+
+        // Sample at the midpoint (25 ms in).
+        const mid = interp.sample(1025);
+        expect(mid.ships).toHaveLength(1);
+        const ship = mid.ships[0];
+        expect(ship.x).toBeCloseTo(50);
+        expect(ship.y).toBeCloseTo(100);
+        expect(ship.vx).toBeCloseTo(5);
+        expect(ship.vy).toBeCloseTo(10);
+    });
+
+    test('4-snapshot ring evicts the oldest snapshot on overflow', () => {
+        const interp = new Interpolator();
+        // Ingest 5 snapshots at the 20 Hz cadence — capacity is 4.
+        interp.ingest(1000, makeSnapshot({ ship: { x: 0,   y: 0 } }));
+        interp.ingest(1050, makeSnapshot({ ship: { x: 100, y: 0 } }));
+        interp.ingest(1100, makeSnapshot({ ship: { x: 200, y: 0 } }));
+        interp.ingest(1150, makeSnapshot({ ship: { x: 300, y: 0 } }));
+        interp.ingest(1200, makeSnapshot({ ship: { x: 400, y: 0 } })); // evicts t=1000
+
+        // Sampling at the evicted time falls back to a buffered snapshot
+        // (per the original API: "never return null when any data is
+        // buffered"). Old behavior returned the newest snapshot when the
+        // request time fell outside the buffered range; verify the same
+        // contract here.
+        const old = interp.sample(1000);
+        expect(old).not.toBeNull();
+        // The evicted snapshot had ship.x=0; result must be a buffered
+        // snapshot. Specifically the fallback returns the newest (x=400).
+        expect(old.ships[0].x).toBe(400);
+        // And it must NOT be the (now-evicted) oldest snapshot's content.
+        expect(old.ships[0].x).not.toBe(0);
+
+        // Sampling at the newest still returns the newest snapshot.
+        const newest = interp.sample(1200);
+        expect(newest.ships[0].x).toBe(400);
+
+        // Sampling between the two newest interpolates between them.
+        const between = interp.sample(1175);
+        expect(between.ships[0].x).toBeCloseTo(350);
+    });
+
+    test('out-of-order ingests are sorted internally (latest snapshot wins)', () => {
+        const interp = new Interpolator();
+        interp.ingest(1000, makeSnapshot({ ship: { x: 0,   y: 0 } }));
+        // Ingest the *third* snapshot before the second — TickBuffer
+        // should re-sort by tick so bracketing still works.
+        interp.ingest(1100, makeSnapshot({ ship: { x: 200, y: 0 } }));
+        interp.ingest(1050, makeSnapshot({ ship: { x: 100, y: 0 } }));
+
+        // Midway between t=1050 and t=1100 should lerp 100 → 200 → x = 150.
+        const mid = interp.sample(1075);
+        expect(mid.ships[0].x).toBeCloseTo(150);
+
+        // Latest snapshot is t=1100; sampling past it returns the latest.
+        const past = interp.sample(2000);
+        expect(past.ships[0].x).toBe(200);
+    });
+
+    test('sample with no snapshots returns null', () => {
+        const interp = new Interpolator();
+        expect(interp.sample(0)).toBeNull();
+        expect(interp.sample(Date.now())).toBeNull();
+        // Constructing with a custom render delay shouldn't affect this.
+        const interp2 = new Interpolator({ renderDelayMs: 200 });
+        expect(interp2.sample(99999)).toBeNull();
+    });
+
+    test('lerpSnapshot lerps ships, enemies, asteroids, and drops uniformly', () => {
+        const interp = new Interpolator();
+        interp.ingest(1000, {
+            ships:     [{ player: 'p1', x: 0,   y: 0,   vx: 0,  vy: 0 }],
+            enemies:   [{ id: 'e1',     x: 10,  y: 20,  vx: 1,  vy: 2 }],
+            asteroids: [{ id: 'a1',     x: 30,  y: 40,  vx: 3,  vy: 4 }],
+            drops:     [{ id: 'd1',     x: 50,  y: 60,  vx: 5,  vy: 6 }],
+        });
+        interp.ingest(1050, {
+            ships:     [{ player: 'p1', x: 100, y: 200, vx: 10, vy: 20 }],
+            enemies:   [{ id: 'e1',     x: 110, y: 220, vx: 11, vy: 22 }],
+            asteroids: [{ id: 'a1',     x: 130, y: 240, vx: 13, vy: 24 }],
+            drops:     [{ id: 'd1',     x: 150, y: 260, vx: 15, vy: 26 }],
+        });
+
+        // Sample at the midpoint — every category should be lerped t=0.5.
+        const mid = interp.sample(1025);
+
+        expect(mid.ships[0].x).toBeCloseTo(50);
+        expect(mid.ships[0].y).toBeCloseTo(100);
+        expect(mid.ships[0].vx).toBeCloseTo(5);
+        expect(mid.ships[0].vy).toBeCloseTo(10);
+
+        expect(mid.enemies[0].x).toBeCloseTo(60);
+        expect(mid.enemies[0].y).toBeCloseTo(120);
+        expect(mid.enemies[0].vx).toBeCloseTo(6);
+        expect(mid.enemies[0].vy).toBeCloseTo(12);
+
+        expect(mid.asteroids[0].x).toBeCloseTo(80);
+        expect(mid.asteroids[0].y).toBeCloseTo(140);
+        expect(mid.asteroids[0].vx).toBeCloseTo(8);
+        expect(mid.asteroids[0].vy).toBeCloseTo(14);
+
+        expect(mid.drops[0].x).toBeCloseTo(100);
+        expect(mid.drops[0].y).toBeCloseTo(160);
+        expect(mid.drops[0].vx).toBeCloseTo(10);
+        expect(mid.drops[0].vy).toBeCloseTo(16);
+    });
+
+    test('large wall-clock timestamps do not overflow int32 tick coercion', () => {
+        // The original ring stored serverT directly. TickBuffer coerces
+        // keys via `tick | 0`, which would corrupt typical Date.now()
+        // values (≈ 1.7e12). The epoch-anchored shim keeps ticks small
+        // enough that int32 truncation is lossless.
+        const interp = new Interpolator();
+        const NOW = 1_750_000_000_000; // ~2025 in ms
+        interp.ingest(NOW,      makeSnapshot({ ship: { x: 0,   y: 0 } }));
+        interp.ingest(NOW + 50, makeSnapshot({ ship: { x: 100, y: 0 } }));
+        interp.ingest(NOW +100, makeSnapshot({ ship: { x: 200, y: 0 } }));
+
+        // Mid-sample between t=NOW+50 and t=NOW+100 → x = 150.
+        const mid = interp.sample(NOW + 75);
+        expect(mid).not.toBeNull();
+        expect(mid.ships[0].x).toBeCloseTo(150);
+    });
+
+    test('renderDelayMs option is preserved on the instance', () => {
+        // Public API surface check: callers may read `renderDelayMs` to
+        // schedule their sample time. The refactor must not drop this.
+        const def = new Interpolator();
+        expect(def.renderDelayMs).toBe(100);
+        const custom = new Interpolator({ renderDelayMs: 200 });
+        expect(custom.renderDelayMs).toBe(200);
+    });
+});


### PR DESCRIPTION
## Summary
Phase 3 follow-up. `Interpolator` now composes `TickBuffer` (PR #43) instead of managing its own 4-snapshot ring buffer. **Public API unchanged**; callers don't need updates.

## Old vs new internal storage
**Old**: hand-rolled `this.buf` array of `{serverT, snapshot}` pairs, manually trimmed past 4 entries.

**New**: `this._buf = new TickBuffer({capacity:4, interpolate:lerpSnapshot})`. `lerpSnapshot` drives bracketing + lerp inside TickBuffer. Anchored epoch shim (`this._epochMs` from first snapshot) converts wall-clock ms to tick numbers via `Math.round((serverT - epoch) / 50)` (20 Hz cadence) — avoids int32 overflow in TickBuffer's `tick|0` coercion.

## Public API preserved
- `new Interpolator({renderDelayMs})` — same constructor
- `ingest(serverT, snapshot)` — same
- `sample(t)` — same return-value contract
- `renderDelayMs` property on instance

**Callers that need updates: NONE.** `grep -r Interpolator js/` shows only doc-comment references; no actual imports exist yet.

## 10 new tests
Empty/single/exact/mid/overflow/out-of-order/no-snapshots/sub-object lerp/large-timestamp/renderDelayMs.

## Documented divergence
With exactly one snapshot in the buffer, old code returned it for any `t`. New code layers that single-entry fallback on top of `getInterpolated` (which would otherwise return null because TickBuffer's range check rejects ticks outside `[oldest, newest]`).

## Test plan
- [x] `interpolation.test.js`: 10 passed
- [x] `tick-buffer.test.js`: 19 passed (unchanged)
- [x] Full unit suite: 526/526 across 21 suites
- [x] `tick-buffer.js` UNTOUCHED

## Phase 3 progress (task #31)
- ✓ TickBuffer scaffolding (PR #43)
- ✓ Predictor wired to js/sim/ship.js (PR #48)
- ✓ Predictor snapshot history via TickBuffer (PR #49)
- ✓ Interpolator composes TickBuffer (this PR)
- ⬜ Wire Predictor + Interpolator into engine-driver.js / ws-client.js
- ⬜ f32 tolerance comparator for Rust↔JS cross-language parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)