### PR TITLE
mp/server: Rust Mine collision mirror (parity with JS detectMineHits)

### DIFF
--- a/server/src/sim/collision.rs
+++ b/server/src/sim/collision.rs
@@ -539,6 +539,48 @@ pub enum CollisionEvent {
         asteroid_y: f32,
         distance_from_center: f32,
     },
+    /// Mirrors `{ type: 'mine_detonated', ... }` in `js/sim/collision.js`.
+    ///
+    /// Emitted exactly ONCE per triggered mine per tick. The first target
+    /// (enemy or asteroid) whose body overlaps the mine's trigger ring sets
+    /// the mine off; subsequent overlaps in the same tick produce no
+    /// additional events. The wrapper applies the AoE damage downstream
+    /// (typically by forwarding `mine_x` / `mine_y` / `explosion_radius` /
+    /// `damage` into `detect_nova_blast_hits`, or by running its own
+    /// falloff + knockback pass).
+    ///
+    /// Field-count rationale (7 non-type, 8 total with the tag):
+    ///   - `mine_id` lets the wrapper mark the source mine inactive.
+    ///   - `mine_x` / `mine_y` are the AoE center the wrapper feeds into
+    ///     a Nova-style downstream pass (or the legacy linear-falloff
+    ///     manual scan).
+    ///   - `explosion_radius` / `damage` flow through from the mine state
+    ///     so the wrapper does NOT have to look up the mine again.
+    ///   - `trigger_kind` + `trigger_id` identify the entity that tripped
+    ///     the mine, for kill-feed attribution / daisy-chain detection.
+    ///   - No `distance_from_center` field — the trigger lies inside the
+    ///     trigger ring by construction, and the wrapper does not need the
+    ///     trigger-distance to apply AoE. Mirrors the JS event minus the
+    ///     debug-only distance field.
+    MineDetonated {
+        mine_id: u32,
+        mine_x: f32,
+        mine_y: f32,
+        explosion_radius: f32,
+        damage: f32,
+        trigger_kind: TriggerKind,
+        trigger_id: u32,
+    },
+}
+
+/// Which kind of target tripped a mine. Mirrors the JS string-tagged
+/// `triggerKind: 'enemy' | 'asteroid'`. The Rust mirror uses an enum
+/// instead of a string so the variant-tag is checked at compile time —
+/// no typos, no case-mismatch bugs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TriggerKind {
+    Enemy,
+    Asteroid,
 }
 
 // ─── Bullet-vs-asteroid pair detection ──────────────────────────────
@@ -2091,3 +2133,311 @@ pub fn detect_nova_blast_hits(
 // now this is a no-op that satisfies the existing call site. Mirrors
 // the matching stub in `asteroid.rs::update_all`.
 pub fn detect_and_resolve(_state: &mut GameState, _events: &mut Vec<GameEvent>) {}
+
+// ═════════════════════════════════════════════════════════════════════
+// MINE — proximity-triggered persistent AoE (Phase 2.5, dispatch 8)
+// ═════════════════════════════════════════════════════════════════════
+//
+// Rust mirror of `js/sim/collision.js::detectMineHits` (PR #57). The
+// 8th power-weapon collision pair in this module.
+//
+// Mines are persistent bullets placed in the world by the player. They
+// sit (or seek, depending on the variant) and detonate when an enemy or
+// asteroid crosses their trigger ring. On detonation they deal area
+// damage to everything inside the larger blast ring + knockback.
+//
+// ─── What the pure step does and does NOT do ──────────────────────────
+//
+// THIS module ONLY detects which mines are triggered this tick and by
+// what (enemy or asteroid). One `MineDetonated` event per triggered
+// mine. The wrapper applies AoE damage downstream — typically by
+// forwarding `mine_x` / `mine_y` / `explosion_radius` / `damage` into
+// `detect_nova_blast_hits` to enumerate AoE targets, or by running its
+// own falloff + knockback pass per the legacy `mineDamage * (1 -
+// dist/blastR * 0.5)` curve.
+//
+// The pure step intentionally does NOT report:
+//   - Per-target AoE damage events (use `detect_nova_blast_hits` or a
+//     custom scan from the `MineDetonated` event center / radius).
+//   - Per-target knockback impulses (wrapper-owned, upgrade-dependent).
+//   - Lifetime-expiry self-detonations (`mine.expired = true` from the
+//     mine update step). The wrapper detects this BEFORE calling the
+//     pure step and emits its own detonation event, OR sets a sentinel
+//     trigger entity.
+//   - Daisy-chain cascades (DAISY_CHAIN upgrade: nearby mines detonate
+//     together). Emerges naturally if the wrapper re-runs detection
+//     after applying the first detonation's AoE to neighbor mines' HP.
+//     Not modelled here.
+//   - Mine HP / shoot-down (a mine being destroyed by a player bullet
+//     is handled by a bullet-vs-mine pair, NOT here).
+//
+// ─── Skip-gates ──────────────────────────────────────────────────────
+//
+//   Mines:
+//     - Inactive          (`!mine.active`)
+//
+//   Targets (enemies + asteroids):
+//     - Inactive          (`!target.active`)
+//     - Warping           (`target.warping`) — asteroids only in legacy,
+//                         applied to both kinds here for parity with
+//                         every other pair in this file.
+//     - Mid death-flash   (`target.death_flash > 0`) — strict superset
+//                         of legacy (which only gates on `!active`).
+//
+// NOTE on the `armed` gate: the JS code gates on `mine.armed` (a ~1s
+// arm timer after placement). The Rust mirror collapses this into the
+// `active` gate — the wrapper sets `mine.active = false` until the arm
+// timer fires, so a mine that isn't armed is treated as inactive from
+// the pure step's perspective. This keeps `CollisionMine` slim and
+// avoids carrying the armed flag through every pair-detection signature.
+//
+// ─── First-trigger semantics ─────────────────────────────────────────
+//
+// A mine detonates exactly ONCE — the very first target whose body
+// overlaps its trigger ring sets it off. We mirror this by emitting
+// exactly one `MineDetonated` event per mine per tick (early-return on
+// first hit inside the scan). The event's `trigger_kind` and
+// `trigger_id` identify which entity tripped the mine; the wrapper
+// applies AoE to ALL targets in the blast radius (not just the trigger).
+// Iteration order: enemies first, then asteroids, mirroring the legacy
+// JS ordering.
+//
+// ─── Geometry — divergence from JS ──────────────────────────────────
+//
+// The JS pure step uses a CENTER-vs-disc test: a target whose center
+// lies inside the mine's trigger ring trips the mine. The Rust mirror
+// uses a circle-vs-circle test: a target whose BODY overlaps the mine's
+// trigger ring trips the mine. The trigger radius is `mine.radius +
+// target.radius` rather than just `mine.radius`. This is slightly more
+// permissive (a big asteroid grazing the trigger ring with its edge
+// trips the mine even if the center is outside), and matches the
+// circle-circle overlap convention used by every other pair in this
+// Rust module (bullet-vs-asteroid, bullet-vs-enemy, etc.). Wrapper code
+// that wants exact JS parity can shrink the mine's `radius` field by
+// the appropriate target-radius constant before handing it to the
+// detector.
+
+/// Minimal mine view for collision detection.
+///
+/// Mirrors the JS fields read by `detectMineHits`:
+///   `{ id, x, y, radius, hp, explosionRadius, damage, active }`.
+///
+/// The `radius` field is the mine's TRIGGER ring radius (the legacy
+/// `triggerRadius`, default 60 from `MINE_DEFAULT_TRIGGER_RADIUS`). It
+/// is NOT the visual mine body radius. The wrapper composes this from
+/// `POWER_WEAPONS.MINE_LAYER.triggerRadius` + per-mine TRIGGER_RANGE
+/// upgrade stacks.
+///
+/// `hp` is carried for parity with the JS shape (bullet-vs-mine
+/// shoot-down handling lives in a separate pair); the pure step does
+/// not consult it.
+///
+/// `explosion_radius` is the blast disc radius (default 80 from
+/// `MINE_DEFAULT_BLAST_RADIUS`) — flows verbatim into the event so the
+/// wrapper can apply AoE without re-reading mine state.
+///
+/// `damage` is the flat blast damage (default 3 from
+/// `MINE_DEFAULT_DAMAGE`) — flows verbatim into the event.
+#[derive(Debug, Clone, Copy)]
+pub struct CollisionMine {
+    pub id: u32,
+    pub x: f32,
+    pub y: f32,
+    /// Trigger-ring radius (NOT visual body radius). Targets whose
+    /// body-circle overlaps this ring trip the mine.
+    pub radius: f32,
+    /// Current hit points. Unused by the pair-detection step (the
+    /// wrapper applies shoot-down damage via a separate bullet-vs-mine
+    /// pair); carried for parity with the JS shape.
+    pub hp: f32,
+    /// Blast disc radius — flows through into `MineDetonated.explosion_radius`.
+    pub explosion_radius: f32,
+    /// Flat blast damage — flows through into `MineDetonated.damage`.
+    /// The wrapper applies any distance-based falloff curve.
+    pub damage: f32,
+    pub active: bool,
+}
+
+impl CollisionMine {
+    /// Construct a fresh mine at the origin with the live game's
+    /// default trigger radius (60), blast radius (80), and damage (3).
+    /// Test convenience.
+    pub fn fresh(id: u32) -> Self {
+        Self {
+            id,
+            x: 0.0,
+            y: 0.0,
+            radius: 60.0,
+            hp: 1.0,
+            explosion_radius: 80.0,
+            damage: 3.0,
+            active: true,
+        }
+    }
+}
+
+// ─── Mine collision detection ────────────────────────────────────────
+
+/// Detect mine collisions for one tick.
+///
+/// Pure step: for every active mine, scan enemies + asteroids for a
+/// target whose body overlaps the mine's trigger ring. On the first
+/// detected target, emit one `MineDetonated` event and stop scanning
+/// that mine. A mine detonates at most ONCE per tick.
+///
+/// Geometry:
+///   Circle-circle overlap: `(dx² + dy²) < (mine.radius + target.radius)²`.
+///   We use the squared form for the gate to skip the sqrt. Mirrors the
+///   bullet-vs-asteroid / bullet-vs-enemy / enemy-vs-asteroid pairs'
+///   convention. See module comment above for divergence from JS
+///   (which uses a center-only test).
+///
+/// Trigger semantics:
+///   First target wins. Iteration order is `enemies` (in slice order),
+///   then `asteroids` (in slice order). The first one to overlap the
+///   trigger ring sets off the mine; subsequent overlaps in the same
+///   tick produce no additional events (and the wrapper observes the
+///   mine going inactive between ticks via the detonation event).
+///
+/// What the pure step does NOT do:
+///   - Apply AoE damage to all enemies / asteroids inside the blast
+///     radius (wrapper concern — typically forwarded to
+///     `detect_nova_blast_hits` with `(mine_x, mine_y, explosion_radius,
+///     damage)`).
+///   - Apply outward knockback impulses (wrapper concern — depends on
+///     KNOCKBACK powerup multipliers).
+///   - Mutate the mine's `active` flag (wrapper sets `active = false`
+///     when it drains the `MineDetonated` event).
+///   - Handle daisy-chain cascades or mine HP / shoot-down (separate
+///     concerns, see module comment).
+///
+/// Skip-gates (no event emitted):
+///   Mines:
+///     - Inactive          (`!mine.active`)
+///   Targets (both kinds):
+///     - Inactive          (`!target.active`)
+///     - Warping           (`target.warping`)
+///     - Mid death-flash   (`target.death_flash > 0`)
+///
+/// Defensive guards:
+///   - `mine.radius <= 0` → mine cannot trigger (`(r1 + r2)²` is still
+///     positive but the target must overlap the zero-extent trigger
+///     ring AT the mine center; in practice this is virtually
+///     unreachable for live mines but is harmless).
+///   - Empty mine slice → no events emitted.
+///   - Empty enemy + empty asteroid slices → no events emitted.
+///
+/// JS line refs: `js/sim/collision.js:2319–2422`.
+pub fn detect_mine_hits(
+    mines: &[CollisionMine],
+    enemies: &[CollisionEnemy],
+    asteroids: &[CollisionAsteroid],
+    _ctx: &CollisionContext,
+    events: &mut Vec<CollisionEvent>,
+) {
+    // 1. Tolerate an empty mine slice — a frame with no placed mines
+    //    is the common case (JS collision.js:2322).
+    if mines.is_empty() {
+        return;
+    }
+    let has_enemies = !enemies.is_empty();
+    let has_asteroids = !asteroids.is_empty();
+    // 2. If there are no possible triggers at all, nothing to detect
+    //    (JS collision.js:2323–2326).
+    if !has_enemies && !has_asteroids {
+        return;
+    }
+
+    for mine in mines.iter() {
+        // 3. Mine-active gate (JS collision.js:2330). The Rust mirror
+        //    collapses the JS `armed` gate into `active`; see module
+        //    comment above.
+        if !mine.active {
+            continue;
+        }
+
+        let mine_x = mine.x;
+        let mine_y = mine.y;
+        let mine_r = mine.radius;
+
+        let mut triggered = false;
+
+        // ── Enemies ────────────────────────────────────────────────
+        // First target whose body overlaps the trigger ring wins.
+        // Early-break so a mine sitting in the middle of a crowd
+        // reports just ONE trigger event per detonation (JS
+        // collision.js:2348–2380).
+        if has_enemies {
+            for enemy in enemies.iter() {
+                if !enemy.active {
+                    continue;
+                }
+                if enemy.warping {
+                    continue;
+                }
+                if enemy.death_flash > 0 {
+                    continue;
+                }
+
+                let dx = enemy.x - mine_x;
+                let dy = enemy.y - mine_y;
+                let sum_r = mine_r + enemy.radius;
+                if dx * dx + dy * dy >= sum_r * sum_r {
+                    continue;
+                }
+
+                events.push(CollisionEvent::MineDetonated {
+                    mine_id: mine.id,
+                    mine_x,
+                    mine_y,
+                    explosion_radius: mine.explosion_radius,
+                    damage: mine.damage,
+                    trigger_kind: TriggerKind::Enemy,
+                    trigger_id: enemy.id,
+                });
+                triggered = true;
+                break;
+            }
+        }
+
+        if triggered {
+            continue;
+        }
+
+        // ── Asteroids ──────────────────────────────────────────────
+        // Fall-through path when no enemy tripped the mine. Same
+        // first-hit-wins semantics, asteroid id space (JS
+        // collision.js:2385–2420).
+        if has_asteroids {
+            for asteroid in asteroids.iter() {
+                if !asteroid.active {
+                    continue;
+                }
+                if asteroid.warping {
+                    continue;
+                }
+                if asteroid.death_flash > 0 {
+                    continue;
+                }
+
+                let dx = asteroid.x - mine_x;
+                let dy = asteroid.y - mine_y;
+                let sum_r = mine_r + asteroid.radius;
+                if dx * dx + dy * dy >= sum_r * sum_r {
+                    continue;
+                }
+
+                events.push(CollisionEvent::MineDetonated {
+                    mine_id: mine.id,
+                    mine_x,
+                    mine_y,
+                    explosion_radius: mine.explosion_radius,
+                    damage: mine.damage,
+                    trigger_kind: TriggerKind::Asteroid,
+                    trigger_id: asteroid.id,
+                });
+                break;
+            }
+        }
+    }
+}

--- a/server/tests/parity_collision.rs
+++ b/server/tests/parity_collision.rs
@@ -40,13 +40,13 @@
 
 use rainboids_server::sim::collision::{
     detect_bullet_asteroid_hits, detect_bullet_enemy_hits, detect_enemy_asteroid_hits,
-    detect_nova_blast_hits, detect_player_asteroid_hits, detect_player_drop_pickups,
-    detect_player_enemy_bullet_hits, detect_player_enemy_hits, CollisionAsteroid, CollisionBullet,
-    CollisionContext, CollisionDrop, CollisionEnemy, CollisionEnemyBullet, CollisionEvent,
-    CollisionPlayer, NovaBlast, ASTEROID_ENEMY_PUSH, ASTEROID_KNOCKBACK_MULTIPLIER,
-    BOUNCE_FORCE_MULTIPLIER, BOUNCE_RESTITUTION, ENEMY_ASTEROID_PUSH, OVERLAP_PUSH_FORCE,
-    OVERLAP_SEPARATION_RATIO, PLAYER_ASTEROID_COLLISION_DAMAGE, PLAYER_ENEMY_COLLISION_DAMAGE,
-    SEPARATION_BUFFER,
+    detect_mine_hits, detect_nova_blast_hits, detect_player_asteroid_hits,
+    detect_player_drop_pickups, detect_player_enemy_bullet_hits, detect_player_enemy_hits,
+    CollisionAsteroid, CollisionBullet, CollisionContext, CollisionDrop, CollisionEnemy,
+    CollisionEnemyBullet, CollisionEvent, CollisionMine, CollisionPlayer, NovaBlast, TriggerKind,
+    ASTEROID_ENEMY_PUSH, ASTEROID_KNOCKBACK_MULTIPLIER, BOUNCE_FORCE_MULTIPLIER,
+    BOUNCE_RESTITUTION, ENEMY_ASTEROID_PUSH, OVERLAP_PUSH_FORCE, OVERLAP_SEPARATION_RATIO,
+    PLAYER_ASTEROID_COLLISION_DAMAGE, PLAYER_ENEMY_COLLISION_DAMAGE, SEPARATION_BUFFER,
 };
 use rainboids_server::sim::drops::DropKind;
 
@@ -2521,4 +2521,257 @@ fn nova_blast_zero_radius() {
     let mut events = Vec::new();
     detect_nova_blast_hits(&blast, &enemies, &asteroids, &ctx, &mut events);
     assert_eq!(events.len(), 0);
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Mine fixtures (Phase 2.5 — 8th power-weapon mirror, dispatch 8).
+//
+// Rust mirror of `js/sim/collision.js::detectMineHits` (PR #57).
+//
+// The Rust mirror uses circle-circle overlap (`mine.radius +
+// target.radius`) rather than the JS center-only test. Fixtures pick
+// distances that are clearly inside or outside the overlap to avoid
+// straddling the JS-vs-Rust boundary.
+// ═════════════════════════════════════════════════════════════════════
+
+/// Build a mine at (x, y) with the live game defaults (trigger
+/// radius 60, blast radius 80, damage 3).
+fn make_mine(id: u32, x: f32, y: f32) -> CollisionMine {
+    let mut m = CollisionMine::fresh(id);
+    m.x = x;
+    m.y = y;
+    m
+}
+
+// ---------------------------------------------------------------------
+// Fixture — mine triggered by single enemy.
+//
+// Mine at origin, trigger radius 60, enemy at (50, 0) with radius 18.
+// sum_r = 78; |dx| = 50 < 78 ⇒ overlap. One MineDetonated event with
+// trigger_kind = Enemy, trigger_id = the enemy id.
+// ---------------------------------------------------------------------
+
+#[test]
+fn mine_single_enemy_trigger() {
+    let mines = vec![make_mine(7, 0.0, 0.0)];
+    let enemies = vec![make_enemy(101, 50.0, 0.0)];
+    let asteroids: Vec<CollisionAsteroid> = vec![];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_mine_hits(&mines, &enemies, &asteroids, &ctx, &mut events);
+    assert_eq!(events.len(), 1);
+    match events[0] {
+        CollisionEvent::MineDetonated {
+            mine_id,
+            mine_x,
+            mine_y,
+            explosion_radius,
+            damage,
+            trigger_kind,
+            trigger_id,
+        } => {
+            assert_eq!(mine_id, 7);
+            approx_eq(mine_x, 0.0, "mine_x");
+            approx_eq(mine_y, 0.0, "mine_y");
+            approx_eq(explosion_radius, 80.0, "explosion_radius");
+            approx_eq(damage, 3.0, "damage");
+            assert_eq!(trigger_kind, TriggerKind::Enemy);
+            assert_eq!(trigger_id, 101);
+        }
+        _ => panic!("expected MineDetonated"),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — mine triggered by single asteroid (no enemies present).
+//
+// Mine at origin, trigger radius 60, asteroid at (70, 0) with radius
+// 30. sum_r = 90; |dx| = 70 < 90 ⇒ overlap. One MineDetonated event
+// with trigger_kind = Asteroid.
+// ---------------------------------------------------------------------
+
+#[test]
+fn mine_single_asteroid_trigger() {
+    let mines = vec![make_mine(7, 0.0, 0.0)];
+    let enemies: Vec<CollisionEnemy> = vec![];
+    let asteroids = vec![make_asteroid(201, 70.0, 0.0)];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_mine_hits(&mines, &enemies, &asteroids, &ctx, &mut events);
+    assert_eq!(events.len(), 1);
+    match events[0] {
+        CollisionEvent::MineDetonated {
+            mine_id,
+            trigger_kind,
+            trigger_id,
+            ..
+        } => {
+            assert_eq!(mine_id, 7);
+            assert_eq!(trigger_kind, TriggerKind::Asteroid);
+            assert_eq!(trigger_id, 201);
+        }
+        _ => panic!("expected MineDetonated"),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — mine has no overlapping targets ⇒ no events.
+//
+// Mine at origin, trigger radius 60. Place an enemy 500 px east
+// (clearly outside trigger ring even with radius 18) and an asteroid
+// 500 px north (clearly outside even with radius 30).
+// ---------------------------------------------------------------------
+
+#[test]
+fn mine_outside_all_targets() {
+    let mines = vec![make_mine(7, 0.0, 0.0)];
+    let enemies = vec![make_enemy(101, 500.0, 0.0)];
+    let asteroids = vec![make_asteroid(201, 0.0, 500.0)];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_mine_hits(&mines, &enemies, &asteroids, &ctx, &mut events);
+    assert_eq!(events.len(), 0, "no overlapping targets ⇒ no events");
+}
+
+// ---------------------------------------------------------------------
+// Fixture — multiple mines, only one overlapping.
+//
+// Three mines: mine A at origin (no overlap), mine B at (1000, 0)
+// (overlaps enemy 101), mine C at (0, 1000) (no overlap). Verify only
+// mine B's id appears in the event.
+// ---------------------------------------------------------------------
+
+#[test]
+fn mine_multiple_one_triggered() {
+    let mines = vec![
+        make_mine(1, 0.0, 0.0),     // far from enemy
+        make_mine(2, 1000.0, 0.0),  // overlaps enemy at (1050, 0)
+        make_mine(3, 0.0, 1000.0),  // far from enemy
+    ];
+    let enemies = vec![make_enemy(101, 1050.0, 0.0)];
+    let asteroids: Vec<CollisionAsteroid> = vec![];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_mine_hits(&mines, &enemies, &asteroids, &ctx, &mut events);
+    assert_eq!(events.len(), 1, "only mine 2 should trigger");
+    match events[0] {
+        CollisionEvent::MineDetonated { mine_id, trigger_id, trigger_kind, .. } => {
+            assert_eq!(mine_id, 2);
+            assert_eq!(trigger_id, 101);
+            assert_eq!(trigger_kind, TriggerKind::Enemy);
+        }
+        _ => panic!("expected MineDetonated"),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — skip-gates: inactive mine / inactive target / warping
+// target / death-flash target ⇒ 0 events.
+//
+// All target candidates would overlap the mine geometrically; the
+// gates must short-circuit every one.
+// ---------------------------------------------------------------------
+
+#[test]
+fn mine_skip_gates() {
+    // Inactive mine — even with a geometrically overlapping enemy,
+    // no event should fire.
+    let mut inactive_mine = make_mine(1, 0.0, 0.0);
+    inactive_mine.active = false;
+    let live_enemy = make_enemy(101, 30.0, 0.0); // would overlap
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_mine_hits(
+        &[inactive_mine],
+        &[live_enemy],
+        &[],
+        &ctx,
+        &mut events,
+    );
+    assert_eq!(events.len(), 0, "inactive mine must not trigger");
+
+    // Active mine, but every target skipped via a gate.
+    let mine = make_mine(1, 0.0, 0.0);
+    let mut inactive_enemy = make_enemy(101, 30.0, 0.0);
+    inactive_enemy.active = false;
+    let mut warping_enemy = make_enemy(102, 30.0, 5.0);
+    warping_enemy.warping = true;
+    let mut flash_enemy = make_enemy(103, 30.0, 10.0);
+    flash_enemy.death_flash = 1;
+    let mut inactive_ast = make_asteroid(201, -30.0, 0.0);
+    inactive_ast.active = false;
+    let mut warping_ast = make_asteroid(202, -30.0, 5.0);
+    warping_ast.warping = true;
+    let mut flash_ast = make_asteroid(203, -30.0, 10.0);
+    flash_ast.death_flash = 1;
+    let mut events = Vec::new();
+    detect_mine_hits(
+        &[mine],
+        &[inactive_enemy, warping_enemy, flash_enemy],
+        &[inactive_ast, warping_ast, flash_ast],
+        &ctx,
+        &mut events,
+    );
+    assert_eq!(
+        events.len(),
+        0,
+        "every target must be skipped: inactive/warping/death-flash"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Fixture — trigger-kind correctness when both kinds overlap.
+//
+// Two mines, each with exactly one overlapping target of a specific
+// kind. Verify that mine A reports TriggerKind::Enemy and mine B
+// reports TriggerKind::Asteroid. Also verify the enemy-first iteration
+// order: when BOTH an enemy and an asteroid overlap the same mine,
+// the enemy wins.
+// ---------------------------------------------------------------------
+
+#[test]
+fn mine_trigger_kind_correctness() {
+    // Mine 1 only has an overlapping enemy.
+    // Mine 2 only has an overlapping asteroid.
+    // Mine 3 has BOTH an enemy and asteroid overlapping — enemy must
+    // win (mirrors JS iteration order: enemies first, then asteroids).
+    let mines = vec![
+        make_mine(1, 0.0, 0.0),
+        make_mine(2, 500.0, 0.0),
+        make_mine(3, 0.0, 500.0),
+    ];
+    let enemies = vec![
+        make_enemy(101, 40.0, 0.0),   // overlaps mine 1
+        make_enemy(103, 40.0, 500.0), // overlaps mine 3
+    ];
+    let asteroids = vec![
+        make_asteroid(201, 540.0, 0.0), // overlaps mine 2
+        make_asteroid(203, -40.0, 500.0), // overlaps mine 3 (loses to enemy)
+    ];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_mine_hits(&mines, &enemies, &asteroids, &ctx, &mut events);
+    assert_eq!(events.len(), 3, "all three mines should trigger");
+
+    // Index events by mine_id for kind verification.
+    let mut by_mine: std::collections::HashMap<u32, (TriggerKind, u32)> =
+        std::collections::HashMap::new();
+    for ev in &events {
+        if let CollisionEvent::MineDetonated {
+            mine_id,
+            trigger_kind,
+            trigger_id,
+            ..
+        } = *ev
+        {
+            by_mine.insert(mine_id, (trigger_kind, trigger_id));
+        }
+    }
+    assert_eq!(by_mine.get(&1), Some(&(TriggerKind::Enemy, 101)));
+    assert_eq!(by_mine.get(&2), Some(&(TriggerKind::Asteroid, 201)));
+    assert_eq!(
+        by_mine.get(&3),
+        Some(&(TriggerKind::Enemy, 103)),
+        "when enemy + asteroid both overlap a mine, enemy wins (iteration order)",
+    );
 }


### PR DESCRIPTION
## Summary
- Mirrors PR #57's `js/sim/collision.js` `detectMineHits` into Rust. Sibling of Nova (PRs #44/#56) — second power-weapon collision pair with full server-side parity coverage.
- New: `CollisionMine` struct, `TriggerKind` enum, `CollisionEvent::MineDetonated` variant, `detect_mine_hits()` pure step.
- +6 parity fixtures (46 → 52 passing, clean build, zero warnings).

## Mine remains MP-unsafe in this PR
The MP feature-flag scaffold (PR #63) keeps `MINE_LAYER` in `MP_UNSAFE_ABILITIES_LIST`. This PR adds the collision pair's Rust mirror — a prerequisite — but full MP support also needs (a) mine spawning in `GameState`, and (b) wiring into the room actor's drain loop (touched by PR for task #81). Until then this code is a parallel implementation reachable only via direct unit/parity test.

## Divergences from JS (documented inline)
1. **Geometry**: circle-vs-circle overlap (`mine.radius + target.radius`) instead of JS center-vs-disc. Spec explicit; matches every other Rust pair's convention.
2. **Armed gate**: collapsed into `active` (wrapper sets `active=false` until armed).
3. **No `distance_from_center` field**: trigger is inside ring by construction.
4. **Skip-gates uniform**: `warping` + `death_flash` on BOTH targets (matches JS pure step's superset behavior).

## Test plan
- [x] 6 new parity fixtures (single-enemy, single-asteroid, miss, multiple, skip-gates, trigger-kind-correctness)
- [x] 52/52 parity_collision tests passing
- [x] Build clean, zero warnings
- [x] `mvd_ship_sync` integration test still passes (drain path unaffected)
- [x] Enemy-wins-over-asteroid iteration order pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)