### PR TITLE
mp/server: Rust Missile Salvo collision mirror (parity with JS)

### DIFF
--- a/server/src/room/collision.rs
+++ b/server/src/room/collision.rs
@@ -391,6 +391,20 @@ pub fn apply_event(
         } => {
             side.damage_asteroid(target_id, damage);
         }
+        CollisionEvent::MissileHitEnemy {
+            target_id, damage, ..
+        } => {
+            if let Some(enemy) =
+                state.enemies.iter_mut().find(|e| e.id.0 as u32 == target_id)
+            {
+                enemy.hp -= damage;
+            }
+        }
+        CollisionEvent::MissileHitAsteroid {
+            target_id, damage, ..
+        } => {
+            side.damage_asteroid(target_id, damage);
+        }
     }
 }
 

--- a/server/src/sim/collision.rs
+++ b/server/src/sim/collision.rs
@@ -617,6 +617,56 @@ pub enum CollisionEvent {
         distance_along_beam: f32,
         distance_from_beam: f32,
     },
+    /// Mirrors `{ type: 'missile_hit_enemy', ... }` in `js/sim/collision.js`.
+    ///
+    /// Missile Salvo is a directional projectile vs enemy/asteroid pair.
+    /// Each missile detonates on FIRST contact — at most ONE event per
+    /// missile per tick. Iteration order is enemies-first, then asteroids;
+    /// if a missile is in range of BOTH an enemy and an asteroid in the
+    /// same tick, the enemy variant wins (and the asteroid variant is not
+    /// emitted for that missile).
+    ///
+    /// Field-count rationale (5 non-type fields, 6 total with the tag):
+    ///   - `missile_id` lets the wrapper despawn the source projectile
+    ///     (`missile.active = false`) on event drain.
+    ///   - `target_id` is the enemy id (the asteroid variant carries the
+    ///     same field name in the asteroid id space).
+    ///   - `damage` flows verbatim from `CollisionMissile.damage` so the
+    ///     wrapper does NOT have to look up the missile again.
+    ///   - `knock_x` / `knock_y` are the pre-computed knockback impulse
+    ///     (`unit(missile.vel) * MISSILE_KNOCK`). The wrapper applies
+    ///     these to the target's velocity as `target.vel.x += knock_x;
+    ///     target.vel.y += knock_y` with NO further scaling.
+    ///
+    /// Knockback direction is the missile's direction of TRAVEL (NOT the
+    /// missile-to-target normal) — see section comment above for the
+    /// rationale. Zero-velocity missiles produce zero knockback (no crash,
+    /// no NaN) via the `mv_len.max(EPSILON)` fallback in the detector.
+    MissileHitEnemy {
+        missile_id: u32,
+        target_id: u32,
+        damage: f32,
+        knock_x: f32,
+        knock_y: f32,
+    },
+    /// Mirrors `{ type: 'missile_hit_asteroid', ... }` in `js/sim/collision.js`.
+    ///
+    /// Sister variant to `MissileHitEnemy` — same field layout, asteroid
+    /// id space instead of enemy id space. See `MissileHitEnemy` docstring
+    /// for field-count rationale and field-by-field semantics.
+    ///
+    /// IMPORTANT: `knock_x` / `knock_y` carry the asteroid-path knockback
+    /// pre-scaled by `0.6` INSIDE the detector (i.e. the 0.6× discount is
+    /// baked into the event payload, NOT the wrapper). The wrapper drains
+    /// the event uniformly across both variants — `asteroid.vel.x +=
+    /// knock_x; asteroid.vel.y += knock_y` with no per-variant scaling.
+    MissileHitAsteroid {
+        missile_id: u32,
+        target_id: u32,
+        damage: f32,
+        knock_x: f32,
+        knock_y: f32,
+    },
 }
 
 /// Which kind of target tripped a mine. Mirrors the JS string-tagged
@@ -2824,5 +2874,328 @@ pub fn detect_lance_beam_hits(
             distance_along_beam: proj,
             distance_from_beam: perp,
         });
+    }
+}
+
+// =====================================================================
+// MISSILE SALVO — directional projectile vs enemy/asteroid (first-hit)
+// =====================================================================
+//
+// Rust mirror of `js/sim/collision.js::detectMissileSalvoHits` (PR #68).
+// Missiles are seeking projectiles fired by the MISSILE_SALVO power
+// weapon. They impact either an enemy OR an asteroid — whichever they
+// touch first — and detonate on contact. Each missile is a single-
+// target weapon (no piercing, no AoE in the pure step) and emits at
+// most ONE event per tick. The pure step splits detection from
+// application: the wrapper drains the event and is responsible for the
+// visible explosion, audio, particles, screen shake, camera kick,
+// asteroid-cascade destruction, the `damageEnemy` call, the asteroid
+// `_hitFlashTimer` mutation, and flipping `missile.active = false` on
+// the source missile.
+//
+// ─── First-hit-wins semantics ────────────────────────────────────────
+//
+// A missile detonates on contact — the first target it touches sets
+// it off. Mirrors the legacy `checkMissileCollisions` (collision-system
+// .js:1369) ordering: enemies first (legacy line 1417), then asteroids
+// (legacy line 1435). If a missile is in range of both an enemy and an
+// asteroid in the same tick, the enemy variant wins.
+//
+// ─── Knockback direction ─────────────────────────────────────────────
+//
+// Knockback is applied in the missile's direction of TRAVEL (not from
+// missile-position toward the target). The legacy computes a unit
+// vector from `missile.vel` and scales it by `MISSILE_KNOCK` (enemy)
+// or `MISSILE_KNOCK * 0.6` (asteroid). The pure step pre-computes
+// `knock_x`/`knock_y` in the event so the wrapper just adds them to the
+// target's velocity — no re-normalization required. The 0.6× discount
+// on the asteroid path is baked INSIDE this module's event payload —
+// the wrapper drains both variants uniformly.
+//
+// Degenerate case: if `missile.vx == missile.vy == 0` (a stationary
+// missile, which shouldn't happen in live play but is defensible in
+// tests / replays), `mv_len = 0`. The JS source uses `Math.hypot(0,0)
+// || 1 = 1`, yielding `kx = ky = 0`. The Rust mirror replicates this
+// with an explicit `if mv_len == 0.0 { mv_len = 1.0 }` so we never
+// divide by zero. The event still emits with zero knockback — no
+// crash, no NaN.
+//
+// ─── Skip-gates ──────────────────────────────────────────────────────
+//
+//   Missiles:
+//     - Inactive          (`!missile.active`)
+//
+//   Targets (enemies + asteroids), strict superset of legacy:
+//     - Inactive          (`!target.active`)
+//     - Warping           (`target.warping`)
+//     - Mid death-flash   (`target.death_flash > 0`)
+//
+// NOTE: the legacy enemy-impact loop (line 1417) gates only on
+// `!active`. The legacy asteroid-impact loop (line 1435) gates on
+// `!active` and `warping`. The pure step adds death-flash skipping
+// for both (consistency with every other pair in this file —
+// mid-destruction targets shouldn't take a missile hit).
+//
+// ─── Boundary semantic ──────────────────────────────────────────────
+//
+// Strict `<` on the radius-sum check (`dist < target.radius +
+// missile.radius`). Matches the legacy `dist < ...` test and the JS
+// pure step — `dist == sum` is a MISS. See `missile_boundary_strict_
+// less_than` parity fixture.
+//
+// ─── What the pure step does NOT do (stays wrapper-only) ─────────────
+//
+//   - Audio + particle FX (`starSparkle`, `explosionFlash`,
+//     `explosionRingColored`, `explosionShrapnel`, `explosionEmber`),
+//     screen shake, camera kick — presentation, wrapper-owned.
+//   - The `missile.active = false` mutation that despawns the
+//     projectile (wrapper applies on event drain).
+//   - The `damageEnemy(enemy, damage)` invocation for enemy hits —
+//     the wrapper calls its own helper so upgrade-state-dependent
+//     damage modifiers stack correctly.
+//   - The asteroid `_hitFlashTimer = 4` mutation (wrapper-side).
+//   - The `destroyAsteroid` cascade when an asteroid's HP drops to
+//     zero — emerges naturally from the wrapper's event drain via
+//     the asteroid's resulting HP.
+//   - HOMING / cluster-warhead split / extra-ordnance modifiers —
+//     those modify the missile state itself (count, behavior) and
+//     are not part of this pair.
+
+/// Missile → knockback magnitude default. Mirrors the legacy `const
+/// MISSILE_KNOCK = 9 * knockMul` at line 1373 of
+/// `collision-system.js`. The legacy expression scales by a per-player
+/// `getKnockbackMultiplier()` returned from the player upgrade state —
+/// the pure step does NOT consult that multiplier here. The wrapper is
+/// expected to pre-bake the multiplier into the missile's own knockback
+/// constant before invoking detection, or to scale the event payload
+/// after the fact. The default exported below is the raw 9 (no
+/// multiplier).
+///
+/// Asteroid path uses `MISSILE_KNOCK * 0.6` — applied INSIDE this
+/// module to the event payload's `knock_x` / `knock_y`, so the wrapper
+/// adds the impulse to `asteroid.vel` verbatim with no further scaling.
+pub const MISSILE_KNOCK: f32 = 9.0;
+
+/// Missile → default radius. Matches the legacy `+ 6` literal in the
+/// radius-sum test at lines 1420 and 1438 of `collision-system.js`. A
+/// missile that fails to provide an explicit `radius` is treated as a
+/// 6-pixel projectile.
+pub const MISSILE_DEFAULT_RADIUS: f32 = 6.0;
+
+/// Minimal missile view for collision detection.
+///
+/// Mirrors the JS fields read by `detectMissileSalvoHits`:
+///   `{ id, x, y, vx, vy, radius?, damage, active }`.
+///
+/// `radius` defaults to `MISSILE_DEFAULT_RADIUS` (6 px) on the JS side
+/// via `missile.radius || MISSILE_DEFAULT_RADIUS` — the Rust mirror
+/// carries a non-optional `radius` field; the wrapper substitutes the
+/// default when populating the view from the live missile pool. Test
+/// convenience constructor `fresh(id)` pins `radius = 6.0`.
+///
+/// `damage` flows verbatim into the event payload — no per-target
+/// scaling pure-side.
+///
+/// `vx` / `vy` define the missile's direction of travel; the unit
+/// vector is used for knockback direction. Zero velocity yields zero
+/// knockback (no crash) via the detector's `mv_len.max` fallback.
+#[derive(Debug, Clone, Copy)]
+pub struct CollisionMissile {
+    pub id: u32,
+    pub x: f32,
+    pub y: f32,
+    pub vx: f32,
+    pub vy: f32,
+    /// Missile collision radius. Live-game default is 6 px (see
+    /// `MISSILE_DEFAULT_RADIUS`). Wrapper sets explicitly when populating
+    /// the view from the live missile pool.
+    pub radius: f32,
+    pub damage: f32,
+    pub active: bool,
+}
+
+impl CollisionMissile {
+    /// Construct a fresh missile at the origin with the live-game default
+    /// radius (6 px) and damage (1). Velocity is zero — tests that need a
+    /// specific direction-of-travel should set `vx` / `vy` explicitly.
+    /// Test convenience.
+    pub fn fresh(id: u32) -> Self {
+        Self {
+            id,
+            x: 0.0,
+            y: 0.0,
+            vx: 0.0,
+            vy: 0.0,
+            radius: MISSILE_DEFAULT_RADIUS,
+            damage: 1.0,
+            active: true,
+        }
+    }
+}
+
+// ─── Missile Salvo hit detection ─────────────────────────────────────
+
+/// Detect Missile Salvo collisions for one tick.
+///
+/// Pure step: for every active missile, scan enemies first (in slice
+/// order) for a target whose CENTER lies inside the missile + target
+/// radius sum. On first enemy hit, emit one `MissileHitEnemy` event
+/// and stop scanning that missile. If no enemy is hit, scan asteroids
+/// (in slice order) — first asteroid hit emits one `MissileHitAsteroid`
+/// event (with knockback pre-scaled by 0.6×) and stops the scan. A
+/// missile detonates at most ONCE per tick.
+///
+/// Geometry:
+///   Circle-circle overlap: `hypot(target.x - missile.x, target.y -
+///   missile.y) < (target.radius + missile.radius)`. Uses `hypot`
+///   (NOT the squared form) to exactly mirror the legacy `dist =
+///   Math.hypot(...); if (dist < ...)` test — the strict-less-than
+///   boundary is part of the legacy contract and is preserved. JS line
+///   refs: `js/sim/collision.js:3090–3091` (enemy) and `:3129–3130`
+///   (asteroid).
+///
+/// Iteration order:
+///   Missiles outer-loop; for each missile, enemies first then
+///   asteroids inner-loop. First hit wins per missile. JS line refs:
+///   `js/sim/collision.js:3049–3142`.
+///
+/// Knockback:
+///   Unit vector from `missile.vx`, `missile.vy` scaled by
+///   `MISSILE_KNOCK`. Asteroid path applies an additional `× 0.6`
+///   factor inside the detector so the wrapper drains both variants
+///   uniformly. Zero-velocity missile → `mv_len = 1.0` fallback →
+///   `kx = ky = 0`, event still emits with zero knockback.
+///
+/// Skip-gates (no event emitted):
+///   Missiles:
+///     - Inactive          (`!missile.active`)
+///   Enemies / asteroids:
+///     - Inactive          (`!target.active`)
+///     - Warping           (`target.warping`)
+///     - Mid death-flash   (`target.death_flash > 0`)
+///
+/// Defensive guards:
+///   - Empty missile slice → no events.
+///   - Empty enemy + empty asteroid slices → no events.
+///
+/// JS line refs: `js/sim/collision.js:3040–3144`.
+pub fn detect_missile_salvo_hits(
+    missiles: &[CollisionMissile],
+    enemies: &[CollisionEnemy],
+    asteroids: &[CollisionAsteroid],
+    _ctx: &CollisionContext,
+    events: &mut Vec<CollisionEvent>,
+) {
+    // Defensive: empty missile slice → nothing to detect.
+    if missiles.is_empty() {
+        return;
+    }
+    let has_enemies = !enemies.is_empty();
+    let has_asteroids = !asteroids.is_empty();
+    // If there are no possible targets at all, nothing to detect.
+    if !has_enemies && !has_asteroids {
+        return;
+    }
+
+    for missile in missiles.iter() {
+        // 1. Active-guard (JS collision.js:3051).
+        if !missile.active {
+            continue;
+        }
+
+        // 2. Knockback direction = unit vector in missile direction of
+        //    travel. Mirrors JS lines 3056–3060. Zero-velocity missile →
+        //    `mv_len = 0`, replaced with 1.0 so we don't divide by zero.
+        //    `kx = ky = 0` falls out naturally.
+        let mvx = missile.vx;
+        let mvy = missile.vy;
+        let mut mv_len = (mvx * mvx + mvy * mvy).sqrt();
+        if mv_len == 0.0 {
+            mv_len = 1.0;
+        }
+        let kx = mvx / mv_len;
+        let ky = mvy / mv_len;
+
+        let missile_radius = missile.radius;
+        let missile_x = missile.x;
+        let missile_y = missile.y;
+
+        let mut hit = false;
+
+        // ── Enemies ────────────────────────────────────────────────
+        // First target inside the radius sum wins. Mirrors JS lines
+        // 3071–3103 (enemies-first iteration order).
+        if has_enemies {
+            for enemy in enemies.iter() {
+                if !enemy.active {
+                    continue;
+                }
+                if enemy.warping {
+                    continue;
+                }
+                if enemy.death_flash > 0 {
+                    continue;
+                }
+
+                let dx = enemy.x - missile_x;
+                let dy = enemy.y - missile_y;
+                // Use `hypot`-equivalent sqrt (not the squared form) to
+                // mirror the legacy `dist < ...` test exactly. Strict
+                // less-than boundary preserved.
+                let dist = (dx * dx + dy * dy).sqrt();
+                if dist >= enemy.radius + missile_radius {
+                    continue;
+                }
+
+                events.push(CollisionEvent::MissileHitEnemy {
+                    missile_id: missile.id,
+                    target_id: enemy.id,
+                    damage: missile.damage,
+                    knock_x: kx * MISSILE_KNOCK,
+                    knock_y: ky * MISSILE_KNOCK,
+                });
+                hit = true;
+                break;
+            }
+        }
+
+        if hit {
+            continue;
+        }
+
+        // ── Asteroids ──────────────────────────────────────────────
+        // No enemy hit — try asteroids next. Mirrors JS lines
+        // 3113–3142. Knockback is pre-scaled by 0.6 in the event so
+        // the wrapper's drain code is uniform across both target
+        // kinds.
+        if has_asteroids {
+            for asteroid in asteroids.iter() {
+                if !asteroid.active {
+                    continue;
+                }
+                if asteroid.warping {
+                    continue;
+                }
+                if asteroid.death_flash > 0 {
+                    continue;
+                }
+
+                let dx = asteroid.x - missile_x;
+                let dy = asteroid.y - missile_y;
+                let dist = (dx * dx + dy * dy).sqrt();
+                if dist >= asteroid.radius + missile_radius {
+                    continue;
+                }
+
+                events.push(CollisionEvent::MissileHitAsteroid {
+                    missile_id: missile.id,
+                    target_id: asteroid.id,
+                    damage: missile.damage,
+                    knock_x: kx * MISSILE_KNOCK * 0.6,
+                    knock_y: ky * MISSILE_KNOCK * 0.6,
+                });
+                break;
+            }
+        }
     }
 }

--- a/server/tests/parity_collision.rs
+++ b/server/tests/parity_collision.rs
@@ -40,12 +40,13 @@
 
 use rainboids_server::sim::collision::{
     detect_bullet_asteroid_hits, detect_bullet_enemy_hits, detect_enemy_asteroid_hits,
-    detect_lance_beam_hits, detect_mine_hits, detect_nova_blast_hits, detect_player_asteroid_hits,
-    detect_player_drop_pickups, detect_player_enemy_bullet_hits, detect_player_enemy_hits,
-    CollisionAsteroid, CollisionBullet, CollisionContext, CollisionDrop, CollisionEnemy,
-    CollisionEnemyBullet, CollisionEvent, CollisionLance, CollisionMine, CollisionPlayer,
-    NovaBlast, TriggerKind, ASTEROID_ENEMY_PUSH, ASTEROID_KNOCKBACK_MULTIPLIER,
-    BOUNCE_FORCE_MULTIPLIER, BOUNCE_RESTITUTION, ENEMY_ASTEROID_PUSH, OVERLAP_PUSH_FORCE,
+    detect_lance_beam_hits, detect_mine_hits, detect_missile_salvo_hits, detect_nova_blast_hits,
+    detect_player_asteroid_hits, detect_player_drop_pickups, detect_player_enemy_bullet_hits,
+    detect_player_enemy_hits, CollisionAsteroid, CollisionBullet, CollisionContext, CollisionDrop,
+    CollisionEnemy, CollisionEnemyBullet, CollisionEvent, CollisionLance, CollisionMine,
+    CollisionMissile, CollisionPlayer, NovaBlast, TriggerKind, ASTEROID_ENEMY_PUSH,
+    ASTEROID_KNOCKBACK_MULTIPLIER, BOUNCE_FORCE_MULTIPLIER, BOUNCE_RESTITUTION,
+    ENEMY_ASTEROID_PUSH, MISSILE_DEFAULT_RADIUS, MISSILE_KNOCK, OVERLAP_PUSH_FORCE,
     OVERLAP_SEPARATION_RATIO, PLAYER_ASTEROID_COLLISION_DAMAGE, PLAYER_ENEMY_COLLISION_DAMAGE,
     SEPARATION_BUFFER,
 };
@@ -3120,4 +3121,396 @@ fn lance_boundary_pin_far_end() {
         }
         ev => panic!("expected LanceHitEnemy, got {:?}", ev),
     }
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// MISSILE SALVO fixtures (dispatch — Rust mirror of PR #68).
+// ═════════════════════════════════════════════════════════════════════
+//
+// Coverage mirrors `js/sim/collision.js::detectMissileSalvoHits` —
+// directional projectile vs enemy/asteroid with first-hit-wins per
+// missile. Iteration order: missiles outer-loop; for each, enemies
+// first then asteroids. Knockback direction = unit(missile.vel) *
+// MISSILE_KNOCK (enemy) or * MISSILE_KNOCK * 0.6 (asteroid, pre-
+// scaled inside the event payload).
+//
+// Tolerance: 0.01 — pure linear physics, no trig (knockback is the
+// missile's own velocity normalized; no sin/cos involved). Matches
+// player-asteroid + mine fixture conventions.
+// ═════════════════════════════════════════════════════════════════════
+
+/// Missile-specific float-tolerance helper. Linear-physics path, no
+/// trig — 0.01 slack mirrors the player-asteroid + mine fixture
+/// convention.
+fn approx_eq_missile(actual: f32, expected: f32, what: &str) {
+    let delta = (actual - expected).abs();
+    assert!(
+        delta < 0.01,
+        "{} diverged: rust={}, expected={}, |Δ|={}",
+        what,
+        actual,
+        expected,
+        delta,
+    );
+}
+
+/// Build a missile at (x, y) moving along +X axis (vx=1, vy=0). Default
+/// damage 1, radius 6 (live-game default). Tests that need a specific
+/// direction can override `vx` / `vy` post-construction.
+fn make_missile(id: u32, x: f32, y: f32) -> CollisionMissile {
+    let mut m = CollisionMissile::fresh(id);
+    m.x = x;
+    m.y = y;
+    m.vx = 1.0;
+    m.vy = 0.0;
+    m
+}
+
+// ---------------------------------------------------------------------
+// Fixture — single missile vs single enemy in range.
+//
+// Missile at (0, 0) moving along +X (vx=1, vy=0). Enemy at (10, 0)
+// with default radius 18. Sum-of-radii = 6 + 18 = 24, distance = 10
+// → HIT. Expect 1 `MissileHitEnemy` event with knockback in +X axis
+// at full MISSILE_KNOCK magnitude.
+// ---------------------------------------------------------------------
+#[test]
+fn missile_single_enemy_hit() {
+    let mut missile = make_missile(1, 0.0, 0.0);
+    missile.damage = 4.0;
+    let missiles = vec![missile];
+    let enemies = vec![make_enemy(101, 10.0, 0.0)];
+    let asteroids: Vec<CollisionAsteroid> = vec![];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_missile_salvo_hits(&missiles, &enemies, &asteroids, &ctx, &mut events);
+    assert_eq!(events.len(), 1, "in-range enemy → 1 event");
+    match events[0] {
+        CollisionEvent::MissileHitEnemy {
+            missile_id,
+            target_id,
+            damage,
+            knock_x,
+            knock_y,
+        } => {
+            assert_eq!(missile_id, 1);
+            assert_eq!(target_id, 101);
+            approx_eq_missile(damage, 4.0, "damage");
+            approx_eq_missile(knock_x, MISSILE_KNOCK, "knock_x = full +X knockback");
+            approx_eq_missile(knock_y, 0.0, "knock_y = 0");
+        }
+        ev => panic!("expected MissileHitEnemy, got {:?}", ev),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — single missile vs single asteroid in range.
+//
+// Missile at (0, 0) moving along +X (vx=1, vy=0). Asteroid at (20, 0)
+// with default radius 30. Sum-of-radii = 6 + 30 = 36, distance = 20
+// → HIT. No enemies, so the asteroid branch fires. Expect 1
+// `MissileHitAsteroid` event with knockback PRE-SCALED by 0.6×.
+// ---------------------------------------------------------------------
+#[test]
+fn missile_single_asteroid_hit() {
+    let mut missile = make_missile(1, 0.0, 0.0);
+    missile.damage = 4.0;
+    let missiles = vec![missile];
+    let enemies: Vec<CollisionEnemy> = vec![];
+    let asteroids = vec![make_asteroid(101, 20.0, 0.0)];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_missile_salvo_hits(&missiles, &enemies, &asteroids, &ctx, &mut events);
+    assert_eq!(events.len(), 1, "in-range asteroid → 1 event");
+    match events[0] {
+        CollisionEvent::MissileHitAsteroid {
+            missile_id,
+            target_id,
+            damage,
+            knock_x,
+            knock_y,
+        } => {
+            assert_eq!(missile_id, 1);
+            assert_eq!(target_id, 101);
+            approx_eq_missile(damage, 4.0, "damage");
+            // 0.6× discount applied INSIDE the event payload.
+            approx_eq_missile(knock_x, MISSILE_KNOCK * 0.6, "knock_x = 0.6× knock");
+            approx_eq_missile(knock_y, 0.0, "knock_y = 0");
+        }
+        ev => panic!("expected MissileHitAsteroid, got {:?}", ev),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — enemies preferred over asteroids when both reachable.
+//
+// Missile at (0, 0) is in range of BOTH an enemy and an asteroid.
+// Iteration order enemies-first → enemy wins. Only 1 event, of the
+// enemy variant. The asteroid is NOT emitted for this missile this
+// tick.
+// ---------------------------------------------------------------------
+#[test]
+fn missile_iteration_enemy_preferred() {
+    let missile = make_missile(1, 0.0, 0.0);
+    let missiles = vec![missile];
+    let enemies = vec![make_enemy(101, 10.0, 0.0)];
+    let asteroids = vec![make_asteroid(102, 20.0, 0.0)];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_missile_salvo_hits(&missiles, &enemies, &asteroids, &ctx, &mut events);
+    assert_eq!(events.len(), 1, "enemy-first → exactly 1 event");
+    match events[0] {
+        CollisionEvent::MissileHitEnemy { target_id, .. } => {
+            assert_eq!(target_id, 101, "enemy variant wins");
+        }
+        ev => panic!("expected MissileHitEnemy (enemies preferred), got {:?}", ev),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — geometry miss, target outside sum-of-radii.
+//
+// Missile at (0, 0), enemy at (100, 0), asteroid at (200, 0). Both
+// far outside missile_radius + target_radius. Expect 0 events.
+// ---------------------------------------------------------------------
+#[test]
+fn missile_geometry_miss() {
+    let missile = make_missile(1, 0.0, 0.0);
+    let missiles = vec![missile];
+    let enemies = vec![make_enemy(101, 100.0, 0.0)];
+    let asteroids = vec![make_asteroid(102, 200.0, 0.0)];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_missile_salvo_hits(&missiles, &enemies, &asteroids, &ctx, &mut events);
+    assert_eq!(events.len(), 0, "out-of-range targets → no events");
+}
+
+// ---------------------------------------------------------------------
+// Fixture — skip-gates cover all combinations.
+//
+// One inactive missile (geometrically in range — proves missile.active
+// gate fires). One active missile with three gated enemies (inactive,
+// warping, death_flash) and three gated asteroids (inactive, warping,
+// death_flash) all positioned in geometric range. Expect 0 events.
+// ---------------------------------------------------------------------
+#[test]
+fn missile_skip_gates() {
+    let mut inactive_missile = make_missile(1, 0.0, 0.0);
+    inactive_missile.active = false;
+    let active_missile = make_missile(2, 100.0, 0.0);
+    let missiles = vec![inactive_missile, active_missile];
+
+    let mut inactive_enemy = make_enemy(10, 100.0, 0.0);
+    inactive_enemy.active = false;
+    let mut warping_enemy = make_enemy(11, 100.0, 5.0);
+    warping_enemy.warping = true;
+    let mut flash_enemy = make_enemy(12, 100.0, 10.0);
+    flash_enemy.death_flash = 1;
+    let enemies = vec![inactive_enemy, warping_enemy, flash_enemy];
+
+    let mut inactive_ast = make_asteroid(20, 100.0, 0.0);
+    inactive_ast.active = false;
+    let mut warping_ast = make_asteroid(21, 100.0, 5.0);
+    warping_ast.warping = true;
+    let mut flash_ast = make_asteroid(22, 100.0, 10.0);
+    flash_ast.death_flash = 1;
+    let asteroids = vec![inactive_ast, warping_ast, flash_ast];
+
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_missile_salvo_hits(&missiles, &enemies, &asteroids, &ctx, &mut events);
+    assert_eq!(events.len(), 0, "all gates active → no events");
+}
+
+// ---------------------------------------------------------------------
+// Fixture — first-hit-wins per missile.
+//
+// One missile in geometric range of TWO enemies. Pure step emits at
+// most ONE event per missile per tick → exactly 1 event for the FIRST
+// in-range enemy (slice order), and the second enemy is NOT emitted.
+// Distinguishes from a per-target loop (would emit 2 events for the
+// same missile).
+// ---------------------------------------------------------------------
+#[test]
+fn missile_first_hit_wins_per_missile() {
+    let missile = make_missile(1, 0.0, 0.0);
+    let missiles = vec![missile];
+    // Both enemies are well inside the radius-sum (6 + 18 = 24).
+    let enemies = vec![make_enemy(101, 5.0, 0.0), make_enemy(102, 10.0, 0.0)];
+    let asteroids: Vec<CollisionAsteroid> = vec![];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_missile_salvo_hits(&missiles, &enemies, &asteroids, &ctx, &mut events);
+    assert_eq!(events.len(), 1, "first-hit-wins per missile → exactly 1 event");
+    match events[0] {
+        CollisionEvent::MissileHitEnemy { target_id, .. } => {
+            assert_eq!(target_id, 101, "first enemy in slice order wins");
+        }
+        ev => panic!("expected MissileHitEnemy for first enemy, got {:?}", ev),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — multiple missiles hit different targets independently.
+//
+// Two missiles, each in range of a distinct target. Pure step iterates
+// missiles outer-loop → each fires independently → 2 events total
+// (one per missile).
+// ---------------------------------------------------------------------
+#[test]
+fn missile_multiple_missiles_independent() {
+    let m1 = make_missile(1, 0.0, 0.0);
+    let m2 = make_missile(2, 100.0, 0.0);
+    let missiles = vec![m1, m2];
+    let enemies = vec![
+        make_enemy(101, 5.0, 0.0),   // in range of missile 1
+        make_enemy(102, 105.0, 0.0), // in range of missile 2
+    ];
+    let asteroids: Vec<CollisionAsteroid> = vec![];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_missile_salvo_hits(&missiles, &enemies, &asteroids, &ctx, &mut events);
+    assert_eq!(events.len(), 2, "2 missiles each hit distinct enemies → 2 events");
+
+    match events[0] {
+        CollisionEvent::MissileHitEnemy {
+            missile_id,
+            target_id,
+            ..
+        } => {
+            assert_eq!(missile_id, 1, "first event = missile 1");
+            assert_eq!(target_id, 101, "first event hits enemy 101");
+        }
+        ev => panic!("expected MissileHitEnemy first, got {:?}", ev),
+    }
+    match events[1] {
+        CollisionEvent::MissileHitEnemy {
+            missile_id,
+            target_id,
+            ..
+        } => {
+            assert_eq!(missile_id, 2, "second event = missile 2");
+            assert_eq!(target_id, 102, "second event hits enemy 102");
+        }
+        ev => panic!("expected MissileHitEnemy second, got {:?}", ev),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — zero-velocity missile yields zero knockback (no NaN).
+//
+// Missile with vx = vy = 0. JS uses `Math.hypot(0,0) || 1 = 1`, Rust
+// uses an explicit `mv_len == 0.0 → mv_len = 1.0` fallback. Either
+// way: kx = ky = 0. The event still emits — geometry is independent
+// of velocity.
+// ---------------------------------------------------------------------
+#[test]
+fn missile_zero_velocity_knockback_zero() {
+    let mut missile = make_missile(1, 0.0, 0.0);
+    missile.vx = 0.0;
+    missile.vy = 0.0;
+    let missiles = vec![missile];
+    let enemies = vec![make_enemy(101, 10.0, 0.0)];
+    let asteroids: Vec<CollisionAsteroid> = vec![];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_missile_salvo_hits(&missiles, &enemies, &asteroids, &ctx, &mut events);
+    assert_eq!(events.len(), 1, "zero-velocity missile still detects hit");
+    match events[0] {
+        CollisionEvent::MissileHitEnemy {
+            knock_x, knock_y, ..
+        } => {
+            approx_eq_missile(knock_x, 0.0, "zero-velocity → knock_x = 0");
+            approx_eq_missile(knock_y, 0.0, "zero-velocity → knock_y = 0");
+        }
+        ev => panic!("expected MissileHitEnemy, got {:?}", ev),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — knockback direction is normalized unit-vector × magnitude.
+//
+// Missile moving at (3, 4) — `mv_len = sqrt(9 + 16) = 5`. Unit vector
+// is (0.6, 0.8). Expected enemy knock: (0.6 * 9, 0.8 * 9) = (5.4, 7.2).
+// For an asteroid hit (separate sub-case below): (0.6 * 9 * 0.6, 0.8 *
+// 9 * 0.6) = (3.24, 4.32). Confirms the knockback vector is unit-
+// normalized BEFORE scaling, and that the 0.6× discount is asteroid-
+// only.
+// ---------------------------------------------------------------------
+#[test]
+fn missile_knockback_direction_normalized() {
+    // Enemy branch — full MISSILE_KNOCK.
+    {
+        let mut missile = make_missile(1, 0.0, 0.0);
+        missile.vx = 3.0;
+        missile.vy = 4.0;
+        let missiles = vec![missile];
+        let enemies = vec![make_enemy(101, 10.0, 0.0)];
+        let asteroids: Vec<CollisionAsteroid> = vec![];
+        let ctx = CollisionContext;
+        let mut events = Vec::new();
+        detect_missile_salvo_hits(&missiles, &enemies, &asteroids, &ctx, &mut events);
+        assert_eq!(events.len(), 1);
+        match events[0] {
+            CollisionEvent::MissileHitEnemy {
+                knock_x, knock_y, ..
+            } => {
+                approx_eq_missile(knock_x, 0.6 * MISSILE_KNOCK, "enemy knock_x = ux * KNOCK");
+                approx_eq_missile(knock_y, 0.8 * MISSILE_KNOCK, "enemy knock_y = uy * KNOCK");
+            }
+            ev => panic!("expected MissileHitEnemy, got {:?}", ev),
+        }
+    }
+    // Asteroid branch — MISSILE_KNOCK × 0.6 discount.
+    {
+        let mut missile = make_missile(1, 0.0, 0.0);
+        missile.vx = 3.0;
+        missile.vy = 4.0;
+        let missiles = vec![missile];
+        let enemies: Vec<CollisionEnemy> = vec![];
+        let asteroids = vec![make_asteroid(101, 20.0, 0.0)];
+        let ctx = CollisionContext;
+        let mut events = Vec::new();
+        detect_missile_salvo_hits(&missiles, &enemies, &asteroids, &ctx, &mut events);
+        assert_eq!(events.len(), 1);
+        match events[0] {
+            CollisionEvent::MissileHitAsteroid {
+                knock_x, knock_y, ..
+            } => {
+                approx_eq_missile(
+                    knock_x,
+                    0.6 * MISSILE_KNOCK * 0.6,
+                    "asteroid knock_x = ux * KNOCK * 0.6",
+                );
+                approx_eq_missile(
+                    knock_y,
+                    0.8 * MISSILE_KNOCK * 0.6,
+                    "asteroid knock_y = uy * KNOCK * 0.6",
+                );
+            }
+            ev => panic!("expected MissileHitAsteroid, got {:?}", ev),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — strict-less-than boundary (dist == sum → MISS).
+//
+// Missile radius = 6 (MISSILE_DEFAULT_RADIUS). Enemy radius = 18.
+// Sum-of-radii = 24. Place enemy exactly 24 units away from the
+// missile → dist == sum → MISS. JS pure step gate is `dist < sum`
+// (strict). This fixture guards against drift to `<=` (inclusive).
+// ---------------------------------------------------------------------
+#[test]
+fn missile_boundary_strict_less_than() {
+    let missile = make_missile(1, 0.0, 0.0);
+    let missiles = vec![missile];
+    // Enemy radius 18 + missile radius 6 = 24. Place at (24, 0).
+    let sum = 18.0 + MISSILE_DEFAULT_RADIUS;
+    let enemies = vec![make_enemy(101, sum, 0.0)];
+    let asteroids: Vec<CollisionAsteroid> = vec![];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_missile_salvo_hits(&missiles, &enemies, &asteroids, &ctx, &mut events);
+    assert_eq!(events.len(), 0, "dist == sum-of-radii → MISS (strict <)");
 }


### PR DESCRIPTION
## Summary
- Mirrors PR #68's \`detectMissileSalvoHits\` into Rust. 4th power-weapon Rust mirror after Nova (#73), Mine (#65), and Lance Beam (#69).
- 10 new parity fixtures (60 → 70 passing). Clean build, zero warnings.
- Also adds the \`apply_event\` arms in \`server/src/room/collision.rs\` for the new variants (HP decrement; knockback deferred until GameState carries velocity fields).
- Missile Salvo remains MP-unsafe per mp-feature-flags.js until the wrapper-side knockback plumbing lands.

## Base branch
**This PR is based on \`mp/restore-server-collision-drain\` (PR #70).** PR #70 carries the room/collision.rs file plus Lance Beam apply_event arms. After #70 merges to master, this PR's base auto-shifts to master and lands cleanly.

## Algorithm
For each missile (skip !active):
1. Normalize velocity (vx, vy) → unit vector (kx, ky); use mv_len=1.0 fallback when zero
2. Enemies first (skip !active, warping, death_flash): first hit within sum-of-radii emits MissileHitEnemy
3. If no enemy hit, asteroids: first hit emits MissileHitAsteroid with knockback pre-scaled by 0.6

## New types + variants
- \`CollisionMissile { id, x, y, vx, vy, radius, damage, active }\`
- \`CollisionEvent::MissileHitEnemy { missile_id, target_id, damage, knock_x, knock_y }\`
- \`CollisionEvent::MissileHitAsteroid { missile_id, target_id, damage, knock_x, knock_y }\`

## Constants exported
- \`MISSILE_KNOCK: f32 = 9.0\`
- \`MISSILE_DEFAULT_RADIUS: f32 = 6.0\`

## Divergences from JS (documented)
- Algebraic: Rust uses \`(dx*dx + dy*dy).sqrt()\` vs JS \`Math.hypot(dx, dy)\` — identical for finite f32 inputs.
- Zero-velocity guard: Rust uses explicit \`if mv_len == 0.0 { mv_len = 1.0 }\` vs JS \`Math.hypot(0,0) || 1\` — same end-state, kx=ky=0.

## Test plan
- [x] 10 new parity fixtures (60 → 70 passing)
- [x] 7/7 collision_drain tests still passing (apply_event arms work)
- [x] Build clean, zero warnings
- [x] Boundary strict-\`<\` pinned (dist == sum-of-radii → MISS)
- [x] Knockback math (normalized + 0.6× factor) pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)