### PR TITLE
mp/net: Hybrid LoopbackConnection scaffold (Phase 1)

### DIFF
--- a/js/net/loopback-connection.js
+++ b/js/net/loopback-connection.js
@@ -1,0 +1,509 @@
+// js/net/loopback-connection.js — in-process counterpart to `ConnectionTask`.
+//
+// PURPOSE — Hybrid Solo↔MP unification (Phase 1 scaffold):
+//
+//   `LoopbackConnection` implements the same event-emitter API surface as
+//   `js/net/ws-client.js::ConnectionTask`, but runs the game simulation
+//   in-process instead of going over a WebSocket. This lets the engine
+//   driver's `startOnline({ connection, welcome, baselineShip })` path
+//   run solo mode through the EXACT same code as actual multiplayer —
+//   solo and online share `Predictor` + `Interpolator` + snapshot dispatch,
+//   with the only difference being where the snapshot bytes come from.
+//
+//   On the wire, the Rust server emits `S2C.SNAPSHOT { tick, baseTick,
+//   payload: { ships, enemies, asteroids, drops, enemy_bullets } }` every
+//   50 ms. This class synthesizes that frame locally by advancing a
+//   single-ship sim step (`js/sim/ship.js::updateShip`) per 50 ms tick and
+//   emitting the same `snapshot` event the real connection emits.
+//
+// SCOPE (Phase 1, scaffold only):
+//
+//   • Event-emitter surface that mirrors `ConnectionTask` byte-for-byte
+//     (`on(event, fn) → unsubscribe`, `_emit(event, payload)`).
+//   • Lifecycle: `start()` emits `welcome`, then drives a `setInterval`
+//     tick loop at 20 Hz that emits synthetic `snapshot` frames.
+//   • `disconnect()` stops the loop and emits `disconnect`.
+//   • `sendInput(packedInput)` queues input for the next tick. Phase 1
+//     accepts plain `InputFrame`-shaped objects directly (see "Input
+//     shape" below); decoding a wire `PackedInput` Uint8Array is Phase 2.
+//
+//   NOT IN SCOPE for Phase 1 (Phase 2 will wire these in):
+//   • Engine-driver integration — this class is API-compatible but the
+//     driver still gets a real `ConnectionTask` today.
+//   • Game-engine integration — enemies / asteroids / drops are empty
+//     arrays in the synthetic snapshot. Only ship sync.
+//   • PackedInput Uint8Array decode path — see `sendInput()` docs.
+//
+// API CONTRACT (subset of `ConnectionTask` that `engine-driver.js` uses):
+//
+//   • `on(event, fn) → unsubscribe`
+//   • `disconnect()`
+//   • `sendInput(packedInput)` — note: engine-driver calls this with
+//     `(tick, packed)` two-arg form on the real ConnectionTask; the
+//     scaffold uses the simpler one-arg form documented in the Phase 1
+//     spec. Phase 2 reconciles the signatures.
+//   • Property accessors: `isConnected`, `playerId`.
+//
+//   Events emitted: `welcome`, `disconnect`, `snapshot`. (No `frame`,
+//   `error_msg`, `room_list`, `room_joined`, `room_left`, `peer_joined`,
+//   `peer_left` — those are network-layer concerns the loopback path
+//   doesn't model. Subscribing to them is a no-op, matching the
+//   ConnectionTask convention.)
+
+import { updateShip } from '../sim/ship.js';
+
+/**
+ * 20 Hz tick = 50 ms per step. Matches the server's snapshot cadence
+ * (`server/src/sim/loop.rs`). Keeping the same dt as the wire path
+ * means the predictor / interpolator see the same per-tick deltas in
+ * loopback mode as they would over a real socket.
+ */
+export const LOOPBACK_TICK_HZ = 20;
+export const LOOPBACK_TICK_MS = 1000 / LOOPBACK_TICK_HZ; // 50
+
+/** dt used for the ship physics step. `updateShip` currently ignores dt
+ *  (per-tick deltas baked into thrustPower/friction), but the slot is
+ *  plumbed for forward compatibility. We use 0.05 to match the server
+ *  tick rate; the test suite verifies the contract, not this constant. */
+export const LOOPBACK_DT = LOOPBACK_TICK_MS / 1000; // 0.05
+
+/**
+ * Default ship-physics constants used when the caller's `sendInput`
+ * payload doesn't supply them. These mirror the `freshShipState` /
+ * Predictor defaults so a single-ship loopback sim behaves like the
+ * solo `Player.update()` step. The numbers come from the canonical
+ * GAME_CONFIG values in `js/modules/config.js` (TICK_SCALE = 30/60):
+ *
+ *   thrustPower = 2.0 * 0.5            = 1.0
+ *   friction    = Math.pow(0.5, 0.5)   ≈ 0.7071067811865476
+ *   maxV        = 7   * 0.5            = 3.5
+ *   velEpsilon  = 0.05
+ *   bounceDamp  = 0.8
+ *
+ * Keeping them as module-level constants (vs. importing from config.js)
+ * keeps the scaffold dependency-free; the wiring session can swap to a
+ * GAME_CONFIG passthrough if those values drift.
+ */
+const DEFAULT_PHYSICS = Object.freeze({
+    thrustPower: 1.0,
+    speedMult: 1,
+    thrustersDisabled: false,
+    maxV: 3.5,
+    friction: 0.7071067811865476,
+    velEpsilon: 0.05,
+    bounceDamp: 0.8,
+});
+
+/**
+ * In-process counterpart to `ConnectionTask`. Behaves like a Welcomed
+ * WebSocket connection for the engine driver — emits `welcome` once,
+ * then `snapshot` every 50 ms, and `disconnect` on teardown.
+ *
+ * @example
+ *     const loop = new LoopbackConnection({ playerId: 1 });
+ *     loop.on('welcome',  ({ playerId, session }) => console.log('welcomed', playerId));
+ *     loop.on('snapshot', ({ tick, payload }) => render(payload.ships));
+ *     loop.start();
+ *     // … later …
+ *     loop.disconnect();
+ */
+export class LoopbackConnection {
+    /**
+     * @param {object} [opts]
+     * @param {number|bigint} [opts.playerId=1]         logical player id; emitted in `welcome`
+     * @param {string}        [opts.sessionId='loopback'] surfaced as `session` in `welcome`
+     * @param {number|bigint} [opts.serverTimeMs]       initial clock; defaults to `Date.now()`
+     * @param {object}        [opts.baselineShip]       optional initial ship state
+     * @param {Function}      [opts.setInterval]        injectable scheduler (tests)
+     * @param {Function}      [opts.clearInterval]      injectable canceller (tests)
+     * @param {Function}      [opts.now]                injectable clock for `recvTime` stamps
+     */
+    constructor({
+        playerId = 1,
+        sessionId = 'loopback',
+        serverTimeMs = Date.now(),
+        baselineShip = null,
+        setInterval: setIntervalImpl,
+        clearInterval: clearIntervalImpl,
+        now,
+    } = {}) {
+        this._playerId = playerId;
+        this.session = sessionId;
+        this.serverTimeMs = serverTimeMs;
+
+        // Injectable timer hooks. We default to globalThis at call time so
+        // jest `useFakeTimers()` patching takes effect even if it ran after
+        // construction. Production code never sets these; the test suite
+        // uses them for deterministic loops.
+        this._setInterval = setIntervalImpl ?? null;
+        this._clearInterval = clearIntervalImpl ?? null;
+        this._now = now ?? null;
+
+        // ── Event-emitter shim ───────────────────────────────────────────
+        // Same shape as `ConnectionTask._listeners` (event → Set<fn>).
+        // Kept inline (no shared mixin) to mirror the reference class
+        // byte-for-byte — see ws-client.js around line 150.
+        this._listeners = new Map();
+
+        // ── Connection state ─────────────────────────────────────────────
+        // `'idle' | 'open' | 'closed'`. The real ConnectionTask also has
+        // `'connecting'` and `'welcomed'`, but loopback collapses both
+        // into `'open'` since there's no async handshake.
+        this.state = 'idle';
+        this._intervalHandle = null;
+
+        // ── Sim state ────────────────────────────────────────────────────
+        // Single ship for now. Phase 2 may extend to enemies / asteroids /
+        // drops; for the scaffold we keep them as fixed empty arrays so
+        // the snapshot shape matches the wire payload.
+        // The `field` is required by `updateShip`'s boundary-bounce path;
+        // we use the same 1920×1080 default as `freshShipState`.
+        this._field = { width: 1920, height: 1080 };
+        this._ship = baselineShip ? this._cloneShip(baselineShip) : this._defaultShip();
+
+        // ── Tick state ───────────────────────────────────────────────────
+        // `_tick` increments by 1 each emission, matching the server's
+        // monotonic snapshot tick. `_baseTick` mirrors the wire field
+        // (server uses it for delta-encoded snapshots; loopback always
+        // emits full state so we set it to 0).
+        this._tick = 0;
+        this._baseTick = 0;
+        this._pendingInputs = [];
+    }
+
+    // ── Property accessors ───────────────────────────────────────────────
+
+    /**
+     * Whether the loopback is actively ticking. Mirrors the spirit of
+     * `ConnectionTask.state === 'welcomed'` — the engine driver treats
+     * this as "the session is live".
+     */
+    get isConnected() {
+        return this.state === 'open';
+    }
+
+    /** Player id of the local ship. Set at construction time. */
+    get playerId() {
+        return this._playerId;
+    }
+
+    // ── Event emitter ────────────────────────────────────────────────────
+
+    /**
+     * Subscribe to an event. Returns an unsubscribe fn.
+     * Mirrors `ConnectionTask.on` exactly. Subscribing to an event the
+     * loopback never emits is harmless — the listener simply never fires.
+     */
+    on(event, fn) {
+        let set = this._listeners.get(event);
+        if (!set) {
+            set = new Set();
+            this._listeners.set(event, set);
+        }
+        set.add(fn);
+        return () => set.delete(fn);
+    }
+
+    /**
+     * Emit an event to all subscribers. Each listener is wrapped in an
+     * isolated try/catch so one throwing handler can't break the others
+     * — same convention as `ConnectionTask._emit`.
+     */
+    _emit(event, payload) {
+        const set = this._listeners.get(event);
+        if (!set) return;
+        for (const fn of set) {
+            try {
+                fn(payload);
+            } catch (err) {
+                // eslint-disable-next-line no-console
+                console.error(`LoopbackConnection: listener for "${event}" threw`, err);
+            }
+        }
+    }
+
+    // ── Lifecycle ────────────────────────────────────────────────────────
+
+    /**
+     * Begin the loopback "session". Idempotent — calling start twice is
+     * a no-op past the first call.
+     *
+     * Order of operations:
+     *   1. Flip state → 'open'.
+     *   2. Schedule the welcome emission via `queueMicrotask` so the
+     *      caller has a chance to subscribe AFTER `new LoopbackConnection
+     *      (...)` but BEFORE the welcome fires. (Synchronous emission at
+     *      this point would fire before the caller's `on('welcome', ...)`
+     *      registration in the canonical "subscribe-then-start" pattern.)
+     *   3. Start the 50 ms tick interval. Each tick advances ship
+     *      physics with any queued input and emits a `snapshot` frame.
+     */
+    start() {
+        if (this.state === 'open') return;
+        if (this.state === 'closed') return; // Idempotent — disconnected loopbacks stay disconnected.
+
+        this.state = 'open';
+
+        // Resolve the scheduler at start-time so jest fake-timers patches
+        // (which replace globalThis.setInterval) are respected even if
+        // they're installed between construction and start.
+        const setIntervalImpl = this._setInterval ?? globalThis.setInterval;
+        // Welcome via microtask so subscribers registered after `new`
+        // but before the next macrotask receive the event.
+        queueMicrotask(() => {
+            // Guard against disconnect-before-welcome: if the caller
+            // disconnects synchronously between start() and the microtask
+            // running, we must not emit welcome after a disconnect.
+            if (this.state !== 'open') return;
+            this._emit('welcome', {
+                playerId: this._playerId,
+                session: this.session,
+                serverTimeMs: this.serverTimeMs,
+            });
+        });
+
+        this._intervalHandle = setIntervalImpl(() => this._onTick(), LOOPBACK_TICK_MS);
+    }
+
+    /**
+     * Stop the loopback session. Idempotent. Emits a final `disconnect`
+     * event with an empty payload (matches the shape ConnectionTask uses
+     * for clean closes).
+     */
+    disconnect() {
+        if (this.state === 'closed') return;
+        if (this.state === 'idle') {
+            // Never started; just mark closed without emitting disconnect
+            // — there's nothing to disconnect from. Matches
+            // `ConnectionTask.disconnect()` early-return for idle state.
+            this.state = 'closed';
+            return;
+        }
+        this.state = 'closed';
+        if (this._intervalHandle != null) {
+            const clearIntervalImpl = this._clearInterval ?? globalThis.clearInterval;
+            clearIntervalImpl(this._intervalHandle);
+            this._intervalHandle = null;
+        }
+        this._emit('disconnect', {});
+    }
+
+    // ── Input ────────────────────────────────────────────────────────────
+
+    /**
+     * Queue an input frame to be applied on the next tick.
+     *
+     * INPUT SHAPE (Phase 1 scaffold):
+     *
+     *   The real `ConnectionTask.sendInput(tick, packed)` accepts a
+     *   PackedInput wire struct (`{ moveX:i8, moveY:i8, aimX:i16,
+     *   aimY:i16, buttons:u8 }`) — the byte-form documented in
+     *   `js/sim/input.js`. The loopback scaffold accepts a SUPERSET of
+     *   shapes and normalizes internally:
+     *
+     *     1. An InputFrame plain object (preferred): the shape
+     *        `updateShip` already consumes — `{up, down, left, right,
+     *         aimX, aimY, thrustPower, speedMult, friction, ...}`.
+     *        Used as-is.
+     *
+     *     2. A PackedInput plain object (interop): `{moveX, moveY,
+     *         aimX, aimY, buttons}`. Converted to InputFrame via a
+     *        lightweight signed-axis → directional-boolean mapping.
+     *        The physics constants (`thrustPower`, `friction`, etc.)
+     *        come from `DEFAULT_PHYSICS`.
+     *
+     *     3. A `Uint8Array` (true wire form): NOT decoded in Phase 1.
+     *        Phase 2 will route through `js/sim/protocol-generated.js`'s
+     *        decoder. Today we accept and ignore (no crash) so engine-
+     *        driver integration can land without changing call sites.
+     *
+     *   The engine-driver currently calls `sendInput(tick, packed)` with
+     *   two args; we accept either `sendInput(input)` or `sendInput(_, input)`
+     *   to keep both call sites working during the Phase 1↔2 transition.
+     *
+     * @param {object|Uint8Array} packedInputOrTick
+     * @param {object|Uint8Array} [maybePacked]
+     */
+    sendInput(packedInputOrTick, maybePacked) {
+        // Engine-driver shape: sendInput(tick, packed) → second arg.
+        // Scaffold shape: sendInput(input) → first arg.
+        // We pick whichever arg looks like an object/Uint8Array.
+        let raw = maybePacked ?? packedInputOrTick;
+        if (raw == null) return;
+
+        // Uint8Array wire bytes — Phase 1 scope explicitly skips decode.
+        // The slot is wired so Phase 2 can drop in a real decoder without
+        // breaking call sites. Accept silently for now.
+        if (raw instanceof Uint8Array) {
+            // TODO(Phase 2): decode via protocol-generated.js
+            return;
+        }
+
+        if (typeof raw !== 'object') return;
+
+        const normalized = this._normalizeInput(raw);
+        if (normalized) this._pendingInputs.push(normalized);
+    }
+
+    // ── Internals ────────────────────────────────────────────────────────
+
+    /**
+     * Single tick step. Drains pending inputs, advances ship physics,
+     * emits a synthetic snapshot.
+     */
+    _onTick() {
+        if (this.state !== 'open') return;
+
+        // Apply queued inputs in order. The engine driver typically sends
+        // one input per logic tick at 60 Hz, so we'll see ~3 inputs per
+        // 50 ms snapshot tick. The pure step is idempotent enough that
+        // applying them all in order produces a sensible aggregate
+        // position; precise per-input granularity is a Phase 2 concern
+        // (the predictor will handle sub-tick reconciliation when wired).
+        const inputs = this._pendingInputs;
+        this._pendingInputs = [];
+        for (const input of inputs) {
+            updateShip(this._ship, input, LOOPBACK_DT, null, null);
+        }
+        // If there were no inputs this tick, still run a no-op step so
+        // friction / boundary effects converge (matches the wire path
+        // where the server steps the ship every tick regardless).
+        if (inputs.length === 0) {
+            updateShip(this._ship, this._idleInput(), LOOPBACK_DT, null, null);
+        }
+
+        this._tick = (this._tick + 1) | 0;
+
+        const recvTime = (this._now ?? (() => Date.now()))();
+
+        this._emit('snapshot', {
+            tick: this._tick,
+            baseTick: this._baseTick,
+            payload: {
+                ships: [this._snapshotShip()],
+                enemies: [],
+                asteroids: [],
+                drops: [],
+                enemy_bullets: [],
+            },
+            recvTime,
+        });
+    }
+
+    /**
+     * Build the wire-shaped ship object embedded in the snapshot. We
+     * trim to the fields documented in the Phase 1 spec — the
+     * `engine-driver._onSnapshot` path only reads `(player, x, y, vx,
+     * vy, angle, hp)` for the predictor, so extra fields are dropped
+     * to keep the synthetic payload narrow and self-documenting.
+     *
+     * Note: the field is `id` per the spec, but ConnectionTask emits
+     * `player` (matching the server's `ShipState`). We emit both so
+     * either consumer is happy during the Phase 1↔2 transition.
+     */
+    _snapshotShip() {
+        return {
+            id: this._playerId,
+            player: this._playerId,
+            x: this._ship.x,
+            y: this._ship.y,
+            vx: this._ship.vx,
+            vy: this._ship.vy,
+            angle: this._ship.angle,
+            hp: this._ship.hp,
+        };
+    }
+
+    /** Default ship at field-center, facing east, 100 HP. */
+    _defaultShip() {
+        return {
+            player: this._playerId,
+            x: 400,
+            y: 300,
+            vx: 0,
+            vy: 0,
+            angle: 0,
+            hp: 100,
+            maxHp: 100,
+            shield: 0,
+            radius: 15,
+            field: this._field,
+            active: true,
+        };
+    }
+
+    /** Shallow-clone of a caller-supplied baseline ship; fills in missing
+     *  fields with defaults so `updateShip` never sees `undefined`. */
+    _cloneShip(src) {
+        const def = this._defaultShip();
+        return {
+            ...def,
+            ...src,
+            // Force-include the field reference so boundary bounce works
+            // even when the caller's baseline omits it.
+            field: src.field ?? def.field,
+        };
+    }
+
+    /**
+     * No-input frame used on idle ticks. Pre-built from DEFAULT_PHYSICS
+     * with all direction booleans false and aim straight east of the
+     * ship — `updateShip` will compute angle=0 with this aim, and the
+     * isMoving guard short-circuits the velocity integration.
+     */
+    _idleInput() {
+        return {
+            up: false,
+            down: false,
+            left: false,
+            right: false,
+            aimX: this._ship.x + 100,
+            aimY: this._ship.y,
+            ...DEFAULT_PHYSICS,
+        };
+    }
+
+    /**
+     * Coerce caller input into the InputFrame shape `updateShip` expects.
+     * If the caller already passed an InputFrame, we just inject the
+     * default physics constants for any missing fields.
+     */
+    _normalizeInput(raw) {
+        // Detect InputFrame: presence of `up/down/left/right` booleans.
+        const looksLikeInputFrame =
+            'up' in raw || 'down' in raw || 'left' in raw || 'right' in raw;
+
+        if (looksLikeInputFrame) {
+            return {
+                up: !!raw.up,
+                down: !!raw.down,
+                left: !!raw.left,
+                right: !!raw.right,
+                aimX: raw.aimX ?? this._ship.x + 100,
+                aimY: raw.aimY ?? this._ship.y,
+                thrustPower: raw.thrustPower ?? DEFAULT_PHYSICS.thrustPower,
+                speedMult: raw.speedMult ?? DEFAULT_PHYSICS.speedMult,
+                thrustersDisabled: raw.thrustersDisabled ?? DEFAULT_PHYSICS.thrustersDisabled,
+                maxV: raw.maxV ?? DEFAULT_PHYSICS.maxV,
+                friction: raw.friction ?? DEFAULT_PHYSICS.friction,
+                velEpsilon: raw.velEpsilon ?? DEFAULT_PHYSICS.velEpsilon,
+                bounceDamp: raw.bounceDamp ?? DEFAULT_PHYSICS.bounceDamp,
+            };
+        }
+
+        // PackedInput-ish shape: signed axes → directional booleans. We
+        // accept either i8-scaled (`moveX` in [-127, 127]) or unit-scaled
+        // (`moveX` in [-1, 1]) values — the comparison is just "nonzero?".
+        const mx = raw.moveX ?? raw.ax ?? 0;
+        const my = raw.moveY ?? raw.ay ?? 0;
+        return {
+            left: mx < 0,
+            right: mx > 0,
+            up: my < 0,
+            down: my > 0,
+            aimX: raw.aimX != null ? raw.aimX : this._ship.x + 100,
+            aimY: raw.aimY != null ? raw.aimY : this._ship.y,
+            ...DEFAULT_PHYSICS,
+        };
+    }
+}

--- a/tests/unit/net/loopback-connection.test.js
+++ b/tests/unit/net/loopback-connection.test.js
@@ -1,0 +1,471 @@
+// tests/unit/net/loopback-connection.test.js — unit coverage for the
+// in-process counterpart to `ConnectionTask` (Phase 1 scaffold).
+//
+// Test plan (mirrors the contract in `js/net/loopback-connection.js`):
+//
+//   • Construction — defaults + option overrides.
+//   • Event emitter — subscribe / unsubscribe / multi-listener / fault
+//     isolation / unknown-event no-op.
+//   • Lifecycle — welcome on start, snapshot cadence, disconnect cleanup,
+//     `isConnected` accessor.
+//   • Snapshot shape — initial ship position, tick monotonicity, payload
+//     subfields, empty entity arrays.
+//   • Input application — queue + drain + velocity progression.
+//
+// We use `jest.useFakeTimers()` to drive `setInterval` deterministically.
+// `queueMicrotask` is NOT a timer, so we flush it via `await Promise.resolve()`
+// after each `start()` call before any synchronous-snapshot assertion.
+
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+import {
+    LOOPBACK_DT,
+    LOOPBACK_TICK_HZ,
+    LOOPBACK_TICK_MS,
+    LoopbackConnection,
+} from '../../../js/net/loopback-connection.js';
+
+// Helper: flush the microtask queue so `queueMicrotask(() => emit('welcome'))`
+// runs before the next assertion. Jest's fake-timer scheduler does NOT
+// advance microtasks, so we do this manually.
+async function flushMicrotasks() {
+    await Promise.resolve();
+}
+
+beforeEach(() => {
+    // Fake setInterval/setTimeout but keep `queueMicrotask` real so the
+    // `start() → welcome` microtask flush still drains via
+    // `await Promise.resolve()`. Mocking microtasks too would force every
+    // welcome assertion to call `jest.runAllTicks()` first, which is
+    // noisier than the natural Promise-based flush.
+    jest.useFakeTimers({
+        doNotFake: ['queueMicrotask'],
+    });
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+});
+
+// ── Construction ────────────────────────────────────────────────────────
+
+describe('LoopbackConnection — construction', () => {
+    test('no-arg construction does not throw', () => {
+        expect(() => new LoopbackConnection()).not.toThrow();
+    });
+
+    test('default playerId is 1', () => {
+        const loop = new LoopbackConnection();
+        expect(loop.playerId).toBe(1);
+    });
+
+    test('default session is "loopback"', () => {
+        const loop = new LoopbackConnection();
+        expect(loop.session).toBe('loopback');
+    });
+
+    test('custom options override defaults', () => {
+        const loop = new LoopbackConnection({
+            playerId: 42,
+            sessionId: 'custom-session',
+            serverTimeMs: 12345,
+        });
+        expect(loop.playerId).toBe(42);
+        expect(loop.session).toBe('custom-session');
+        expect(loop.serverTimeMs).toBe(12345);
+    });
+
+    test('initial state is "idle" before start()', () => {
+        const loop = new LoopbackConnection();
+        expect(loop.state).toBe('idle');
+        expect(loop.isConnected).toBe(false);
+    });
+
+    test('exports cadence constants for reuse', () => {
+        // Pin the wire cadence so a tuning change in the source is caught.
+        expect(LOOPBACK_TICK_HZ).toBe(20);
+        expect(LOOPBACK_TICK_MS).toBe(50);
+        expect(LOOPBACK_DT).toBeCloseTo(0.05, 10);
+    });
+});
+
+// ── Event emitter shim ──────────────────────────────────────────────────
+
+describe('LoopbackConnection — event emitter', () => {
+    test('on(event, fn) subscribes; _emit calls fn with payload', () => {
+        const loop = new LoopbackConnection();
+        const fn = jest.fn();
+        loop.on('foo', fn);
+        loop._emit('foo', { hello: 'world' });
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(fn).toHaveBeenCalledWith({ hello: 'world' });
+    });
+
+    test('multiple subscribers all fire on emit', () => {
+        const loop = new LoopbackConnection();
+        const a = jest.fn();
+        const b = jest.fn();
+        const c = jest.fn();
+        loop.on('event', a);
+        loop.on('event', b);
+        loop.on('event', c);
+        loop._emit('event', 'payload');
+        expect(a).toHaveBeenCalledWith('payload');
+        expect(b).toHaveBeenCalledWith('payload');
+        expect(c).toHaveBeenCalledWith('payload');
+    });
+
+    test('unsubscribe returned by on() removes the listener', () => {
+        const loop = new LoopbackConnection();
+        const fn = jest.fn();
+        const off = loop.on('event', fn);
+        loop._emit('event', 1);
+        expect(fn).toHaveBeenCalledTimes(1);
+        off();
+        loop._emit('event', 2);
+        expect(fn).toHaveBeenCalledTimes(1); // not called a second time
+    });
+
+    test('one throwing handler does not break the others', () => {
+        const loop = new LoopbackConnection();
+        const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const a = jest.fn();
+        const b = jest.fn(() => { throw new Error('boom'); });
+        const c = jest.fn();
+        loop.on('e', a);
+        loop.on('e', b);
+        loop.on('e', c);
+        loop._emit('e', 'p');
+        expect(a).toHaveBeenCalledWith('p');
+        expect(b).toHaveBeenCalledWith('p');
+        expect(c).toHaveBeenCalledWith('p');
+        expect(errSpy).toHaveBeenCalled();
+        errSpy.mockRestore();
+    });
+
+    test('_emit on an unknown event is a no-op (no crash)', () => {
+        const loop = new LoopbackConnection();
+        expect(() => loop._emit('never-subscribed', { x: 1 })).not.toThrow();
+    });
+});
+
+// ── Lifecycle ────────────────────────────────────────────────────────────
+
+describe('LoopbackConnection — lifecycle', () => {
+    test('start() then microtask emits welcome with the expected payload', async () => {
+        const loop = new LoopbackConnection({
+            playerId: 7,
+            sessionId: 'sess-7',
+            serverTimeMs: 999,
+        });
+        const fn = jest.fn();
+        loop.on('welcome', fn);
+        loop.start();
+        // welcome is microtask-scheduled, not a timer — flush it.
+        await flushMicrotasks();
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(fn).toHaveBeenCalledWith({
+            playerId: 7,
+            session: 'sess-7',
+            serverTimeMs: 999,
+        });
+    });
+
+    test('subscribers registered BEFORE start() receive the welcome event', async () => {
+        // This is the documented pattern in the class docstring: caller
+        // subscribes first, then calls start(). The microtask scheduling
+        // exists specifically so this works.
+        const loop = new LoopbackConnection();
+        const fn = jest.fn();
+        loop.on('welcome', fn);
+        loop.start();
+        await flushMicrotasks();
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test('start() begins the 50ms tick loop; snapshot events fire on cadence', async () => {
+        const loop = new LoopbackConnection();
+        const fn = jest.fn();
+        loop.on('snapshot', fn);
+        loop.start();
+        await flushMicrotasks();
+
+        // No snapshot yet — interval hasn't fired.
+        expect(fn).toHaveBeenCalledTimes(0);
+
+        // Advance 49 ms — still no snapshot (interval is 50 ms).
+        jest.advanceTimersByTime(49);
+        expect(fn).toHaveBeenCalledTimes(0);
+
+        // Cross the 50 ms boundary — exactly one snapshot.
+        jest.advanceTimersByTime(1);
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        // 150 ms total → 3 snapshots.
+        jest.advanceTimersByTime(100);
+        expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    test('disconnect() stops the tick loop; no more snapshot events fire', async () => {
+        const loop = new LoopbackConnection();
+        const fn = jest.fn();
+        loop.on('snapshot', fn);
+        loop.start();
+        await flushMicrotasks();
+
+        jest.advanceTimersByTime(100); // 2 snapshots
+        expect(fn).toHaveBeenCalledTimes(2);
+
+        loop.disconnect();
+        jest.advanceTimersByTime(500); // would be +10 snapshots
+        expect(fn).toHaveBeenCalledTimes(2); // …but none fired post-disconnect
+    });
+
+    test('disconnect() emits a disconnect event with an empty-payload shape', async () => {
+        const loop = new LoopbackConnection();
+        const fn = jest.fn();
+        loop.on('disconnect', fn);
+        loop.start();
+        await flushMicrotasks();
+        loop.disconnect();
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(fn).toHaveBeenCalledWith({});
+    });
+
+    test('disconnect() before start() does not emit disconnect (nothing to close)', () => {
+        const loop = new LoopbackConnection();
+        const fn = jest.fn();
+        loop.on('disconnect', fn);
+        loop.disconnect();
+        expect(fn).toHaveBeenCalledTimes(0);
+        expect(loop.state).toBe('closed');
+    });
+
+    test('disconnect() is idempotent — second call is a no-op', async () => {
+        const loop = new LoopbackConnection();
+        const fn = jest.fn();
+        loop.on('disconnect', fn);
+        loop.start();
+        await flushMicrotasks();
+        loop.disconnect();
+        loop.disconnect();
+        loop.disconnect();
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test('isConnected toggles true after start, false after disconnect', async () => {
+        const loop = new LoopbackConnection();
+        expect(loop.isConnected).toBe(false);
+        loop.start();
+        await flushMicrotasks();
+        expect(loop.isConnected).toBe(true);
+        loop.disconnect();
+        expect(loop.isConnected).toBe(false);
+    });
+
+    test('start() is idempotent — second call does not double-schedule', async () => {
+        const loop = new LoopbackConnection();
+        const fn = jest.fn();
+        loop.on('snapshot', fn);
+        loop.start();
+        loop.start(); // should be a no-op
+        await flushMicrotasks();
+        jest.advanceTimersByTime(50);
+        // If start() doubled the interval we'd see 2; correct behavior is 1.
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+});
+
+// ── Snapshot shape ───────────────────────────────────────────────────────
+
+describe('LoopbackConnection — snapshot shape', () => {
+    test('first snapshot has the default ship and tick=1', async () => {
+        const loop = new LoopbackConnection({ playerId: 9 });
+        const frames = [];
+        loop.on('snapshot', (f) => frames.push(f));
+        loop.start();
+        await flushMicrotasks();
+        jest.advanceTimersByTime(50);
+
+        expect(frames).toHaveLength(1);
+        const f = frames[0];
+        expect(f.tick).toBe(1);
+        expect(f.baseTick).toBe(0);
+        expect(typeof f.recvTime).toBe('number');
+        expect(f.payload).toBeDefined();
+
+        const ship = f.payload.ships[0];
+        expect(ship.id).toBe(9);
+        expect(ship.player).toBe(9); // emit both keys for transition compat
+        expect(ship.x).toBe(400);
+        expect(ship.y).toBe(300);
+        expect(ship.vx).toBe(0);
+        expect(ship.vy).toBe(0);
+        expect(ship.angle).toBeDefined();
+        expect(ship.hp).toBe(100);
+    });
+
+    test('tick counter increments by 1 each emission', async () => {
+        const loop = new LoopbackConnection();
+        const ticks = [];
+        loop.on('snapshot', (f) => ticks.push(f.tick));
+        loop.start();
+        await flushMicrotasks();
+        jest.advanceTimersByTime(250); // 5 ticks
+        expect(ticks).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    test('payload.ships[0] has all required wire fields', async () => {
+        const loop = new LoopbackConnection();
+        let frame = null;
+        loop.on('snapshot', (f) => { frame = f; });
+        loop.start();
+        await flushMicrotasks();
+        jest.advanceTimersByTime(50);
+
+        const ship = frame.payload.ships[0];
+        // Spec-required fields per `engine-driver._onSnapshot`:
+        for (const key of ['id', 'x', 'y', 'vx', 'vy', 'angle', 'hp']) {
+            expect(ship).toHaveProperty(key);
+        }
+    });
+
+    test('enemies / asteroids / drops / enemy_bullets are empty arrays in Phase 1', async () => {
+        const loop = new LoopbackConnection();
+        let frame = null;
+        loop.on('snapshot', (f) => { frame = f; });
+        loop.start();
+        await flushMicrotasks();
+        jest.advanceTimersByTime(50);
+
+        expect(Array.isArray(frame.payload.enemies)).toBe(true);
+        expect(Array.isArray(frame.payload.asteroids)).toBe(true);
+        expect(Array.isArray(frame.payload.drops)).toBe(true);
+        expect(Array.isArray(frame.payload.enemy_bullets)).toBe(true);
+        expect(frame.payload.enemies).toHaveLength(0);
+        expect(frame.payload.asteroids).toHaveLength(0);
+        expect(frame.payload.drops).toHaveLength(0);
+        expect(frame.payload.enemy_bullets).toHaveLength(0);
+    });
+
+    test('baselineShip override surfaces in the first snapshot', async () => {
+        const loop = new LoopbackConnection({
+            playerId: 3,
+            baselineShip: { x: 123, y: 456, vx: 0, vy: 0, angle: 1.5, hp: 80 },
+        });
+        let frame = null;
+        loop.on('snapshot', (f) => { frame = f; });
+        loop.start();
+        await flushMicrotasks();
+        jest.advanceTimersByTime(50);
+
+        const ship = frame.payload.ships[0];
+        // x/y may have changed slightly due to the idle-step friction
+        // pass, but velocity stays zero so position is stable.
+        expect(ship.x).toBe(123);
+        expect(ship.y).toBe(456);
+        expect(ship.hp).toBe(80);
+    });
+});
+
+// ── Input application ───────────────────────────────────────────────────
+
+describe('LoopbackConnection — input application', () => {
+    test('sendInput(InputFrame) with right=true → ship.vx > 0 after one tick', async () => {
+        const loop = new LoopbackConnection();
+        const frames = [];
+        loop.on('snapshot', (f) => frames.push(f));
+        loop.start();
+        await flushMicrotasks();
+
+        // Send an explicit InputFrame the ship physics already knows about.
+        loop.sendInput({ right: true, aimX: 1000, aimY: 300 });
+        jest.advanceTimersByTime(50);
+
+        const ship = frames[0].payload.ships[0];
+        expect(ship.vx).toBeGreaterThan(0);
+        // Position should also have moved east.
+        expect(ship.x).toBeGreaterThan(400);
+    });
+
+    test('sendInput accepts PackedInput-shaped objects (moveX/moveY)', async () => {
+        const loop = new LoopbackConnection();
+        const frames = [];
+        loop.on('snapshot', (f) => frames.push(f));
+        loop.start();
+        await flushMicrotasks();
+
+        // PackedInput-style: positive moveX = move east.
+        loop.sendInput({ moveX: 127, moveY: 0, aimX: 1000, aimY: 300, buttons: 0 });
+        jest.advanceTimersByTime(50);
+
+        const ship = frames[0].payload.ships[0];
+        expect(ship.vx).toBeGreaterThan(0);
+    });
+
+    test('multiple queued inputs all apply in order on the next tick', async () => {
+        const loop = new LoopbackConnection();
+        const frames = [];
+        loop.on('snapshot', (f) => frames.push(f));
+        loop.start();
+        await flushMicrotasks();
+
+        // Three thrust inputs queued before the tick fires.
+        loop.sendInput({ right: true, aimX: 1000, aimY: 300 });
+        loop.sendInput({ right: true, aimX: 1000, aimY: 300 });
+        loop.sendInput({ right: true, aimX: 1000, aimY: 300 });
+        jest.advanceTimersByTime(50);
+
+        const ship = frames[0].payload.ships[0];
+        // Three velocity integrations + frictions = more displacement
+        // than a single input frame.
+        const oneInputBaseline = (() => {
+            const c = new LoopbackConnection();
+            const f = [];
+            c.on('snapshot', (fr) => f.push(fr));
+            c.start();
+            // Don't await microtasks/flush — we just need the eventual
+            // tick comparison. Subscribe before start() in this branch
+            // doesn't matter for snapshot.
+            c.sendInput({ right: true, aimX: 1000, aimY: 300 });
+            jest.advanceTimersByTime(50);
+            return f[0].payload.ships[0];
+        })();
+
+        expect(ship.vx).toBeGreaterThan(oneInputBaseline.vx);
+    });
+
+    test('sendInput(Uint8Array) is accepted and ignored in Phase 1 (no decode)', async () => {
+        const loop = new LoopbackConnection();
+        const frames = [];
+        loop.on('snapshot', (f) => frames.push(f));
+        loop.start();
+        await flushMicrotasks();
+
+        // Sending wire bytes — Phase 1 skips decode but must NOT crash.
+        expect(() => loop.sendInput(new Uint8Array([1, 2, 3, 4, 5, 6, 7]))).not.toThrow();
+        jest.advanceTimersByTime(50);
+
+        // Without a decoded input, the ship stays put (idle-step only).
+        const ship = frames[0].payload.ships[0];
+        expect(ship.vx).toBe(0);
+        expect(ship.x).toBe(400);
+    });
+
+    test('engine-driver-style two-arg form sendInput(tick, packed) works too', async () => {
+        // EngineDriver.tick() calls `connection.sendInput(nextTick, packed)`.
+        // The loopback must accept the same signature without changing
+        // the call site.
+        const loop = new LoopbackConnection();
+        const frames = [];
+        loop.on('snapshot', (f) => frames.push(f));
+        loop.start();
+        await flushMicrotasks();
+
+        loop.sendInput(42 /* tick */, { right: true, aimX: 1000, aimY: 300 });
+        jest.advanceTimersByTime(50);
+
+        const ship = frames[0].payload.ships[0];
+        expect(ship.vx).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
## Summary
Phase 1 of the **Hybrid solo↔MP unification** described in \`docs/Multiplayer Coordination – 2026-05-09.md\`.

Adds a \`LoopbackConnection\` class with the same event-emitter surface as \`js/net/ws-client.js\`'s \`ConnectionTask\`, but runs the game sim in-process instead of over WebSocket. Once integrated (Phase 2), \`EngineDriver.startOnline({connection: loopback, welcome, baselineShip})\` will work in solo mode using the exact same code path as actual MP.

**This PR is scaffold only** — class + API + tests. Engine-driver integration is a separate Phase 2 PR.

## API surface
- \`new LoopbackConnection({playerId?, sessionId?, serverTimeMs?})\`
- \`on(event, fn)\` → returns unsubscribe fn
- \`start()\` — emits \`welcome\` via queueMicrotask, then 50ms-cadence \`snapshot\` events
- \`sendInput(input)\` or \`sendInput(tick, input)\` (engine-driver two-arg form supported)
- \`disconnect()\` — stops tick loop, emits \`disconnect\`
- Getters: \`isConnected\`, \`playerId\`

## Snapshot shape
Mirrors S2C.SNAPSHOT: \`{ tick, baseTick, payload: { ships, enemies:[], asteroids:[], drops:[], enemy_bullets:[] }, recvTime }\`. Ship id field doubled (\`id\` + \`player\`) so either reader works during the Phase 1↔2 transition.

## Differences from ConnectionTask
1. State machine collapsed: \`idle | open | closed\` (no async handshake)
2. \`start()\` is sync (no \`Promise<WelcomePayload>\`)
3. \`sendInput\` accepts both 1-arg and 2-arg forms
4. \`Uint8Array\` packed-input bytes are accepted-and-ignored (Phase 2 wires decode)
5. Only emits \`welcome\` / \`disconnect\` / \`snapshot\` (room_*, peer_*, error_msg, frame are no-ops for solo)
6. \`recvTime\` included on every snapshot for engine-driver interpolator anchor

## Open questions for Phase 2 (engine-driver integration)
1. **PackedInput wire decode** — decode \`Uint8Array\` in loopback, or refactor \`engine-driver.tick()\` to pass pre-decoded \`InputFrame\`? (Latter feels cleaner — keeps decode out of loopback's hot path.)
2. **Welcome payload customization** — if engine-driver needs more fields (room id, slot, peers, wave, seed) to make solo↔MP identical, model on \`RoomJoined\` rather than \`Welcome\`?
3. **Enemies/asteroids/drops** — loopback synthesizes them all (engine pulls everything from \`connection.on('snapshot')\`)? Or engine still simulates them locally and loopback only carries the local ship?
4. **Two-arg \`sendInput(tick, packed)\`** — thread the tick arg into the loopback's snapshot tick if predictor reconciliation should work through the local path identically?
5. **\`disconnect\` event payload** — should we surface a synthetic \`{code, reason}\` for parity with real socket-close paths?

## Test plan
- [x] 30 new tests across 5 describe blocks (construction, event emitter, lifecycle, snapshot shape, input application)
- [x] Full unit suite 712/712 passing across 26 suites
- [x] No existing files modified
- [x] No engine-driver / game-engine touches

🤖 Generated with [Claude Code](https://claude.com/claude-code)