### PR TITLE
mp/engine: LoopbackConnection Phase 2 — startSolo({useLoopback:true})

### DIFF
--- a/js/engine/engine-driver.js
+++ b/js/engine/engine-driver.js
@@ -54,6 +54,7 @@
 import { OnlineStatusOverlay } from './online-status-overlay.js';
 import { Predictor } from '../net/prediction.js';
 import { Interpolator } from '../net/interpolation.js';
+import { LoopbackConnection } from '../net/loopback-connection.js';
 import { pack as packInput, emptyPlayerInput } from '../sim/input.js';
 
 /**
@@ -85,6 +86,7 @@ export class EngineDriver {
      *   document?: Document,
      *   Predictor?: typeof Predictor,
      *   Interpolator?: typeof Interpolator,
+     *   LoopbackConnection?: typeof LoopbackConnection,
      *   renderDelayMs?: number,
      *   dt?: number,
      *   now?: () => number,
@@ -112,6 +114,10 @@ export class EngineDriver {
         // bleed across runs).
         this._PredictorCtor = deps.Predictor ?? Predictor;
         this._InterpolatorCtor = deps.Interpolator ?? Interpolator;
+        // Loopback class is also injectable so the hybrid-solo path can be
+        // tested without spinning up a real timer interval. Solo mode that
+        // doesn't opt into loopback never touches this.
+        this._LoopbackCtor = deps.LoopbackConnection ?? LoopbackConnection;
         // 100 ms is the canonical render-delay window for 20 Hz snapshots
         // — enough headroom for one dropped packet without feeling laggy.
         // Matches `Interpolator`'s built-in default; override only for
@@ -158,10 +164,67 @@ export class EngineDriver {
      * starts a new one. Identical to clicking NEW GAME / CONTINUE on the
      * title screen — the driver is a thin pass-through.
      *
-     * @param {{ continueRun?: boolean, animateTitleStart?: boolean }} [opts]
+     * ── Hybrid solo↔MP (Phase 2, 2026-05-13) ─────────────────────────────
+     * When `useLoopback=true`, the driver constructs an in-process
+     * `LoopbackConnection`, synthesizes a welcome payload, and delegates
+     * to `startOnline()`. This drives the SAME Predictor + Interpolator
+     * pipeline used for real multiplayer — solo and online share the
+     * exact same per-frame code path, with the only difference being
+     * where the snapshot bytes originate. The default remains `false`
+     * (legacy solo, no Predictor / Interpolator) so existing call sites
+     * are unaffected; the next slice (game-engine wiring) flips the flag.
+     *
+     * @param {{
+     *   continueRun?: boolean,
+     *   animateTitleStart?: boolean,
+     *   useLoopback?: boolean,
+     *   baselineShip?: object|null,
+     * }} [opts]
      * @returns {boolean} true if the run actually launched
      */
-    startSolo({ continueRun = false, animateTitleStart = true } = {}) {
+    startSolo({
+        continueRun = false,
+        animateTitleStart = true,
+        useLoopback = false,
+        baselineShip = null,
+    } = {}) {
+        // Hybrid path: construct a loopback connection + synthetic welcome
+        // and reuse the existing online pipeline. We do this BEFORE
+        // `_teardownConnection()` because `startOnline()` already calls
+        // teardown internally — calling it twice would be wasted work.
+        if (useLoopback) {
+            const loopback = new this._LoopbackCtor({
+                playerId: 1,
+                sessionId: 'solo-loopback',
+                serverTimeMs: Date.now(),
+                // The Phase 1 scaffold's constructor accepts a `baselineShip`
+                // option; thread it through so callers can pin the ship's
+                // starting position. If the scaffold ever drops this option,
+                // the loopback simply seeds a default ship — both paths are
+                // safe.
+                ...(baselineShip ? { baselineShip } : null),
+            });
+            const welcome = {
+                playerId: loopback.playerId,
+                session: loopback.session ?? 'solo-loopback',
+                serverTimeMs: Date.now(),
+            };
+            // Start the loopback BEFORE startOnline subscribes — the
+            // scaffold emits its welcome on a microtask, so the
+            // engine-driver's snapshot listener (registered inside
+            // startOnline) is in place by the time the first snapshot
+            // arrives 50 ms later. Either ordering works since loopback's
+            // event emitter is sync; we choose this to match the real-MP
+            // sequence where ConnectionTask is already Welcomed by the
+            // time it's handed to the engine driver.
+            loopback.start();
+            return this.startOnline({
+                connection: loopback,
+                welcome,
+                baselineShip,
+            });
+        }
+
         this._teardownConnection();
         this.mode = ENGINE_MODE_SOLO;
 

--- a/tests/unit/engine/engine-driver-solo.test.js
+++ b/tests/unit/engine/engine-driver-solo.test.js
@@ -1,0 +1,536 @@
+// Unit tests for EngineDriver's hybrid-solo wiring.
+//
+// Pins the Phase 2 contract for `startSolo({ useLoopback })` laid out in
+// the Hybrid Solo↔MP unification rollout (2026-05-13):
+//
+//   - `startSolo()` (no opts, OR `useLoopback: false`) — legacy solo
+//     path. No Predictor, no Interpolator, no connection. `isOnline`
+//     stays false. `tick()` is a no-op. This MUST be byte-for-byte
+//     identical to pre-Phase-2 behavior so existing call sites are
+//     unaffected.
+//
+//   - `startSolo({ useLoopback: true })` — hybrid path. The driver
+//     constructs a `LoopbackConnection` internally, synthesizes a
+//     `welcome` payload, and delegates to `startOnline()`. Same
+//     Predictor + Interpolator pipeline as actual multiplayer; the
+//     ONLY difference is where the snapshot bytes come from. After
+//     this call, `isOnline` returns `true`.
+//
+//   - Mode transitions clean up cleanly:
+//       * loopback-solo → legacy-solo: loopback disconnects, MP
+//         pipeline torn down.
+//       * legacy-solo → loopback-solo: predictor + interpolator
+//         engage.
+//       * loopback-solo → startOnline(real): loopback disconnects
+//         before the real connection is wired.
+//
+// The driver remains intentionally thin — these tests use fakes for
+// everything it composes (GameEngine, LoopbackConnection, Predictor,
+// Interpolator) so the asserted behavior is exclusively the wiring
+// contract.
+
+import { describe, test, expect, jest } from '@jest/globals';
+import {
+    EngineDriver,
+    ENGINE_MODE_SOLO,
+    ENGINE_MODE_ONLINE,
+} from '../../../js/engine/engine-driver.js';
+
+// ── Fakes ────────────────────────────────────────────────────────────────────
+
+class StubGameEngine {
+    constructor() {
+        this.calls = [];
+    }
+    hasSavedRun() { return false; }
+    triggerTitleStart(start) {
+        this.calls.push('triggerTitleStart');
+        start();
+        return true;
+    }
+    startNewRun() { this.calls.push('startNewRun'); }
+    startContinueRun() { this.calls.push('startContinueRun'); }
+}
+
+class StubOverlay {
+    constructor() { this.calls = []; }
+    show() { this.calls.push('show'); }
+    showReconnecting() { this.calls.push('reconnecting'); }
+    showDisconnected() { this.calls.push('disconnected'); }
+    hide() { this.calls.push('hide'); }
+}
+
+/**
+ * Fake LoopbackConnection — exposes the surface the engine driver
+ * touches: `on(event, fn)`, `start()`, `disconnect()`, `sendInput(...)`,
+ * `playerId`, `session`. Records every emitted event payload and every
+ * input call so tests can poke individual sites.
+ */
+class FakeLoopback {
+    constructor(opts = {}) {
+        this.constructorOpts = opts;
+        this._playerId = opts.playerId ?? 1;
+        this.session = opts.sessionId ?? 'solo-loopback';
+        this.serverTimeMs = opts.serverTimeMs ?? 0;
+        this.state = 'idle';
+        this._listeners = new Map();
+        this.startCalls = 0;
+        this.disconnectCalls = 0;
+        this.inputsSent = [];
+        this.sendInputThrowsNext = false;
+    }
+    get playerId() { return this._playerId; }
+    on(event, fn) {
+        let set = this._listeners.get(event);
+        if (!set) {
+            set = new Set();
+            this._listeners.set(event, set);
+        }
+        set.add(fn);
+        return () => set.delete(fn);
+    }
+    emit(event, payload) {
+        const set = this._listeners.get(event);
+        if (!set) return;
+        for (const fn of set) fn(payload);
+    }
+    start() {
+        this.startCalls += 1;
+        this.state = 'open';
+    }
+    disconnect() {
+        this.disconnectCalls += 1;
+        this.state = 'closed';
+        this.emit('disconnect');
+    }
+    sendInput(tick, packed) {
+        if (this.sendInputThrowsNext) {
+            this.sendInputThrowsNext = false;
+            throw new Error('sendInput: forced test failure');
+        }
+        this.inputsSent.push({ tick, packed });
+    }
+}
+
+/**
+ * Fake real ConnectionTask — used to verify the loopback gets cleanly
+ * disconnected when a real MP connection takes over (the "loopback-solo
+ * → startOnline(real)" transition).
+ */
+class FakeRealConnection {
+    constructor() {
+        this.playerId = 7n;
+        this.session = 'real-connection-session-uuid';
+        this.state = 'welcomed';
+        this._listeners = new Map();
+        this.disconnectCalls = 0;
+        this.inputsSent = [];
+    }
+    on(event, fn) {
+        let set = this._listeners.get(event);
+        if (!set) {
+            set = new Set();
+            this._listeners.set(event, set);
+        }
+        set.add(fn);
+        return () => set.delete(fn);
+    }
+    emit(event, payload) {
+        const set = this._listeners.get(event);
+        if (!set) return;
+        for (const fn of set) fn(payload);
+    }
+    disconnect() {
+        this.disconnectCalls += 1;
+        this.state = 'closed';
+        this.emit('disconnect');
+    }
+    sendInput(tick, packed) {
+        this.inputsSent.push({ tick, packed });
+    }
+}
+
+function makeSpyPredictor() {
+    const localShipState = { _sentinel: 'predicted-local-ship' };
+    let tickCounter = 0;
+    const instance = {
+        get localShipState() { return localShipState; },
+        get tick() { return tickCounter; },
+        setBaseline: jest.fn(function (ship, tick) { tickCounter = tick; }),
+        applyLocalInput: jest.fn(function () { tickCounter += 1; }),
+        onSnapshot: jest.fn(function (serverTick) { tickCounter = serverTick; }),
+    };
+    return { instance };
+}
+
+function makeSpyInterpolator({ samplePayload = null } = {}) {
+    const instance = {
+        renderDelayMs: 100,
+        ingest: jest.fn(),
+        sample: jest.fn(function () { return samplePayload; }),
+    };
+    return { instance };
+}
+
+/**
+ * Build an EngineDriver wired up with a fake LoopbackConnection ctor
+ * plus spy Predictor + Interpolator. The fake loopback instance is
+ * captured in `loopbackInstances` (most recent at index 0) so tests
+ * can poke the latest constructed instance.
+ */
+function makeSoloDriver({ samplePayload = null } = {}) {
+    const ge = new StubGameEngine();
+    const overlayCtor = jest.fn(function () { return new StubOverlay(); });
+    const spyPred = makeSpyPredictor();
+    const spyInterp = makeSpyInterpolator({ samplePayload });
+    const loopbackInstances = [];
+    const LoopbackCtor = jest.fn(function (opts) {
+        const inst = new FakeLoopback(opts);
+        loopbackInstances.unshift(inst);
+        return inst;
+    });
+    const driver = new EngineDriver({
+        gameEngine: ge,
+        deps: {
+            Overlay: overlayCtor,
+            document: globalThis.document ?? null,
+            Predictor: jest.fn(function () { return spyPred.instance; }),
+            Interpolator: jest.fn(function () { return spyInterp.instance; }),
+            LoopbackConnection: LoopbackCtor,
+            renderDelayMs: 100,
+            dt: 1 / 60,
+        },
+    });
+    return {
+        driver,
+        ge,
+        spyPred,
+        spyInterp,
+        LoopbackCtor,
+        loopbackInstances,
+        latestLoopback: () => loopbackInstances[0],
+    };
+}
+
+const FRESH_SIM_INPUT = {
+    up: false,
+    down: false,
+    left: false,
+    right: true,
+    aimX: 100,
+    aimY: 0,
+    thrustPower: 1.0,
+    speedMult: 1,
+    thrustersDisabled: false,
+    maxV: 3.5,
+    friction: 0.7071067811865476,
+    velEpsilon: 0.05,
+    bounceDamp: 0.8,
+};
+
+// ── Test group 1: legacy solo (useLoopback omitted / false) ─────────────────
+
+describe('EngineDriver solo — legacy path (no loopback)', () => {
+    test('startSolo() omits useLoopback → isOnline stays false', () => {
+        const { driver } = makeSoloDriver();
+        driver.startSolo();
+        expect(driver.mode).toBe(ENGINE_MODE_SOLO);
+        expect(driver.isOnline).toBe(false);
+    });
+
+    test('startSolo({ useLoopback: false }) → isOnline stays false', () => {
+        const { driver, LoopbackCtor } = makeSoloDriver();
+        driver.startSolo({ useLoopback: false });
+        expect(driver.isOnline).toBe(false);
+        // Loopback ctor never called — legacy path is unaffected.
+        expect(LoopbackCtor).not.toHaveBeenCalled();
+    });
+
+    test('legacy solo never instantiates Loopback / Predictor / Interpolator', () => {
+        const { driver, LoopbackCtor } = makeSoloDriver();
+        driver.startSolo();
+        expect(LoopbackCtor).not.toHaveBeenCalled();
+        expect(driver.predictor).toBeNull();
+        expect(driver.interpolator).toBeNull();
+        expect(driver.connection).toBeNull();
+    });
+
+    test('getLocalShipState() returns null in legacy solo', () => {
+        const { driver } = makeSoloDriver();
+        driver.startSolo();
+        expect(driver.getLocalShipState()).toBeNull();
+    });
+
+    test('sampleRemoteShips() returns empty array in legacy solo', () => {
+        const { driver } = makeSoloDriver();
+        driver.startSolo();
+        expect(driver.sampleRemoteShips()).toEqual([]);
+    });
+
+    test('tick() is a no-op in legacy solo (no throw, no predictor)', () => {
+        const { driver } = makeSoloDriver();
+        driver.startSolo();
+        expect(() => driver.tick(FRESH_SIM_INPUT)).not.toThrow();
+        expect(driver.predictor).toBeNull();
+    });
+});
+
+// ── Test group 2: hybrid solo (useLoopback: true) ───────────────────────────
+
+describe('EngineDriver solo — hybrid loopback path', () => {
+    test('startSolo({ useLoopback: true }) constructs a LoopbackConnection', () => {
+        const { driver, LoopbackCtor, latestLoopback } = makeSoloDriver();
+        driver.startSolo({ useLoopback: true });
+        expect(LoopbackCtor).toHaveBeenCalledTimes(1);
+        expect(latestLoopback()).not.toBeUndefined();
+    });
+
+    test('isOnline returns true after starting loopback solo', () => {
+        const { driver } = makeSoloDriver();
+        driver.startSolo({ useLoopback: true });
+        // The driver's `isOnline` reflects "MP pipeline is running",
+        // regardless of whether the connection is a real socket or a
+        // loopback. This is the unification point.
+        expect(driver.isOnline).toBe(true);
+        expect(driver.mode).toBe(ENGINE_MODE_ONLINE);
+    });
+
+    test('Predictor + Interpolator engage in loopback solo', () => {
+        const { driver } = makeSoloDriver();
+        driver.startSolo({ useLoopback: true });
+        expect(driver.predictor).not.toBeNull();
+        expect(driver.interpolator).not.toBeNull();
+    });
+
+    test('connection field is set to the loopback instance', () => {
+        const { driver, latestLoopback } = makeSoloDriver();
+        driver.startSolo({ useLoopback: true });
+        expect(driver.connection).toBe(latestLoopback());
+    });
+
+    test('loopback.start() is called exactly once on entry', () => {
+        const { driver, latestLoopback } = makeSoloDriver();
+        driver.startSolo({ useLoopback: true });
+        expect(latestLoopback().startCalls).toBe(1);
+    });
+
+    test('synthetic welcome has playerId / session / serverTimeMs', () => {
+        const { driver } = makeSoloDriver();
+        driver.startSolo({ useLoopback: true });
+        const w = driver.welcome;
+        expect(w).not.toBeNull();
+        expect(w.playerId).toBeDefined();
+        expect(typeof w.session).toBe('string');
+        expect(Number.isFinite(Number(w.serverTimeMs))).toBe(true);
+    });
+
+    test('synthetic welcome session is "solo-loopback"', () => {
+        const { driver } = makeSoloDriver();
+        driver.startSolo({ useLoopback: true });
+        // The loopback's default session id is 'solo-loopback' (per the
+        // scaffold's documented default). Whichever value the driver
+        // chose, it should be a non-empty string that includes 'solo' or
+        // 'loopback'.
+        expect(driver.welcome.session).toMatch(/(solo|loopback)/);
+    });
+
+    test('inputs sent via tick() flow through to loopback.sendInput', () => {
+        const { driver, latestLoopback } = makeSoloDriver();
+        driver.startSolo({ useLoopback: true });
+        const lb = latestLoopback();
+
+        driver.tick(FRESH_SIM_INPUT);
+        driver.tick({ ...FRESH_SIM_INPUT, left: true, right: false });
+
+        expect(lb.inputsSent).toHaveLength(2);
+        // Each sendInput call gets a tick + a packed wire input.
+        expect(lb.inputsSent[0].tick).toBe(1);
+        expect(lb.inputsSent[1].tick).toBe(2);
+        expect(lb.inputsSent[0].packed).toEqual(expect.objectContaining({
+            moveX: expect.any(Number),
+            moveY: expect.any(Number),
+            aimX: expect.any(Number),
+            aimY: expect.any(Number),
+            buttons: expect.any(Number),
+        }));
+    });
+
+    test('sampleRemoteShips() returns empty array (solo has no peers)', () => {
+        // Even though the MP pipeline is engaged, a loopback session has
+        // exactly one ship (the local player). The interpolator's sample
+        // is wired but returns no peer ships.
+        const { driver } = makeSoloDriver({ samplePayload: null });
+        driver.startSolo({ useLoopback: true });
+        expect(driver.sampleRemoteShips()).toEqual([]);
+    });
+
+    test('getLocalShipState() returns the predictor.localShipState reference', () => {
+        const { driver, spyPred } = makeSoloDriver();
+        driver.startSolo({ useLoopback: true });
+        // Identity check: solo-loopback reads the locally-predicted ship
+        // — same code path as real MP. This is the unification point for
+        // the renderer.
+        expect(driver.getLocalShipState()).toBe(spyPred.instance.localShipState);
+    });
+
+    test('baselineShip option is forwarded to predictor.setBaseline', () => {
+        const { driver, spyPred } = makeSoloDriver();
+        const baselineShip = {
+            player: 1n, x: 960, y: 540, vx: 0, vy: 0, angle: 0,
+            hp: 100, shield: 0,
+        };
+        driver.startSolo({ useLoopback: true, baselineShip });
+        expect(spyPred.instance.setBaseline).toHaveBeenCalledTimes(1);
+        expect(spyPred.instance.setBaseline).toHaveBeenCalledWith(baselineShip, 0);
+    });
+
+    test('baselineShip option is forwarded to LoopbackConnection ctor', () => {
+        const { driver, LoopbackCtor } = makeSoloDriver();
+        const baselineShip = {
+            player: 1n, x: 100, y: 200, vx: 0, vy: 0, angle: 0,
+            hp: 100, shield: 0,
+        };
+        driver.startSolo({ useLoopback: true, baselineShip });
+        // Ctor was called with an opts bag that includes baselineShip.
+        const ctorOpts = LoopbackCtor.mock.calls[0][0];
+        expect(ctorOpts.baselineShip).toBe(baselineShip);
+    });
+});
+
+// ── Test group 3: mode switching ────────────────────────────────────────────
+
+describe('EngineDriver solo — mode switching', () => {
+    test('loopback solo → legacy solo disconnects the loopback', () => {
+        const { driver, latestLoopback } = makeSoloDriver();
+        driver.startSolo({ useLoopback: true });
+        const lb = latestLoopback();
+        expect(lb.disconnectCalls).toBe(0);
+
+        // Flip back to legacy solo. The driver must disconnect the
+        // loopback as part of `_teardownConnection()`.
+        driver.startSolo();
+
+        expect(lb.disconnectCalls).toBe(1);
+        expect(driver.mode).toBe(ENGINE_MODE_SOLO);
+        expect(driver.isOnline).toBe(false);
+        expect(driver.predictor).toBeNull();
+        expect(driver.interpolator).toBeNull();
+        expect(driver.connection).toBeNull();
+    });
+
+    test('legacy solo → loopback solo engages the predictor', () => {
+        const { driver } = makeSoloDriver();
+        driver.startSolo(); // legacy first
+        expect(driver.predictor).toBeNull();
+        expect(driver.interpolator).toBeNull();
+
+        driver.startSolo({ useLoopback: true });
+        expect(driver.predictor).not.toBeNull();
+        expect(driver.interpolator).not.toBeNull();
+        expect(driver.isOnline).toBe(true);
+    });
+
+    test('loopback solo → startOnline(real) disconnects loopback cleanly', () => {
+        const { driver, latestLoopback } = makeSoloDriver();
+        driver.startSolo({ useLoopback: true });
+        const lb = latestLoopback();
+        expect(lb.disconnectCalls).toBe(0);
+
+        const realConn = new FakeRealConnection();
+        driver.startOnline({
+            connection: realConn,
+            welcome: {
+                playerId: 7n,
+                session: 'a'.repeat(36),
+                serverTimeMs: 0n,
+            },
+        });
+
+        // Loopback torn down; real connection takes over.
+        expect(lb.disconnectCalls).toBe(1);
+        expect(driver.connection).toBe(realConn);
+        expect(driver.mode).toBe(ENGINE_MODE_ONLINE);
+    });
+
+    test('two consecutive loopback solos produce two distinct loopbacks', () => {
+        // Each `startSolo({ useLoopback: true })` should construct a
+        // FRESH loopback (the previous one is torn down). This pins the
+        // "session-scoped state" invariant — no stale tick counters or
+        // pending inputs bleeding across runs.
+        const { driver, LoopbackCtor, loopbackInstances } = makeSoloDriver();
+        driver.startSolo({ useLoopback: true });
+        const first = loopbackInstances[0];
+        driver.startSolo({ useLoopback: true });
+        const second = loopbackInstances[0];
+
+        expect(LoopbackCtor).toHaveBeenCalledTimes(2);
+        expect(second).not.toBe(first);
+        // The first loopback was disconnected during the second startSolo.
+        expect(first.disconnectCalls).toBe(1);
+    });
+
+    test('quit() after loopback solo disconnects the loopback', () => {
+        const { driver, latestLoopback } = makeSoloDriver();
+        driver.startSolo({ useLoopback: true });
+        const lb = latestLoopback();
+
+        driver.quit();
+
+        expect(lb.disconnectCalls).toBe(1);
+        expect(driver.mode).toBe(ENGINE_MODE_SOLO);
+        expect(driver.connection).toBeNull();
+        expect(driver.predictor).toBeNull();
+        expect(driver.interpolator).toBeNull();
+    });
+});
+
+// ── Test group 4: snapshot dispatch in loopback solo ────────────────────────
+
+describe('EngineDriver solo — snapshot dispatch in loopback mode', () => {
+    test('loopback-emitted snapshots flow through to predictor + interpolator', () => {
+        const { driver, spyPred, spyInterp, latestLoopback } = makeSoloDriver();
+        driver.startSolo({ useLoopback: true });
+        const lb = latestLoopback();
+
+        // The driver's welcome.playerId comes from the loopback (defaults
+        // to 1). So a ship with player=1 is treated as local.
+        const localShip = {
+            player: 1, x: 500, y: 500, vx: 0, vy: 0, angle: 0, hp: 100,
+        };
+        lb.emit('snapshot', {
+            tick: 17,
+            baseTick: null,
+            payload: {
+                ships: [localShip],
+                enemies: [],
+                asteroids: [],
+                drops: [],
+            },
+            recvTime: 1234,
+        });
+
+        // Local ship reconciled.
+        expect(spyPred.instance.onSnapshot).toHaveBeenCalledTimes(1);
+        expect(spyPred.instance.onSnapshot).toHaveBeenCalledWith(17, localShip);
+        // Interpolator still ingests (with empty remote-ships array) —
+        // matches the "every snapshot drives a beat" contract.
+        expect(spyInterp.instance.ingest).toHaveBeenCalledTimes(1);
+        expect(spyInterp.instance.ingest.mock.calls[0][1].ships).toEqual([]);
+    });
+
+    test('loopback disconnect downgrades the driver back to solo', () => {
+        const { driver, latestLoopback } = makeSoloDriver();
+        driver.startSolo({ useLoopback: true });
+        const lb = latestLoopback();
+        expect(driver.isOnline).toBe(true);
+
+        // Loopback emits disconnect (simulating teardown).
+        lb.disconnect();
+
+        // Driver downgrades to solo mode.
+        expect(driver.mode).toBe(ENGINE_MODE_SOLO);
+        expect(driver.isOnline).toBe(false);
+        expect(driver.predictor).toBeNull();
+        expect(driver.interpolator).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
Phase 2 of the Hybrid solo↔MP unification. Builds on PR #71's LoopbackConnection scaffold. Adds the EngineDriver entry point so solo mode can OPTIONALLY run through the same Predictor + Interpolator pipeline that MP uses.

**Default behavior preserved byte-for-byte** — solo callers without \`useLoopback\` see no change. The opt-in is dormant until a future Phase 3 PR flips it on at the title-screen NEW GAME call site.

## API
\`\`\`js
engineDriver.startSolo();                              // legacy solo (unchanged)
engineDriver.startSolo({ useLoopback: true });         // hybrid loopback solo
engineDriver.startSolo({ useLoopback: true, baselineShip });
\`\`\`

When \`useLoopback: true\`:
1. Construct \`LoopbackConnection\` internally (injectable via \`_LoopbackCtor\` for tests)
2. Synthesize welcome \`{ playerId: 1, session: 'solo-loopback', serverTimeMs }\`
3. Call \`loopback.start()\`
4. Delegate to existing \`startOnline({connection: loopback, welcome, baselineShip})\`
5. \`engineDriver.isOnline === true\`; predictor/interpolator engage

## Test plan
- [x] 25 new tests across 4 groups (legacy solo, hybrid loopback, mode switching, snapshot dispatch)
- [x] 86 engine-driver tests passing (5 suites, was 61)
- [x] 737 unit tests passing across 27 suites (was 712), 0 regressions
- [x] LoopbackConnection scaffold untouched

## Open Phase 3 concerns (documented in commit)
1. **game-engine.js wiring** — flipping \`useLoopback:true\` at the actual NEW GAME call site
2. **PackedInput Uint8Array decode** — engine currently sends plain object; works today
3. **Peer event handling** — modal may need synthetic peer events from loopback
4. **Welcome.playerId type** — real ConnectionTask uses bigint; loopback defaults to Number(1); \`idKey()\` normalizes downstream
5. **continueRun flag** — hybrid path always startNewRun; real MP doesn't model saved runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)