### PR TITLE
mp/player: wire MP feature-flag gate into Player.firePower + .activateSkill

### DIFF
--- a/js/modules/player/player.js
+++ b/js/modules/player/player.js
@@ -10,6 +10,12 @@ import * as playerRenderer from './renderer.js';
 // `ShipState` from `this`, calls `updateShip`, and writes the result
 // back. Behavior is byte-for-byte equivalent to the legacy inline code.
 import { updateShip } from '../../sim/ship.js';
+// MP feature-flag gate: in online mode, abilities that lack full
+// Rust-mirror parity are suppressed at the fire-site so they can't
+// desync gameplay. Solo runs are unaffected (the helper returns true
+// when no online driver is attached). See `js/net/mp-feature-flags.js`
+// for the per-ability allowlist.
+import { isAbilityMpSafe } from '../../net/mp-feature-flags.js';
 
 export class Player {
     constructor() {
@@ -310,7 +316,26 @@ export class Player {
     // ── Weapon bindings ──
     getBulletVelocityDamageMult(id)     { return weapons.getBulletVelocityDamageMult.call(this, id); }
 
+    // ── MP feature-flag suppression helper ─────────────────────────────────
+    // Returns true when an ability should be suppressed because the engine
+    // is online AND the ability lacks full Rust-mirror parity. The engine
+    // driver lives on `window.engineDriver` (set in `main.js`); the same
+    // lookup convention game-engine.js's `_mpDriverIfOnline()` uses. In
+    // solo runs (or before the driver is attached) this returns false and
+    // the gate is a no-op.
+    _isAbilitySuppressedByMp(abilityId) {
+        const driver = (typeof window !== 'undefined') ? window.engineDriver : null;
+        if (!driver || !driver.isOnline) return false;
+        return !isAbilityMpSafe(abilityId);
+    }
+
     firePower(bulletPool, audioManager, particlePool) {
+        // MP gate — suppress power weapons that don't yet have a Rust mirror.
+        // The cooldown gate is upstream in weapons.updateChargingSystem(),
+        // and the caller (weapons.js:163) clears `input.fireSecondary`
+        // unconditionally after calling us, so an early-return here cleanly
+        // no-ops: no entity spawn, no audio, no FX, no cooldown consumed.
+        if (this._isAbilitySuppressedByMp(this.activePower)) return;
         return weapons.firePower.call(this, bulletPool, audioManager, particlePool);
     }
 
@@ -812,6 +837,13 @@ export class Player {
     }
 
     activateSkill() {
+        // MP gate — all six defense skills mutate ship state in ways the
+        // server doesn't model yet, so they're suppressed in online mode.
+        // The Q-key one-shot pulse is consumed in update() regardless
+        // (see input.activateSkill = false right after the call site),
+        // so an early-return here means no cooldown, no FX, no audio,
+        // and the input stays consumed.
+        if (this._isAbilitySuppressedByMp(this.activeSkill)) return false;
         return skills.activateSkill.call(this);
     }
 

--- a/tests/unit/player/mp-ability-gate.test.js
+++ b/tests/unit/player/mp-ability-gate.test.js
@@ -1,0 +1,339 @@
+/**
+ * tests/unit/player/mp-ability-gate.test.js — unit tests for the MP
+ * feature-flag suppression gate at the Player ability fire-site.
+ *
+ * The gate wires `js/net/mp-feature-flags.js::isAbilityMpSafe(id)` into
+ * `Player.firePower()` and `Player.activateSkill()` so that, when the
+ * engine driver reports `isOnline === true`, abilities lacking full
+ * Rust-mirror parity early-return without spawning entities / consuming
+ * cooldown / playing audio.
+ *
+ * Strategy: instead of module-mocking (ESM module exports are read-only
+ * in Jest, so jest.spyOn() can't replace them), the tests observe
+ * concrete side-effects of the underlying weapons/skills implementation:
+ *
+ *   • activateSkill → `activeSkillCooldown` flips from 0 to config.cooldown
+ *     and `activeSkillEffects` gains an entry, OR neither does if gated.
+ *   • firePower (NOVA_BLAST) → `powerCooldown` flips to non-zero and
+ *     `novaRings` gains an entry, OR neither does if gated.
+ *
+ * These tests pin the contract:
+ *   • MP-unsafe id + online → state unchanged (gated)
+ *   • MP-unsafe id + solo → state changes (unchanged behavior)
+ *   • MP-safe id + online → state changes (allowlist path)
+ *   • Unknown id + online → state changes (conservative-permissive default)
+ *   • All 6 power weapons + all 6 defense skills are individually gated.
+ *
+ * The lists themselves track Phase 2.5 collision-pair progress in
+ * `docs/Multiplayer Coordination – 2026-05-09.md`; as Rust mirrors land,
+ * abilities migrate from MP_UNSAFE → MP_SAFE and these tests should
+ * be updated alongside js/net/mp-feature-flags.js.
+ */
+
+// ---------------------------------------------------------------------------
+// Browser shims — must happen before any game module import (player.js
+// reads `window.innerWidth` in its constructor). Same pattern as
+// tests/unit/pool.test.js.
+// ---------------------------------------------------------------------------
+if (typeof globalThis.window === 'undefined') {
+    globalThis.window = {
+        innerWidth: 1920, innerHeight: 1080,
+        matchMedia: () => ({ matches: false }),
+        addEventListener: () => {}, removeEventListener: () => {},
+    };
+}
+if (typeof globalThis.document === 'undefined') {
+    globalThis.document = {
+        createElement: () => ({ getContext: () => ({}), style: {}, addEventListener: () => {} }),
+        getElementById: () => null, querySelector: () => null, querySelectorAll: () => [],
+        addEventListener: () => {}, body: { appendChild: () => {} },
+    };
+}
+if (typeof globalThis.navigator === 'undefined') {
+    globalThis.navigator = { vibrate: undefined };
+}
+
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import { Player } from '../../../js/modules/player/player.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setOnline(value) {
+    globalThis.window.engineDriver = value
+        ? { isOnline: true }
+        : { isOnline: false };
+}
+
+function clearDriver() {
+    delete globalThis.window.engineDriver;
+}
+
+/**
+ * Snapshot the observable side-effect fields the gate guards. After
+ * calling firePower / activateSkill, comparing snapshots tells us whether
+ * the underlying weapons/skills implementation actually ran.
+ */
+function snapshotState(player) {
+    return {
+        powerCooldown: player.powerCooldown,
+        activeSkillCooldown: player.activeSkillCooldown,
+        novaRingCount: player.novaRings.length,
+        activeMineCount: player.activeMines.length,
+        skillEffectCount: player.activeSkillEffects.size,
+    };
+}
+
+function stateUnchanged(before, after) {
+    return JSON.stringify(before) === JSON.stringify(after);
+}
+
+/** Minimal audio manager shape that weapons.firePower can call into. */
+function mockAudio() {
+    return {
+        playShoot: () => {},
+        playSound: () => true,
+        startLoop: () => {},
+    };
+}
+
+/** Minimal particle pool shape for spawnMuzzleFlare / fireNova. */
+function mockParticlePool() {
+    return {
+        get: () => ({ life: 0, length: 0 }),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests — firePower gate
+// ---------------------------------------------------------------------------
+
+describe('Player.firePower — MP feature-flag gate', () => {
+    let player;
+
+    beforeEach(() => {
+        player = new Player();
+        // Force a deterministic state. `powerCooldown` is 0 from
+        // initializePlayer(), and `novaRings`/`activeMines` start empty.
+        player.powerCooldown = 0;
+        player.novaRings = [];
+        player.activeMines = [];
+    });
+
+    afterEach(() => {
+        clearDriver();
+    });
+
+    test('NOVA_BLAST + online → no state change (suppressed)', () => {
+        setOnline(true);
+        player.activePower = 'NOVA_BLAST';
+        const before = snapshotState(player);
+        player.firePower({}, mockAudio(), mockParticlePool());
+        const after = snapshotState(player);
+        expect(stateUnchanged(before, after)).toBe(true);
+        expect(after.powerCooldown).toBe(0);
+        expect(after.novaRingCount).toBe(0);
+    });
+
+    test('NOVA_BLAST + solo → state changes (unchanged behavior)', () => {
+        setOnline(false);
+        player.activePower = 'NOVA_BLAST';
+        player.firePower({}, mockAudio(), mockParticlePool());
+        // fireNova sets powerCooldown and pushes a ring to novaRings —
+        // both observable signals that the dispatch ran.
+        expect(player.powerCooldown).toBeGreaterThan(0);
+        expect(player.novaRings.length).toBe(1);
+    });
+
+    test('NOVA_BLAST + no driver attached → state changes (early-init safe)', () => {
+        clearDriver();
+        player.activePower = 'NOVA_BLAST';
+        player.firePower({}, mockAudio(), mockParticlePool());
+        expect(player.powerCooldown).toBeGreaterThan(0);
+        expect(player.novaRings.length).toBe(1);
+    });
+
+    test('MINE_LAYER + online → no state change (suppressed)', () => {
+        setOnline(true);
+        player.activePower = 'MINE_LAYER';
+        const before = snapshotState(player);
+        player.firePower({}, mockAudio(), mockParticlePool());
+        const after = snapshotState(player);
+        expect(stateUnchanged(before, after)).toBe(true);
+        expect(after.activeMineCount).toBe(0);
+    });
+
+    test('MINE_LAYER + solo → state changes (mine pushed, cooldown set)', () => {
+        setOnline(false);
+        player.activePower = 'MINE_LAYER';
+        player.firePower({}, mockAudio(), mockParticlePool());
+        expect(player.activeMines.length).toBe(1);
+        expect(player.powerCooldown).toBeGreaterThan(0);
+    });
+
+    test('unknown power id + online → dispatch reached (conservative-permissive)', () => {
+        // An unknown id doesn't match a real branch in weapons.firePower's
+        // switch, so the dispatch falls through to `audioManager.playShoot()`
+        // (the default tail of the function). We use that to assert the
+        // gate let it through — if the gate had suppressed it, playShoot
+        // would never be called.
+        setOnline(true);
+        player.activePower = 'TOTALLY_FAKE_WEAPON_XYZ';
+        let played = false;
+        const audio = { ...mockAudio(), playShoot: () => { played = true; } };
+        player.firePower({}, audio, mockParticlePool());
+        expect(played).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — activateSkill gate
+// ---------------------------------------------------------------------------
+
+describe('Player.activateSkill — MP feature-flag gate', () => {
+    let player;
+
+    beforeEach(() => {
+        player = new Player();
+        // Fresh state; activateSkill checks cooldown > 0 as a precondition.
+        player.activeSkillCooldown = 0;
+        player.activeSkillEffects = new Map();
+    });
+
+    afterEach(() => {
+        clearDriver();
+    });
+
+    test('BULWARK + online → no state change, returns false (suppressed)', () => {
+        setOnline(true);
+        player.activeSkill = 'BULWARK';
+        const before = snapshotState(player);
+        const result = player.activateSkill();
+        const after = snapshotState(player);
+        expect(result).toBe(false);
+        expect(stateUnchanged(before, after)).toBe(true);
+        expect(after.activeSkillCooldown).toBe(0);
+        expect(after.skillEffectCount).toBe(0);
+    });
+
+    test('BULWARK + solo → state changes (cooldown + effect set)', () => {
+        setOnline(false);
+        player.activeSkill = 'BULWARK';
+        const result = player.activateSkill();
+        expect(result).toBe(true);
+        expect(player.activeSkillCooldown).toBeGreaterThan(0);
+        expect(player.activeSkillEffects.has('BULWARK')).toBe(true);
+    });
+
+    test('PHASE_DASH + online → no state change (suppressed)', () => {
+        setOnline(true);
+        player.activeSkill = 'PHASE_DASH';
+        const before = snapshotState(player);
+        const result = player.activateSkill();
+        const after = snapshotState(player);
+        expect(result).toBe(false);
+        expect(stateUnchanged(before, after)).toBe(true);
+    });
+
+    test('PHASE_DASH + solo → state changes', () => {
+        setOnline(false);
+        player.activeSkill = 'PHASE_DASH';
+        const result = player.activateSkill();
+        expect(result).toBe(true);
+        expect(player.activeSkillCooldown).toBeGreaterThan(0);
+        expect(player.activeSkillEffects.has('PHASE_DASH')).toBe(true);
+    });
+
+    test('every defense skill is suppressed when online', () => {
+        const defenseSkills = [
+            'BULWARK',
+            'REPAIR_NANITES',
+            'PHASE_DASH',
+            'DEFLECTOR_ORBS',
+            'EMP_PULSE',
+            'TRACTOR_SHIELD',
+        ];
+        for (const id of defenseSkills) {
+            setOnline(true);
+            const fresh = new Player();
+            fresh.activeSkillCooldown = 0;
+            fresh.activeSkillEffects = new Map();
+            fresh.activeSkill = id;
+            const result = fresh.activateSkill();
+            expect(result).toBe(false);
+            expect(fresh.activeSkillCooldown).toBe(0);
+            expect(fresh.activeSkillEffects.size).toBe(0);
+        }
+    });
+
+    test('unknown skill id + online → dispatch reached, lookup-misses internally', () => {
+        // activateSkill returns false when DEFENSE_SKILLS[skillId] is
+        // undefined — the gate-permissive path lets the dispatch run and
+        // the inner lookup-miss returns false. Observable signal:
+        // `activeSkillCooldown` stays 0 (the dispatch's own early-return
+        // path), but the gate itself did NOT block — we'd only know that
+        // by checking the helper. Cover both paths.
+        setOnline(true);
+        const fresh = new Player();
+        fresh.activeSkill = 'FAKE_SKILL_FOR_TEST';
+        fresh.activeSkillCooldown = 0;
+        fresh.activeSkillEffects = new Map();
+        // Helper returns false for unknown ids → not suppressed by gate.
+        expect(fresh._isAbilitySuppressedByMp('FAKE_SKILL_FOR_TEST')).toBe(false);
+        const result = fresh.activateSkill();
+        // Inner activateSkill returns false because DEFENSE_SKILLS lookup
+        // misses. The contract we care about is: the gate did NOT block.
+        expect(result).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — _isAbilitySuppressedByMp helper directly
+// ---------------------------------------------------------------------------
+
+describe('Player._isAbilitySuppressedByMp — direct helper contract', () => {
+    let player;
+
+    beforeEach(() => {
+        player = new Player();
+    });
+
+    afterEach(() => {
+        clearDriver();
+    });
+
+    test('no driver → returns false (solo init safe)', () => {
+        clearDriver();
+        expect(player._isAbilitySuppressedByMp('NOVA_BLAST')).toBe(false);
+    });
+
+    test('driver offline → returns false for unsafe ids', () => {
+        setOnline(false);
+        expect(player._isAbilitySuppressedByMp('NOVA_BLAST')).toBe(false);
+        expect(player._isAbilitySuppressedByMp('BULWARK')).toBe(false);
+    });
+
+    test('driver online + MP-safe id → returns false', () => {
+        setOnline(true);
+        expect(player._isAbilitySuppressedByMp('PULSE_CANNON')).toBe(false);
+        expect(player._isAbilitySuppressedByMp('STORM_NEEDLES')).toBe(false);
+        expect(player._isAbilitySuppressedByMp('SCATTER_GUN')).toBe(false);
+        expect(player._isAbilitySuppressedByMp('RAIL_DRIVER')).toBe(false);
+    });
+
+    test('driver online + MP-unsafe id → returns true', () => {
+        setOnline(true);
+        expect(player._isAbilitySuppressedByMp('NOVA_BLAST')).toBe(true);
+        expect(player._isAbilitySuppressedByMp('MINE_LAYER')).toBe(true);
+        expect(player._isAbilitySuppressedByMp('LANCE_BEAM')).toBe(true);
+        expect(player._isAbilitySuppressedByMp('BULWARK')).toBe(true);
+        expect(player._isAbilitySuppressedByMp('REPAIR_NANITES')).toBe(true);
+    });
+
+    test('driver online + unknown id → returns false (permissive)', () => {
+        setOnline(true);
+        expect(player._isAbilitySuppressedByMp('UNKNOWN_THING')).toBe(false);
+        expect(player._isAbilitySuppressedByMp('')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
Wires PR #63's \`isAbilityMpSafe(abilityId)\` into the Player class so MP_UNSAFE abilities are suppressed when \`engineDriver.isOnline\`.

Completes the MP-unsafe ability suppression loop: feature-flag config (PR #63) + helper + Player gate. Future slices that flip a power weapon or defense skill to MP_SAFE just add its id to \`MP_SAFE_ABILITIES\` — no other code change needed.

## Gate locations
\`Player.firePower()\` (line 332) and \`Player.activateSkill()\` (line 839) — both at the wrapper-method level, ABOVE the dispatch into \`weapons.firePower\` / \`skills.activateSkill\`. One gate covers all 6 power weapons and all 6 defense skills.

## Helper
\`\`\`js
Player._isAbilitySuppressedByMp(abilityId)
\`\`\`
Reads \`window.engineDriver\` per codebase convention (matches \`js/modules/game-engine.js::_mpDriverIfOnline\` and \`js/engine/mp-frame.js\`). Returns \`false\` when offline; otherwise \`!isAbilityMpSafe(abilityId)\`.

## Behavior
- **Offline (solo)**: no change, all abilities work
- **Online + MP-safe ability**: fires normally
- **Online + MP-unsafe ability**: silent no-op (no cooldown burn, no audio, no entity spawn)
- **Online + unknown ability id**: fires (conservative-permissive default from the scaffold)

## Test plan
- [x] 17 new tests across 3 describe blocks (firePower gate, activateSkill gate, direct helper contract)
- [x] Full unit suite 729/729 across 27 suites
- [x] Tests use observable-state-change assertions (no Jest module mocking, since ESM exports are read-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)