### PR TITLE
mp/server: Rust Lightning Arc collision mirror (final Phase 2.5 mirror)

### DIFF
--- a/server/src/room/collision.rs
+++ b/server/src/room/collision.rs
@@ -405,6 +405,15 @@ pub fn apply_event(
         } => {
             side.damage_asteroid(target_id, damage);
         }
+        CollisionEvent::LightningArcHitEnemy {
+            target_id, damage, ..
+        } => {
+            if let Some(enemy) =
+                state.enemies.iter_mut().find(|e| e.id.0 as u32 == target_id)
+            {
+                enemy.hp -= damage;
+            }
+        }
     }
 }
 

--- a/server/src/sim/collision.rs
+++ b/server/src/sim/collision.rs
@@ -667,6 +667,36 @@ pub enum CollisionEvent {
         knock_x: f32,
         knock_y: f32,
     },
+    /// Mirrors `{ type: 'lightning_arc_hit_enemy', ... }` in `js/sim/collision.js`.
+    ///
+    /// Lightning Arc is a continuous single-target tether power weapon
+    /// (the 5th and final power weapon Rust mirror). The pure step emits
+    /// AT MOST ONE event per call — the nearest active enemy within
+    /// `range`. There is intentionally NO asteroid variant: Lightning Arc
+    /// targets enemies only (mirrors the player-facing semantics of the
+    /// live weapon — "fry the closest priority target", not terrain-clearing).
+    ///
+    /// Field-count rationale (3 non-type fields, 4 total with the tag):
+    ///   - `target_id` is the enemy id of the latched-on target.
+    ///   - `damage` flows verbatim from `CollisionLightningArc.damage` so
+    ///     the wrapper does NOT have to look up the arc spec again. The
+    ///     wrapper pre-applies AMPLIFIER stack scaling (× (1 + stacks *
+    ///     0.2)) before passing the spec in — the pure step does NOT
+    ///     re-scale here.
+    ///   - `distance_to_target` is the geographic distance from the arc
+    ///     origin to the enemy's center. The wrapper uses this for
+    ///     impact-spark placement, audio attenuation, particle-density
+    ///     tuning, or a debug overlay.
+    ///
+    /// NO knockback fields — Lightning Arc's TETHER_PUSH is wrapper-side
+    /// because the direction depends on the LATCHED target (which is
+    /// wrapper state) and the wrapper already has both endpoints (origin
+    /// + target.x/y) at the application site.
+    LightningArcHitEnemy {
+        target_id: u32,
+        damage: f32,
+        distance_to_target: f32,
+    },
 }
 
 /// Which kind of target tripped a mine. Mirrors the JS string-tagged
@@ -3197,5 +3227,249 @@ pub fn detect_missile_salvo_hits(
                 break;
             }
         }
+    }
+}
+
+// =====================================================================
+// LIGHTNING ARC — continuous single-target tether (enemies only)
+// =====================================================================
+//
+// Rust mirror of `js/sim/collision.js::detectLightningArcHits` (PR #72).
+// Lightning Arc is the 5th and final power-weapon collision pair after
+// Nova (PR #44/#56), Mine (PR #57/#65), Lance (PR #64/#69), and Missile
+// Salvo (PR #68/#74).
+//
+// Each tick while active, the pure step searches the enemy list and
+// emits AT MOST ONE `LightningArcHitEnemy` event for the NEAREST in-range
+// enemy. The arc never targets asteroids — Lightning Arc emits only
+// enemy hits in the pure step (mirrors the player-facing semantics of
+// the live weapon: a "fry the closest priority target" tool, not a
+// terrain-clearing tool).
+//
+// ─── Pure-step contract: aggressively simplified ─────────────────────
+//
+// The wrapper / parent module is responsible for everything stateful:
+//   - Whether the arc is firing this tick (`arc.active` toggle)
+//   - Target-latch persistence across frames (`p.lightningArcTarget`)
+//   - AMPLIFIER stack damage scaling (× (1 + stacks * 0.2) — wrapper
+//     pre-applies before passing to this pure step)
+//   - ARC_OVERCHARGE range/damage multipliers + aim-cursor target priority
+//     (wrapper pre-applies; the pure step picks geographic nearest)
+//   - Bullet-flavored powerup arc damage bumps (RAPID, MULTI, BIG,
+//     PIERCING, HOMING, EXPLOSIVE — wrapper pre-applies)
+//   - Per-frame audio throttling (sustained beam SFX)
+//   - Particle FX (lightning bolt path drawing + impact sparks)
+//   - `damageEnemy()` upgrade-aware damage application
+//   - Knockback / TETHER_PUSH impulse on the target
+//   - Legacy `p.lightningChains[]` chain logic (wrapper-only; the pure
+//     step does NOT participate in chain hops)
+//   - Defensive `p.lightningArcTarget = null` cleanup when no target
+//     is in range (emerges naturally from "zero events emitted")
+//
+// ─── Single-target nearest-wins semantics ────────────────────────────
+//
+// The pure step iterates enemies in array order and tracks the one
+// with the smallest distance whose distance is `<= arc.range`. On a
+// tie (two enemies at exactly the same distance), the FIRST iterated
+// one wins. This is deterministic given the input order — the wrapper
+// owns the iteration source (the enemy active-objects array). The
+// tracker uses STRICT-LESS-THAN to update so a later-iterated enemy at
+// identical distance does NOT displace the earlier one.
+//
+// ─── Boundary semantics: INCLUSIVE ───────────────────────────────────
+//
+// `dist <= range` — an enemy at exactly `range` distance is HIT.
+// Mirrors the JS pure step's `if (dist > range) continue` gate (a
+// `>` test means equality falls through to the in-range branch) and
+// the legacy `dxp * dxp + dyp * dyp > range * range` test (the
+// `continue` runs only when STRICTLY greater than the squared range,
+// so equality is "still inside"). Two boundary-pin tests in
+// `parity_collision.rs` guard against drift to `<` (strict).
+//
+// ─── Skip-gates ──────────────────────────────────────────────────────
+//
+//   Enemies:
+//     - Inactive          (`!enemy.active`)
+//     - Warping           (`enemy.warping`)
+//     - Mid death-flash   (`enemy.death_flash > 0`)
+//
+// NOTE: the legacy enemy loop (collision-system.js:1223) skips
+// `!active` and `_deathFlash > 0` but does NOT explicitly check
+// `warping`. The pure step adds the warping gate for consistency with
+// every other pair in this file — mid-spawn-warp enemies shouldn't
+// take a continuous-tether hit. The Rust mirror follows the JS pure
+// step exactly.
+//
+// ─── What the pure step does NOT do (stays wrapper-only) ─────────────
+//
+//   - Asteroid targeting — Lightning Arc emits only `_enemy` events.
+//   - Apply damage (`damageEnemy(enemy, event.damage)` is wrapper-side).
+//   - Apply knockback (TETHER_PUSH is wrapper-owned because the
+//     direction depends on the LATCHED target).
+//   - Mutate the arc's `active` flag (wrapper toggles).
+//   - Throttle audio / spawn lightning-bolt particle paths.
+//   - Defensive `p.lightningArcTarget = null` cleanup on no-hit ticks.
+//   - Aim-cursor target priority (legacy nearest-to-aim selection is a
+//     wrapper concern; the pure step uses geographic nearest).
+
+/// Lightning Arc specification — the origin + range + flat damage.
+///
+/// Mirrors the JS shape `{ originX, originY, range, damage }` passed
+/// into `detectLightningArcHits`. The wrapper constructs this each tick
+/// from the player's live state:
+///   - `origin_x` / `origin_y`: world coords (typically the player position).
+///   - `range`: search radius (scaled for ARC_OVERCHARGE by the wrapper).
+///   - `damage`: flat damage emitted in the event (pre-scaled by the
+///     wrapper for AMPLIFIER stacks + ARC_OVERCHARGE + bullet-flavored
+///     powerup stacks).
+///
+/// `damage` is FLAT — the single emitted event carries `arc.damage`
+/// verbatim. AMPLIFIER stack scaling (× (1 + stacks * 0.2)) is
+/// pre-applied by the wrapper; the pure step copies the value through
+/// with no further modification.
+///
+/// Defensive contract: a `range < 0` arc hits nothing (no enemy can
+/// satisfy `dist <= range` for negative range since `dist >= 0`).
+/// A `range == 0` arc may hit a point-blank enemy at the exact origin
+/// (`dist == 0 == range`, INCLUSIVE boundary). The pure step neither
+/// clamps nor validates damage values — negative damage produces a
+/// no-op-ish "heal" event the wrapper can ignore.
+#[derive(Debug, Clone, Copy)]
+pub struct CollisionLightningArc {
+    pub origin_x: f32,
+    pub origin_y: f32,
+    /// Search radius for the nearest-enemy scan. Boundary is INCLUSIVE
+    /// — an enemy at exactly `range` distance is hit.
+    pub range: f32,
+    /// Flat damage emitted in the event. AMPLIFIER stack scaling
+    /// (× (1 + stacks * 0.2)) is pre-applied by the caller.
+    pub damage: f32,
+}
+
+impl CollisionLightningArc {
+    /// Construct a fresh arc at the origin with the live-game default
+    /// range (200) and per-frame flat damage (0.05). Test convenience.
+    pub fn fresh() -> Self {
+        Self {
+            origin_x: 0.0,
+            origin_y: 0.0,
+            range: 200.0,
+            damage: 0.05,
+        }
+    }
+}
+
+// ─── Lightning Arc hit detection ─────────────────────────────────────
+
+/// Detect Lightning Arc hit for one tick.
+///
+/// Pure step: scans `enemies` for the nearest active enemy within
+/// `arc.range` of `(arc.origin_x, arc.origin_y)` and emits ONE
+/// `LightningArcHitEnemy` event for that enemy. If no enemy is in
+/// range (or the enemy list is empty), emits zero events. Does NOT
+/// mutate enemies — every effect (HP loss, knockback, FX, audio) is
+/// reported in the event payload for the wrapper to apply downstream.
+///
+/// Geometry:
+///   For each enemy with center `T = (ex, ey)`:
+///     dist = sqrt((ex - origin_x)² + (ey - origin_y)²)
+///   Hit iff:
+///     dist <= arc.range
+///   Tracks the smallest-dist hit across the scan and emits at end.
+///   JS line ref: `js/sim/collision.js:3354–3370`.
+///
+/// Damage model:
+///   FLAT — the single emitted event carries `arc.damage` verbatim.
+///   AMPLIFIER stack scaling (× (1 + stacks * 0.2)) is pre-applied by
+///   the caller before invoking this function. JS line ref:
+///   `js/sim/collision.js:3251–3254`.
+///
+/// Single-target nearest-wins:
+///   Iterates enemies in slice order and tracks the smallest distance
+///   with STRICT-LESS-THAN updates. On tied distance, the FIRST
+///   iterated enemy wins (preserves deterministic outcome given
+///   wrapper-provided input order). JS line ref:
+///   `js/sim/collision.js:3363–3369`.
+///
+/// Boundary semantic:
+///   INCLUSIVE — `dist <= arc.range`. An enemy at exactly `range`
+///   distance is HIT. Mirrors the JS pure step's `if (dist > range)
+///   continue` gate (the `>` means equality falls through). JS line
+///   ref: `js/sim/collision.js:3360–3361`.
+///
+/// Skip-gates (no event emitted):
+///   Enemies:
+///     - Inactive          (`!enemy.active`)
+///     - Warping           (`enemy.warping`)
+///     - Mid death-flash   (`enemy.death_flash > 0`)
+///
+/// Defensive guards:
+///   - Empty enemy slice → no events.
+///   - `range < 0` → no events (no `dist >= 0` can satisfy `<= negative`).
+///
+/// JS line refs: `js/sim/collision.js:3324–3380`.
+pub fn detect_lightning_arc_hits(
+    arc: &CollisionLightningArc,
+    enemies: &[CollisionEnemy],
+    _ctx: &CollisionContext,
+    events: &mut Vec<CollisionEvent>,
+) {
+    // Defensive: empty enemy slice → nothing to detect.
+    // (JS collision.js:3329 — `if (!enemies || enemies.length === 0) return`).
+    if enemies.is_empty() {
+        return;
+    }
+
+    let origin_x = arc.origin_x;
+    let origin_y = arc.origin_y;
+    let range = arc.range;
+    let damage = arc.damage;
+
+    // Track the nearest in-range enemy across the scan. First iterated
+    // wins on tied distance — deterministic given the wrapper's input
+    // order. STRICT-LESS-THAN update preserves "first wins on tie".
+    // (JS collision.js:3339–3340).
+    let mut best_enemy_id: Option<u32> = None;
+    let mut best_dist: f32 = f32::INFINITY;
+
+    for enemy in enemies.iter() {
+        // Skip-gates: inactive / warping / death-flash.
+        // (JS collision.js:3344–3352).
+        if !enemy.active {
+            continue;
+        }
+        if enemy.warping {
+            continue;
+        }
+        if enemy.death_flash > 0 {
+            continue;
+        }
+
+        let dx = enemy.x - origin_x;
+        let dy = enemy.y - origin_y;
+        // `hypot`-equivalent sqrt feeds directly into the emitted
+        // `distance_to_target` field. INCLUSIVE boundary (`<= range`).
+        // (JS collision.js:3360 — `if (dist > range) continue`).
+        let dist = (dx * dx + dy * dy).sqrt();
+        if dist > range {
+            continue;
+        }
+
+        // Strict-less-than: a later enemy at identical distance does
+        // NOT displace the earlier-iterated one. Preserves "first
+        // iterated wins on tie" semantics.
+        // (JS collision.js:3366 — `if (dist < bestDist)`).
+        if dist < best_dist {
+            best_dist = dist;
+            best_enemy_id = Some(enemy.id);
+        }
+    }
+
+    if let Some(target_id) = best_enemy_id {
+        events.push(CollisionEvent::LightningArcHitEnemy {
+            target_id,
+            damage,
+            distance_to_target: best_dist,
+        });
     }
 }

--- a/server/tests/parity_collision.rs
+++ b/server/tests/parity_collision.rs
@@ -40,10 +40,11 @@
 
 use rainboids_server::sim::collision::{
     detect_bullet_asteroid_hits, detect_bullet_enemy_hits, detect_enemy_asteroid_hits,
-    detect_lance_beam_hits, detect_mine_hits, detect_missile_salvo_hits, detect_nova_blast_hits,
-    detect_player_asteroid_hits, detect_player_drop_pickups, detect_player_enemy_bullet_hits,
-    detect_player_enemy_hits, CollisionAsteroid, CollisionBullet, CollisionContext, CollisionDrop,
-    CollisionEnemy, CollisionEnemyBullet, CollisionEvent, CollisionLance, CollisionMine,
+    detect_lance_beam_hits, detect_lightning_arc_hits, detect_mine_hits,
+    detect_missile_salvo_hits, detect_nova_blast_hits, detect_player_asteroid_hits,
+    detect_player_drop_pickups, detect_player_enemy_bullet_hits, detect_player_enemy_hits,
+    CollisionAsteroid, CollisionBullet, CollisionContext, CollisionDrop, CollisionEnemy,
+    CollisionEnemyBullet, CollisionEvent, CollisionLance, CollisionLightningArc, CollisionMine,
     CollisionMissile, CollisionPlayer, NovaBlast, TriggerKind, ASTEROID_ENEMY_PUSH,
     ASTEROID_KNOCKBACK_MULTIPLIER, BOUNCE_FORCE_MULTIPLIER, BOUNCE_RESTITUTION,
     ENEMY_ASTEROID_PUSH, MISSILE_DEFAULT_RADIUS, MISSILE_KNOCK, OVERLAP_PUSH_FORCE,
@@ -3513,4 +3514,376 @@ fn missile_boundary_strict_less_than() {
     let mut events = Vec::new();
     detect_missile_salvo_hits(&missiles, &enemies, &asteroids, &ctx, &mut events);
     assert_eq!(events.len(), 0, "dist == sum-of-radii → MISS (strict <)");
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Lightning Arc fixtures (dispatch 11) — single-target nearest-wins.
+//
+// Mirrors `js/sim/collision.js::detectLightningArcHits` (PR #72). The
+// pure step picks the nearest active enemy within `arc.range` and emits
+// AT MOST ONE `LightningArcHitEnemy` event. There is intentionally NO
+// asteroid variant — Lightning Arc emits enemy hits only.
+//
+// Tolerance: 0.01 (linear physics, no compounded multiplication).
+// ═════════════════════════════════════════════════════════════════════
+
+/// Build a default Lightning Arc spec at origin (0, 0) with range 100,
+/// damage 5. Tests override fields post-construction.
+fn make_arc(origin_x: f32, origin_y: f32, range: f32, damage: f32) -> CollisionLightningArc {
+    CollisionLightningArc {
+        origin_x,
+        origin_y,
+        range,
+        damage,
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — single enemy in range → 1 event with correct target id.
+//
+// Arc at (0, 0), range 100. Enemy at (50, 0) with default radius 18
+// (radius is NOT consulted — Lightning Arc uses point-to-point distance
+// from origin to enemy center). dist = 50 <= 100 → HIT.
+// ---------------------------------------------------------------------
+#[test]
+fn lightning_single_enemy_in_range_hit() {
+    let arc = make_arc(0.0, 0.0, 100.0, 5.0);
+    let enemies = vec![make_enemy(101, 50.0, 0.0)];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_lightning_arc_hits(&arc, &enemies, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1, "single in-range enemy → 1 event");
+    match events[0] {
+        CollisionEvent::LightningArcHitEnemy {
+            target_id,
+            damage,
+            distance_to_target,
+        } => {
+            assert_eq!(target_id, 101, "target_id matches the lone enemy");
+            approx_eq(damage, 5.0, "damage flows through verbatim");
+            approx_eq(distance_to_target, 50.0, "distance == 50");
+        }
+        ev => panic!("expected LightningArcHitEnemy, got {:?}", ev),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — single enemy out of range → 0 events.
+//
+// Arc at (0, 0), range 50. Enemy at (100, 0). dist = 100 > 50 → MISS.
+// ---------------------------------------------------------------------
+#[test]
+fn lightning_single_enemy_out_of_range_miss() {
+    let arc = make_arc(0.0, 0.0, 50.0, 5.0);
+    let enemies = vec![make_enemy(101, 100.0, 0.0)];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_lightning_arc_hits(&arc, &enemies, &ctx, &mut events);
+
+    assert_eq!(events.len(), 0, "out-of-range enemy → 0 events");
+}
+
+// ---------------------------------------------------------------------
+// Fixture — multiple enemies in range, nearest wins.
+//
+// Arc at (0, 0), range 200. Enemy 101 at (150, 0) [dist 150]; enemy 102
+// at (50, 0) [dist 50]. Both in range; the closer (102) wins, regardless
+// of slice order.
+// ---------------------------------------------------------------------
+#[test]
+fn lightning_multiple_enemies_nearest_wins() {
+    let arc = make_arc(0.0, 0.0, 200.0, 5.0);
+    // Far enemy first, near enemy second — verifies that the tracker
+    // updates strictly on smaller distance, not on iteration position.
+    let enemies = vec![
+        make_enemy(101, 150.0, 0.0),
+        make_enemy(102, 50.0, 0.0),
+    ];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_lightning_arc_hits(&arc, &enemies, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1, "single-target weapon → at most 1 event");
+    match events[0] {
+        CollisionEvent::LightningArcHitEnemy {
+            target_id,
+            distance_to_target,
+            ..
+        } => {
+            assert_eq!(target_id, 102, "nearest enemy (id 102) wins");
+            approx_eq(distance_to_target, 50.0, "distance_to_target == 50");
+        }
+        ev => panic!("expected LightningArcHitEnemy, got {:?}", ev),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — tied distance, first iterated wins.
+//
+// Arc at (0, 0), range 100. Two enemies at exactly the same distance
+// (one at (50, 0), one at (0, 50) — both dist = 50). The first-iterated
+// (101) wins because the tracker uses STRICT-LESS-THAN updates: a later
+// enemy at IDENTICAL distance does NOT displace the earlier one.
+//
+// This is the deterministic tie-break the JS pure step relies on. The
+// wrapper owns the iteration order (active-objects array order), so
+// this fixture pins the contract.
+// ---------------------------------------------------------------------
+#[test]
+fn lightning_tied_distance_first_iterated_wins() {
+    let arc = make_arc(0.0, 0.0, 100.0, 5.0);
+    let enemies = vec![
+        make_enemy(101, 50.0, 0.0), // first iterated, dist = 50
+        make_enemy(102, 0.0, 50.0), // second iterated, dist = 50 (tied)
+    ];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_lightning_arc_hits(&arc, &enemies, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1, "single-target weapon → at most 1 event");
+    match events[0] {
+        CollisionEvent::LightningArcHitEnemy { target_id, .. } => {
+            assert_eq!(
+                target_id, 101,
+                "tied distance → first iterated (101) wins, not 102"
+            );
+        }
+        ev => panic!("expected LightningArcHitEnemy, got {:?}", ev),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — arc NOT at origin: distance measured from arc origin.
+//
+// Arc at (100, 100), range 20. Enemy at (110, 100). dist = 10 < 20 →
+// HIT. Verifies the detector uses `arc.origin_*` as the distance basis,
+// not the world origin.
+// ---------------------------------------------------------------------
+#[test]
+fn lightning_non_origin_arc() {
+    let arc = make_arc(100.0, 100.0, 20.0, 5.0);
+    let enemies = vec![make_enemy(101, 110.0, 100.0)];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_lightning_arc_hits(&arc, &enemies, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1, "non-origin arc + in-range enemy → 1 event");
+    match events[0] {
+        CollisionEvent::LightningArcHitEnemy {
+            target_id,
+            distance_to_target,
+            ..
+        } => {
+            assert_eq!(target_id, 101);
+            approx_eq(
+                distance_to_target,
+                10.0,
+                "distance is measured from arc origin (100, 100), not world origin",
+            );
+        }
+        ev => panic!("expected LightningArcHitEnemy, got {:?}", ev),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — inactive enemy is skipped.
+//
+// Arc at (0, 0), range 100. Enemy at (50, 0) with `active = false`.
+// Expect 0 events.
+// ---------------------------------------------------------------------
+#[test]
+fn lightning_skip_gates_inactive() {
+    let arc = make_arc(0.0, 0.0, 100.0, 5.0);
+    let mut enemy = make_enemy(101, 50.0, 0.0);
+    enemy.active = false;
+    let enemies = vec![enemy];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_lightning_arc_hits(&arc, &enemies, &ctx, &mut events);
+
+    assert_eq!(events.len(), 0, "!active enemy → skipped");
+}
+
+// ---------------------------------------------------------------------
+// Fixture — warping enemy is skipped.
+//
+// Arc at (0, 0), range 100. Enemy at (50, 0) with `warping = true`.
+// Expect 0 events. The Rust mirror follows the JS pure step in adding
+// the warping gate even though the legacy code does not check it —
+// mid-spawn-warp enemies shouldn't take a continuous-tether hit.
+// ---------------------------------------------------------------------
+#[test]
+fn lightning_skip_gates_warping() {
+    let arc = make_arc(0.0, 0.0, 100.0, 5.0);
+    let mut enemy = make_enemy(101, 50.0, 0.0);
+    enemy.warping = true;
+    let enemies = vec![enemy];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_lightning_arc_hits(&arc, &enemies, &ctx, &mut events);
+
+    assert_eq!(events.len(), 0, "warping enemy → skipped");
+}
+
+// ---------------------------------------------------------------------
+// Fixture — enemy mid death-flash is skipped.
+//
+// Arc at (0, 0), range 100. Enemy at (50, 0) with `death_flash = 1`
+// (> 0). Expect 0 events. Mirrors the legacy `_deathFlash > 0`
+// continue.
+// ---------------------------------------------------------------------
+#[test]
+fn lightning_skip_gates_deathflash() {
+    let arc = make_arc(0.0, 0.0, 100.0, 5.0);
+    let mut enemy = make_enemy(101, 50.0, 0.0);
+    enemy.death_flash = 1;
+    let enemies = vec![enemy];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_lightning_arc_hits(&arc, &enemies, &ctx, &mut events);
+
+    assert_eq!(events.len(), 0, "death_flash > 0 enemy → skipped");
+}
+
+// ---------------------------------------------------------------------
+// Fixture — boundary INCLUSIVE: dist == range → HIT.
+//
+// Arc at (0, 0), range 100. Enemy at (100, 0). dist = 100 == range
+// → HIT (the JS pure step uses `if (dist > range) continue` so
+// equality falls through). The Rust mirror MUST match this — guard
+// against drift to strict `<`.
+// ---------------------------------------------------------------------
+#[test]
+fn lightning_boundary_inclusive_at_range() {
+    let arc = make_arc(0.0, 0.0, 100.0, 5.0);
+    let enemies = vec![make_enemy(101, 100.0, 0.0)];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_lightning_arc_hits(&arc, &enemies, &ctx, &mut events);
+
+    assert_eq!(
+        events.len(),
+        1,
+        "dist == range → HIT (INCLUSIVE boundary)"
+    );
+    match events[0] {
+        CollisionEvent::LightningArcHitEnemy {
+            distance_to_target,
+            ..
+        } => {
+            approx_eq(distance_to_target, 100.0, "distance == range");
+        }
+        ev => panic!("expected LightningArcHitEnemy, got {:?}", ev),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — boundary: dist just past range → MISS.
+//
+// Arc at (0, 0), range 100. Enemy at (101, 0). dist = 101 > 100
+// → MISS. Pins the gate as `dist > range` (strict greater-than for the
+// continue).
+// ---------------------------------------------------------------------
+#[test]
+fn lightning_boundary_just_past_range_miss() {
+    let arc = make_arc(0.0, 0.0, 100.0, 5.0);
+    // 101 > 100 → just past range. Use a clear margin so f32 quirks at
+    // the boundary can't accidentally flip the result.
+    let enemies = vec![make_enemy(101, 101.0, 0.0)];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_lightning_arc_hits(&arc, &enemies, &ctx, &mut events);
+
+    assert_eq!(events.len(), 0, "dist > range → MISS");
+}
+
+// ---------------------------------------------------------------------
+// Fixture — damage flows verbatim into the event payload.
+//
+// Arc damage 12.5 (representative of post-AMPLIFIER pre-scaled value).
+// The pure step does NOT re-scale — the event's `damage` field is the
+// exact spec value.
+// ---------------------------------------------------------------------
+#[test]
+fn lightning_damage_passthrough() {
+    let arc = make_arc(0.0, 0.0, 100.0, 12.5);
+    let enemies = vec![make_enemy(101, 50.0, 0.0)];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_lightning_arc_hits(&arc, &enemies, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1);
+    match events[0] {
+        CollisionEvent::LightningArcHitEnemy { damage, .. } => {
+            approx_eq(damage, 12.5, "damage flows through with no re-scaling");
+        }
+        ev => panic!("expected LightningArcHitEnemy, got {:?}", ev),
+    }
+
+    // Second pass: damage = 0.05 (live-game per-frame flat damage default).
+    let arc2 = make_arc(0.0, 0.0, 100.0, 0.05);
+    let mut events2 = Vec::new();
+    detect_lightning_arc_hits(&arc2, &enemies, &ctx, &mut events2);
+    assert_eq!(events2.len(), 1);
+    match events2[0] {
+        CollisionEvent::LightningArcHitEnemy { damage, .. } => {
+            approx_eq(damage, 0.05, "small-damage variant flows through");
+        }
+        ev => panic!("expected LightningArcHitEnemy, got {:?}", ev),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fixture — empty enemy list → no events, no crash.
+// ---------------------------------------------------------------------
+#[test]
+fn lightning_empty_enemies() {
+    let arc = make_arc(0.0, 0.0, 100.0, 5.0);
+    let enemies: Vec<CollisionEnemy> = vec![];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_lightning_arc_hits(&arc, &enemies, &ctx, &mut events);
+
+    assert_eq!(events.len(), 0, "empty enemy list → no events");
+}
+
+// ---------------------------------------------------------------------
+// Fixture — skip-gated enemies don't participate in nearest tracking.
+//
+// Three enemies: 101 inactive (the geographically nearest), 102 warping,
+// 103 active and in range. The detector should pick 103 because the
+// first two are gated out — they NEVER update the tracker.
+//
+// This guards against a subtle bug where a skipped enemy's distance
+// (which never gets computed) might still influence the result.
+// ---------------------------------------------------------------------
+#[test]
+fn lightning_skip_gates_do_not_block_other_enemies() {
+    let arc = make_arc(0.0, 0.0, 200.0, 5.0);
+    let mut e_inactive = make_enemy(101, 10.0, 0.0); // closest, but inactive
+    e_inactive.active = false;
+    let mut e_warping = make_enemy(102, 20.0, 0.0); // also close, but warping
+    e_warping.warping = true;
+    let e_active = make_enemy(103, 80.0, 0.0); // valid pick at dist 80
+    let enemies = vec![e_inactive, e_warping, e_active];
+    let ctx = CollisionContext;
+    let mut events = Vec::new();
+    detect_lightning_arc_hits(&arc, &enemies, &ctx, &mut events);
+
+    assert_eq!(events.len(), 1, "one valid enemy in range → 1 event");
+    match events[0] {
+        CollisionEvent::LightningArcHitEnemy {
+            target_id,
+            distance_to_target,
+            ..
+        } => {
+            assert_eq!(
+                target_id, 103,
+                "gated enemies (101, 102) are skipped → 103 wins"
+            );
+            approx_eq(distance_to_target, 80.0, "distance reflects 103's position");
+        }
+        ev => panic!("expected LightningArcHitEnemy, got {:?}", ev),
+    }
 }


### PR DESCRIPTION
## Summary
Mirrors PR #72's \`detectLightningArcHits\` into Rust. **5th and FINAL** power-weapon Rust mirror after Nova (#73), Mine (#65), Lance Beam (#69), and Missile Salvo (#74).

After this lands, **Phase 2.5 has full parity**: 5/5 JS pairs + 5/5 Rust mirrors for all power weapons.

Replaces PR #77 (which had a stale base after #74 merged).

## New
- \`CollisionLightningArc { origin_x, origin_y, range, damage }\`
- \`CollisionEvent::LightningArcHitEnemy { target_id, damage, distance_to_target }\` — single-target, single-event-emitter (no asteroid variant)
- \`pub fn detect_lightning_arc_hits(arc, enemies, _ctx, events)\`
- \`apply_event\` arm in \`server/src/room/collision.rs\` (HP decrement on \`state.enemies\`)

## Algorithm (matches JS exactly)
- Track \`best_enemy_id: Option<u32>\`, \`best_dist = f32::INFINITY\`
- Skip gates: \`!active\`, \`warping\`, \`death_flash > 0\`
- INCLUSIVE boundary (\`dist <= range\` → HIT)
- Strict-less-than tracker update preserves first-iterated-wins on ties
- Emits zero or one event per call

## Divergence from legacy (documented inline)
Pure step adds \`warping\` skip-gate (legacy \`checkLightningCollisions\` doesn't). Mid-spawn-warp enemies shouldn't take a continuous-tether hit. Consistent with every other pair in this file.

## Test plan
- [x] 13 new parity fixtures (70 → 83 passing)
- [x] 7/7 collision_drain still passing
- [x] Build clean, zero warnings
- [x] Boundary INCLUSIVE pinned (dist == range → HIT; dist == range+eps → MISS)
- [x] Tied-distance first-wins pinned
- [x] Skip-gates don't block subsequent enemies in iteration pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)