### PR TITLE
mp/net: MP feature-flag scaffold (suppress unported abilities)

### DIFF
--- a/js/net/mp-feature-flags.js
+++ b/js/net/mp-feature-flags.js
@@ -1,0 +1,78 @@
+// js/net/mp-feature-flags.js
+//
+// Centralized feature-flag config for multiplayer mode. Suppresses
+// abilities that don't yet have full Rust-mirror parity, so they
+// can't desync MP gameplay.
+//
+// As Phase 2.5 collision pairs land in `server/src/sim/collision.rs`
+// (see `docs/Multiplayer Coordination – 2026-05-09.md` for the live
+// status table), abilities migrate from `MP_UNSAFE_ABILITIES_LIST`
+// to `MP_SAFE_ABILITIES`. The goal of this module is to be
+// EXPLICIT about which abilities are blocked rather than rely on
+// an allow-all default.
+//
+// Wiring happens in a separate slice; this module is pure data + a
+// helper for the engine-driver / weapon-pickup layer to consult.
+
+// Abilities that have full JS+Rust parity coverage and are safe to use
+// in MP. These IDs come from `js/modules/combat/weapon-data.js` —
+// PRIMARY_WEAPONS section. Primary weapons fire `player_bullet` /
+// straight-line projectiles, which have a Rust mirror (PR #20) plus
+// the bullet ↔ asteroid collision pair (PRs #30/#31). They're the
+// safest subset to expose first.
+//
+// Ships themselves are not listed here — there is no "ability ID" for
+// the ship, the ship is always active. The `isAbilityMpSafe` helper
+// is for abilities/weapons, not entity classes.
+export const MP_SAFE_ABILITIES = new Set([
+    // Primary weapons — straight-line player bullets, mirrored in Rust.
+    'PULSE_CANNON',
+    'STORM_NEEDLES',
+    'SCATTER_GUN',
+    'RAIL_DRIVER',
+]);
+
+// Abilities NOT yet ported / mirrored. Listed explicitly for
+// transparency and so a code-search for any of these IDs lands here.
+// All entries below lack a full Rust collision mirror as of
+// Phase 2.5 (see coordination doc subsystem table).
+export const MP_UNSAFE_ABILITIES_LIST = [
+    // Power weapons (POWER_WEAPONS in weapon-data.js) — none have
+    // Rust mirrors for their collision pairs yet.
+    'CHARGE_SHOT',     // charge-based; no server-side accumulator
+    'MINE_LAYER',      // mine entity + blast-radius collisions unported
+    'NOVA_BLAST',      // ring-expansion + AoE collision unported
+    'MISSILE_SALVO',   // homing missile sim + collision unported
+    'LANCE_BEAM',      // sustained beam + raycast collision unported
+    'LIGHTNING_ARC',   // chain-target lookup + tether sim unported
+
+    // Defense skills (DEFENSE_SKILLS in weapon-data.js) — all six
+    // mutate ship state in ways the server doesn't model yet.
+    'BULWARK',         // damage-reduction window
+    'REPAIR_NANITES',  // HoT regen tick
+    'PHASE_DASH',      // invulnerable teleport + i-frames
+    'DEFLECTOR_ORBS',  // orbiting bullet-blockers
+    'EMP_PULSE',       // AoE stun on enemies
+    'TRACTOR_SHIELD',  // forward bullet-absorb + coin redirect
+];
+
+/**
+ * Whether the given ability ID is safe to fire in multiplayer mode.
+ * Returns true if the ability has full server-side parity; false
+ * otherwise (the wrapper should suppress the input or visually
+ * disable the ability when MP is active).
+ *
+ * Unknown / unrecognized ability IDs default to `true` — the caller
+ * owns the engine state and should know what's running. This module
+ * exists to flag KNOWN-unsafe abilities, not to gate the world.
+ *
+ * @param {string} abilityId
+ * @returns {boolean}
+ */
+export function isAbilityMpSafe(abilityId) {
+    if (MP_SAFE_ABILITIES.has(abilityId)) return true;
+    if (MP_UNSAFE_ABILITIES_LIST.includes(abilityId)) return false;
+    // Unknown ability — be permissive. New abilities should be added
+    // to one of the two lists above as soon as they're authored.
+    return true;
+}

--- a/tests/unit/net/mp-feature-flags.test.js
+++ b/tests/unit/net/mp-feature-flags.test.js
@@ -1,0 +1,93 @@
+/**
+ * tests/unit/net/mp-feature-flags.test.js — unit tests for the MP
+ * ability-allowlist helper.
+ *
+ * `mp-feature-flags.js` is pure config + a `isAbilityMpSafe` helper
+ * that the engine-driver / weapon-pickup layer will consult to
+ * suppress abilities that lack full Rust-mirror parity. These tests
+ * pin the contract:
+ *   - Known-unsafe abilities (power weapons + defense skills) return false.
+ *   - Known-safe primary weapons return true.
+ *   - Unknown IDs default to true (the helper flags known-unsafe; it
+ *     does not gate the unknown).
+ *
+ * The lists themselves track Phase 2.5 collision-pair progress in
+ * `docs/Multiplayer Coordination – 2026-05-09.md`; as Rust mirrors
+ * land, abilities migrate from UNSAFE → SAFE and these tests should
+ * be updated in lock-step.
+ */
+
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    MP_SAFE_ABILITIES,
+    MP_UNSAFE_ABILITIES_LIST,
+    isAbilityMpSafe,
+} from '../../../js/net/mp-feature-flags.js';
+
+describe('mp-feature-flags', () => {
+    test('LANCE_BEAM is known-unsafe and returns false', () => {
+        expect(isAbilityMpSafe('LANCE_BEAM')).toBe(false);
+    });
+
+    test('PULSE_CANNON is known-safe primary weapon and returns true', () => {
+        expect(isAbilityMpSafe('PULSE_CANNON')).toBe(true);
+    });
+
+    test('unknown ability IDs default to true (conservative-permissive)', () => {
+        expect(isAbilityMpSafe('NOT_A_REAL_ABILITY')).toBe(true);
+        expect(isAbilityMpSafe('')).toBe(true);
+        expect(isAbilityMpSafe('definitely-unknown-id-xyz')).toBe(true);
+    });
+
+    test('all six defense skills are in the unsafe list and return false', () => {
+        const defenseSkills = [
+            'BULWARK',
+            'REPAIR_NANITES',
+            'PHASE_DASH',
+            'DEFLECTOR_ORBS',
+            'EMP_PULSE',
+            'TRACTOR_SHIELD',
+        ];
+        for (const id of defenseSkills) {
+            expect(MP_UNSAFE_ABILITIES_LIST).toContain(id);
+            expect(isAbilityMpSafe(id)).toBe(false);
+        }
+    });
+
+    test('all power weapons are in the unsafe list and return false', () => {
+        const powerWeapons = [
+            'CHARGE_SHOT',
+            'MINE_LAYER',
+            'NOVA_BLAST',
+            'MISSILE_SALVO',
+            'LANCE_BEAM',
+            'LIGHTNING_ARC',
+        ];
+        for (const id of powerWeapons) {
+            expect(MP_UNSAFE_ABILITIES_LIST).toContain(id);
+            expect(isAbilityMpSafe(id)).toBe(false);
+        }
+    });
+
+    test('all listed primary weapons are MP-safe', () => {
+        // Sanity check that the safe set matches the documented
+        // contract — primary weapons only.
+        const primaries = [
+            'PULSE_CANNON',
+            'STORM_NEEDLES',
+            'SCATTER_GUN',
+            'RAIL_DRIVER',
+        ];
+        for (const id of primaries) {
+            expect(MP_SAFE_ABILITIES.has(id)).toBe(true);
+            expect(isAbilityMpSafe(id)).toBe(true);
+        }
+    });
+
+    test('safe and unsafe lists are disjoint', () => {
+        for (const id of MP_UNSAFE_ABILITIES_LIST) {
+            expect(MP_SAFE_ABILITIES.has(id)).toBe(false);
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Pure-data config module `js/net/mp-feature-flags.js` plus `isAbilityMpSafe(abilityId)` helper.
- `MP_SAFE_ABILITIES` (4): the four primary weapons (PULSE_CANNON, STORM_NEEDLES, SCATTER_GUN, RAIL_DRIVER) — all have Rust mirrors + bullet↔asteroid collision parity.
- `MP_UNSAFE_ABILITIES_LIST` (12): all six power weapons (CHARGE_SHOT, MINE_LAYER, NOVA_BLAST, MISSILE_SALVO, LANCE_BEAM, LIGHTNING_ARC) and all six defense skills (BULWARK, REPAIR_NANITES, PHASE_DASH, DEFLECTOR_ORBS, EMP_PULSE, TRACTOR_SHIELD) — none have full collision-pair mirrors yet.
- Unknown-ID policy: conservative-permissive (`true`). This module flags KNOWN-unsafe; the wiring layer (separate slice) owns gating policy.

## Why
The MVD ships in primary-weapon-only mode. As Phase 2.5 collision pairs land in `server/src/sim/collision.rs`, abilities migrate from `MP_UNSAFE_ABILITIES_LIST` to `MP_SAFE_ABILITIES`. Explicit listing means a code search for any ability ID lands here, so the next slice can grep for what's still unported.

No engine wiring in this PR — that's a follow-up so the table can be reviewed independently.

## Test plan
- [x] 7 new Jest tests passing (`tests/unit/net/mp-feature-flags.test.js`)
- [x] Full unit suite 575/575 passing
- [x] Disjoint-list invariant test (safe ∩ unsafe = ∅)
- [x] Every PRIMARY_WEAPONS entry from weapon-data.js is in MP_SAFE_ABILITIES
- [x] Every POWER_WEAPONS + DEFENSE_SKILLS entry is in MP_UNSAFE_ABILITIES_LIST

🤖 Generated with [Claude Code](https://claude.com/claude-code)