### PR TITLE
mp/server: bullet GameState plumbing + drain wiring

### DIFF
--- a/server/src/room/collision.rs
+++ b/server/src/room/collision.rs
@@ -177,10 +177,11 @@ pub fn drain(state: &mut GameState, side: &mut CollisionSideState, wire_events: 
         apply_event(event, state, side, wire_events);
     }
 
-    // ── Despawn pass: remove asteroids/drops/enemies marked dead ──
+    // ── Despawn pass: remove asteroids/drops/enemies/bullets marked dead ──
     despawn_dead_asteroids(state, side, wire_events);
     despawn_dead_enemies(state, wire_events);
     despawn_consumed_drops(state, side);
+    despawn_dead_bullets(state, side);
 }
 
 /// Dispatch a single `CollisionEvent` to a `GameState` mutation. Each variant
@@ -208,10 +209,19 @@ pub fn apply_event(
             // Apply asteroid HP loss. Despawn pass will prune at hp <= 0.
             side.damage_asteroid(asteroid_id, damage);
 
-            // Bullet despawn — emit wire event so clients can release the FX.
+            // Bullet despawn — emit wire event so clients can release the FX,
+            // AND mark the bullet inactive in `state.bullets` so the sim-side
+            // collection reflects the despawn. The detect-step
+            // (sim/collision.rs::detect_bullet_asteroid_hits) only sets
+            // `bullet_will_despawn` in the event payload; propagating that
+            // back here keeps `state.bullets` in sync so the next-tick
+            // `build_bullets` filters it out before the pierce-budget guard
+            // misfires.
+            //
             // BulletId is a wire-format newtype around u64; the pure step
             // narrowed to u32 for storage. Restore by widening.
             if bullet_will_despawn {
+                deactivate_bullet(state, bullet_id);
                 wire_events.push(GameEvent::BulletDespawn {
                     id: crate::protocol::BulletId(bullet_id as u64),
                     reason: crate::protocol::DespawnReason::Hit,
@@ -247,7 +257,10 @@ pub fn apply_event(
             if let Some(enemy) = state.enemies.iter_mut().find(|e| e.id.0 as u32 == enemy_id) {
                 enemy.hp -= damage;
             }
+            // Mark the bullet inactive in `state.bullets` (parallel to the
+            // BulletHitAsteroid arm above; same rationale).
             if bullet_will_despawn {
+                deactivate_bullet(state, bullet_id);
                 wire_events.push(GameEvent::BulletDespawn {
                     id: crate::protocol::BulletId(bullet_id as u64),
                     reason: crate::protocol::DespawnReason::Hit,
@@ -426,12 +439,59 @@ pub fn apply_event(
 // produce empty Vecs today; subsequent PRs add the field plumbing as
 // each entity gets wired into the snapshot.
 
-fn build_bullets(_state: &GameState, _side: &mut CollisionSideState) -> Vec<CollisionBullet> {
-    // No player-bullet collection on GameState yet — the simulate_tick
-    // bullet update is stubbed in `sim/bullet.rs`. When bullets get
-    // their wire field set, this builder joins it with the
-    // side-table's pierced sets.
-    Vec::new()
+fn build_bullets(state: &GameState, side: &mut CollisionSideState) -> Vec<CollisionBullet> {
+    // Join the authoritative `state.bullets` collection with the wrapper's
+    // per-bullet side-state (pierced id sets + pierce counter carried
+    // across ticks). Inactive bullets are filtered out — the detect-steps
+    // skip them anyway, but excluding them up-front saves a per-pair
+    // active-guard and avoids leaking despawn-pending entities into the
+    // collision view.
+    state
+        .bullets
+        .iter()
+        .filter(|b| b.active)
+        .map(|b| {
+            let id = b.id.0;
+            // Carry persistent per-bullet pierce state across ticks.
+            // Bullets missing from these maps start fresh (empty set /
+            // zero counter) — matches the JS lazy-allocation semantics.
+            let pierced_asteroid_ids = side
+                .bullet_pierced_asteroid_ids
+                .get(&id)
+                .cloned()
+                .unwrap_or_default();
+            let pierced_enemy_ids = side
+                .bullet_pierced_enemy_ids
+                .get(&id)
+                .cloned()
+                .unwrap_or_default();
+            let pierced_enemies = side
+                .bullet_pierced_count
+                .get(&id)
+                .copied()
+                .unwrap_or(0);
+
+            CollisionBullet {
+                id,
+                x: b.x,
+                y: b.y,
+                vx: b.vx,
+                vy: b.vy,
+                radius: b.radius,
+                damage: b.damage,
+                // `BulletState.pierce_count: u32` → `CollisionBullet.piercing: i32`.
+                // `u32 as i32` is lossless for the practical range (we never
+                // spawn 2 billion-pierce bullets). See `CollisionBullet`
+                // semantics: 0 = non-piercing, N>0 = budget of additional
+                // targets before despawn.
+                piercing: b.pierce_count as i32,
+                pierced_enemies,
+                active: b.active,
+                pierced_asteroid_ids,
+                pierced_enemy_ids,
+            }
+        })
+        .collect()
 }
 
 fn build_asteroids(state: &GameState, side: &CollisionSideState) -> Vec<CollisionAsteroid> {
@@ -591,4 +651,42 @@ fn despawn_consumed_drops(state: &mut GameState, side: &mut CollisionSideState) 
     let live_ids: std::collections::HashSet<u32> =
         state.drops.iter().map(|d| d.id.0 as u32).collect();
     side.drop_active.retain(|id, _| live_ids.contains(id));
+}
+
+/// Mark the bullet with `id_u32` (the narrowed-to-u32 id used by the
+/// detect-step events) as `!active` in `state.bullets`. No-op if the
+/// bullet isn't in the collection — tests that drive `apply_event`
+/// directly without populating `state.bullets` rely on this no-op
+/// behavior.
+fn deactivate_bullet(state: &mut GameState, id_u32: u32) {
+    if let Some(b) = state.bullets.iter_mut().find(|b| b.id.0 == id_u32) {
+        b.active = false;
+    }
+}
+
+/// Drain dead bullets from `GameState.bullets` and clean up the per-bullet
+/// side-state (pierced id sets + pierce counter). Pragmatic v1: the drain
+/// (this function) prunes inactive bullets at the tail of the collision
+/// pass. Once bullets get a dedicated sim-side update loop, this can move
+/// alongside `sim::bullet::update_bullets`.
+///
+/// No wire event is emitted here — the `BulletDespawn` for collision hits
+/// is emitted in `apply_event`, and lifetime / off-screen despawns are
+/// emitted as `BulletEvent` values by `update_bullets` (which the
+/// wrapper translates separately). This function is the storage-side
+/// cleanup pass only.
+fn despawn_dead_bullets(state: &mut GameState, side: &mut CollisionSideState) {
+    // Retain only active bullets in the storage Vec.
+    state.bullets.retain(|b| b.active);
+    // Side-table cleanup: drop entries for bullets that no longer exist
+    // in `state.bullets`. Without this the per-bullet pierce-state maps
+    // grow unboundedly across long sessions.
+    let live_ids: std::collections::HashSet<u32> =
+        state.bullets.iter().map(|b| b.id.0).collect();
+    side.bullet_pierced_asteroid_ids
+        .retain(|id, _| live_ids.contains(id));
+    side.bullet_pierced_enemy_ids
+        .retain(|id, _| live_ids.contains(id));
+    side.bullet_pierced_count
+        .retain(|id, _| live_ids.contains(id));
 }

--- a/server/src/sim/bullet.rs
+++ b/server/src/sim/bullet.rs
@@ -1102,3 +1102,144 @@ pub fn update_enemy_bullets(
         update_enemy_bullet(b, ctx, events);
     }
 }
+
+// ── Unified `BulletState` step (sim-storage path) ───────────────────────
+//
+// `update_bullets` advances the sim-internal `BulletState` collection that
+// lives on `GameState.bullets`. This is a SIMPLIFIED step that's distinct
+// from `update_player_bullet` (the JS-parity port).
+//
+// Why two paths?
+//   - `update_player_bullet` is the byte-for-byte JS port. It owns
+//     `PlayerBullet` (a richer field set including `fade_factor`,
+//     `base_radius`, range-multiplier, etc.) and produces parity-tested
+//     trajectories. Tests pin those numbers to JS reference vectors.
+//   - `update_bullets` is the simpler sim-step that the room actor calls
+//     each tick. It takes `BulletState` (the lean storage type), advances
+//     position + helix, ages the bullet, and culls on lifetime / off-screen.
+//
+// When the full parity port is wired into `simulate_tick`, this simplified
+// step gets retired in favor of dispatching to `update_player_bullet` /
+// `update_enemy_bullet` based on the bullet's owner. For now this is the
+// pragmatic v1 that makes `build_bullets` non-empty so collisions can fire.
+//
+// Order of operations matters and matches the spec in the task brief:
+//   1. Active-guard.
+//   2. Position update (vx * dt, vy * dt).
+//   3. Helix offset (if amplitude > 0).
+//   4. Age++.
+//   5. Lifetime check.
+//   6. Off-screen check (arena bounds).
+
+use crate::sim::state::BulletState;
+
+/// Per-tick context for `update_bullets`. Lean — only the fields the
+/// simplified step consumes today. The richer `PlayerBulletContext` /
+/// `EnemyBulletContext` types remain in service of the parity port.
+#[derive(Debug, Clone, Copy)]
+pub struct BulletStepContext {
+    /// Logic-tick delta in seconds. Mirrors `ctx.dt` on the JS side.
+    /// `update_bullets` falls back to `0.05` (≈ 20 Hz, matches the JS
+    /// solo-loop logic-tick rate) when this is zero so callers can pass
+    /// `Default::default()` and still get sensible motion.
+    pub dt: f32,
+    /// Arena half-extents (px). Bullets that drift outside `[-arena_*,
+    /// arena_*]` are culled. Defaults to 4000 × 4000 — large enough that
+    /// playfield-scale ballistics don't false-positive but tight enough
+    /// that runaway bullets eventually drop.
+    pub arena_width: f32,
+    pub arena_height: f32,
+}
+
+impl Default for BulletStepContext {
+    fn default() -> Self {
+        Self {
+            dt: 0.05,
+            arena_width: 4000.0,
+            arena_height: 4000.0,
+        }
+    }
+}
+
+/// Default `dt` used when callers pass `ctx.dt = 0.0`. Matches the JS
+/// solo-loop logic-tick rate (1 / 20 s).
+const BULLET_STEP_DEFAULT_DT: f32 = 0.05;
+
+/// Pure step that advances a single `BulletState` by one tick.
+///
+/// Mutates `b` in place; appends despawn events to `events` so the wrapper
+/// can release pool slots / emit wire-format `BulletDespawn`s.
+pub fn update_bullet(
+    b: &mut BulletState,
+    ctx: &BulletStepContext,
+    events: &mut Vec<BulletEvent>,
+) {
+    // 1. Active-guard.
+    if !b.active {
+        return;
+    }
+
+    // 2. Position update. Use ctx.dt; fall back to default when zero so
+    //    callers can pass `BulletStepContext::default()` and still get
+    //    motion. (Some tests pre-construct a ctx with dt=0 to assert the
+    //    fallback works.)
+    let dt = if ctx.dt == 0.0 {
+        BULLET_STEP_DEFAULT_DT
+    } else {
+        ctx.dt
+    };
+    b.x += b.vx * dt;
+    b.y += b.vy * dt;
+
+    // 3. Helix offset. Add the **delta** of the perpendicular sine each
+    //    frame so the underlying rail position still advances by `vel`
+    //    exactly. Same shape as `update_player_bullet`'s helix branch.
+    if b.helix_amplitude > 0.0 {
+        let speed = b.vx.hypot(b.vy);
+        let speed = if speed == 0.0 { 1.0 } else { speed };
+        let ux = -b.vy / speed;
+        let uy = b.vx / speed;
+        let t = b.age_ticks as f32;
+        let s_now = (t * b.helix_freq).sin();
+        let s_prev = ((t - 1.0) * b.helix_freq).sin();
+        let delta = (s_now - s_prev) * b.helix_amplitude;
+        b.x += ux * delta;
+        b.y += uy * delta;
+    }
+
+    // 4. Age++.
+    b.age_ticks = b.age_ticks.saturating_add(1);
+
+    // 5. Lifetime check.
+    if b.age_ticks > b.max_age_ticks {
+        b.active = false;
+        events.push(BulletEvent::Despawn { bullet_id: b.id.0 });
+        return;
+    }
+
+    // 6. Off-screen check (arena bounds). Use signed half-extents so the
+    //    arena is centered on the origin — matches how JS bullet origins
+    //    are seeded from the player position (which can be anywhere on the
+    //    field).
+    if b.x < -ctx.arena_width
+        || b.x > ctx.arena_width
+        || b.y < -ctx.arena_height
+        || b.y > ctx.arena_height
+    {
+        b.active = false;
+        events.push(BulletEvent::Despawn { bullet_id: b.id.0 });
+    }
+}
+
+/// Loop helper. Advances every bullet in the slice and prunes the inactive
+/// entries from the slice's owning Vec is NOT done here (the room actor
+/// runs `despawn_dead_bullets` after the drain pass — see room/collision.rs).
+pub fn update_bullets(
+    bullets: &mut [BulletState],
+    ctx: &BulletStepContext,
+    events: &mut Vec<BulletEvent>,
+) {
+    for b in bullets.iter_mut() {
+        update_bullet(b, ctx, events);
+    }
+}

--- a/server/src/sim/state.rs
+++ b/server/src/sim/state.rs
@@ -21,6 +21,113 @@ pub struct WaveState {
     pub remaining_to_spawn: u32,
 }
 
+/// Sim-internal bullet id newtype.
+///
+/// Distinct from the wire-format `BulletId` in `util::id` (which wraps `u64`
+/// for serde-friendly transport). This newtype wraps `u32` because the
+/// collision pure-step storage path already narrows to `u32` (see
+/// `CollisionBullet.id: u32` in `sim/collision.rs`) — keeping the sim-side
+/// container in the same width avoids an unnecessary conversion in the
+/// `build_bullets` view-builder hot path.
+///
+/// Bullets are deterministic from input + tick + asteroid state, so they
+/// don't need to traverse the wire — clients re-derive them. That's why
+/// this type lives in `sim/state.rs` rather than `protocol::generated`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
+pub struct BulletId(pub u32);
+
+/// Sim-internal bullet state — the authoritative storage feeding both
+/// `update_bullets` (physics) and `build_bullets` (collision view-builder).
+///
+/// Distinct from the protocol's wire-format types because bullets aren't on
+/// the wire (see `BulletId` docstring). The fields here are the minimal set
+/// the room actor needs:
+///
+///   - Position / velocity (`x`, `y`, `vx`, `vy`, `angle`) for physics +
+///     collision-view emission.
+///   - `radius` / `damage` / `pierce_count` for the bullet-vs-target
+///     collision pass (these flow into `CollisionBullet`).
+///   - `homing`, `helix_amplitude`, `helix_freq` for the Phase 2.1
+///     movement-pattern logic. Today `update_bullets` does a simplified
+///     linear-drift + helix step — when `update_player_bullet` (the full
+///     parity port) takes over, these flags will reroute into that path.
+///   - `age_ticks` / `max_age_ticks` for lifetime culling. Separate from
+///     `PlayerBullet.life/max_life` because this is the simpler sim-step
+///     model (frame counter incremented per tick, hard cap drops to
+///     `!active`); the parity port uses fade-factor math instead.
+///   - `active` for the standard despawn latch.
+#[derive(Debug, Clone, Copy)]
+pub struct BulletState {
+    pub id: BulletId,
+
+    // ── Position / velocity (px / px-per-tick) ──────────────────────────
+    pub x: f32,
+    pub y: f32,
+    pub vx: f32,
+    pub vy: f32,
+    /// Render orientation in radians. Independent from `atan2(vy, vx)` so
+    /// helix bullets can carry a fixed barrel direction while their
+    /// velocity sin-waves around the perpendicular axis.
+    pub angle: f32,
+
+    // ── Combat ──────────────────────────────────────────────────────────
+    pub radius: f32,
+    pub damage: f32,
+    /// Number of additional targets the bullet may hit before despawning.
+    /// `0` = non-piercing (one-shot). Mirrors `CollisionBullet.piercing`
+    /// semantics — see `sim/collision.rs:160`.
+    pub pierce_count: u32,
+
+    // ── Movement modifiers ──────────────────────────────────────────────
+    /// Predictive-lead homing flag. Today `update_bullets` does NOT consume
+    /// this (the parity-tested path in `update_player_bullet` does); kept
+    /// on the state so the wrapper can flag-route between the two paths
+    /// once full plumbing lands.
+    pub homing: bool,
+    /// Helix amplitude (px). When `0.0` the helix branch in
+    /// `update_bullets` is bypassed.
+    pub helix_amplitude: f32,
+    /// Angular frequency of the helix sine. Applied to `age_ticks` each
+    /// tick.
+    pub helix_freq: f32,
+
+    // ── Lifetime (logic ticks) ──────────────────────────────────────────
+    pub age_ticks: u32,
+    pub max_age_ticks: u32,
+
+    // ── Lifecycle latch ─────────────────────────────────────────────────
+    pub active: bool,
+}
+
+impl BulletState {
+    /// Fresh bullet with sensible defaults at the origin.
+    ///
+    /// Mirrors `Asteroid::fresh` / `CollisionBullet::fresh`: scalar fields
+    /// at zero or a sensible neutral, lifetime caps at typical defaults
+    /// (`max_age_ticks=120` ≈ 2s at 60 Hz), `active=true`. Callers override
+    /// individual fields via struct-update syntax or direct mutation after
+    /// construction.
+    pub fn fresh(id: BulletId) -> Self {
+        Self {
+            id,
+            x: 0.0,
+            y: 0.0,
+            vx: 0.0,
+            vy: 0.0,
+            angle: 0.0,
+            radius: 4.0,
+            damage: 1.0,
+            pierce_count: 0,
+            homing: false,
+            helix_amplitude: 0.0,
+            helix_freq: 0.0,
+            age_ticks: 0,
+            max_age_ticks: 120,
+            active: true,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct GameState {
     pub field: Field,
@@ -28,6 +135,7 @@ pub struct GameState {
     pub enemies: Vec<EnemyState>,
     pub asteroids: Vec<AsteroidState>,
     pub drops: Vec<DropState>,
+    pub bullets: Vec<BulletState>,
     pub wave: WaveState,
 }
 

--- a/server/tests/parity_bullet.rs
+++ b/server/tests/parity_bullet.rs
@@ -326,3 +326,182 @@ fn player_bullet_homing() {
         events,
     );
 }
+
+// ── BulletState / update_bullets fixtures ───────────────────────────────
+//
+// These exercise the SIM-storage path (the simplified bullet step that
+// the room actor drives each tick — see `sim::bullet::update_bullets`).
+// Distinct from the `update_player_bullet` fixtures above, which pin the
+// byte-for-byte JS parity port.
+//
+// The room-actor path doesn't need to match JS bit-for-bit (clients
+// re-derive bullets from input + tick); it just needs reasonable physics
+// so the collision view-builder has non-empty input.
+
+use rainboids_server::sim::bullet::{update_bullet, BulletStepContext};
+use rainboids_server::sim::state::{BulletId, BulletState};
+
+#[test]
+fn bullet_state_constructor_defaults() {
+    // `BulletState::fresh` should produce a fully-initialized bullet ready
+    // for the room actor to consume. Spot-check the defaults that load-
+    // bearing fields rely on:
+    //   - `active=true` so the room actor's view-builder picks it up.
+    //   - `age_ticks=0` so a 30-tick fixture sees the lifetime ramp from
+    //     the top.
+    //   - `max_age_ticks > 0` so the cap-check doesn't trigger on tick 0.
+    //   - Velocity / position at zero so the call site can drop in
+    //     overrides without worrying about leftover state.
+    let b = BulletState::fresh(BulletId(42));
+
+    assert_eq!(b.id, BulletId(42));
+    assert!(b.active, "fresh bullet should be active");
+    assert_eq!(b.age_ticks, 0);
+    assert!(b.max_age_ticks > 0, "max_age_ticks must be positive");
+    assert_eq!(b.x, 0.0);
+    assert_eq!(b.y, 0.0);
+    assert_eq!(b.vx, 0.0);
+    assert_eq!(b.vy, 0.0);
+    assert_eq!(b.angle, 0.0);
+    assert_eq!(b.pierce_count, 0);
+    assert!(!b.homing);
+    assert_eq!(b.helix_amplitude, 0.0);
+    // damage / radius should be a positive default (so a fresh bullet is
+    // immediately usable as a "default test bullet" without overrides).
+    assert!(b.damage > 0.0);
+    assert!(b.radius > 0.0);
+}
+
+#[test]
+fn update_bullets_advances_position() {
+    // Setup: a bullet at (100, 200) drifting east at vx=10 px/s with the
+    // default dt of 0.05 s. After 1 tick: x should advance by exactly
+    // vx * dt = 10 * 0.05 = 0.5 px. (The room-actor step is dt-scaled,
+    // distinct from the JS parity port which uses raw vx/vy per frame.)
+    let mut b = BulletState::fresh(BulletId(1));
+    b.x = 100.0;
+    b.y = 200.0;
+    b.vx = 10.0;
+    b.vy = 0.0;
+
+    let ctx = BulletStepContext::default();
+    let mut events: Vec<BulletEvent> = Vec::new();
+
+    update_bullet(&mut b, &ctx, &mut events);
+
+    let expected_dx = 10.0 * 0.05;
+    close(b.x, 100.0 + expected_dx, "bullet.x after 1 tick");
+    close(b.y, 200.0, "bullet.y unchanged");
+    assert!(b.active, "bullet should still be active");
+    assert_eq!(b.age_ticks, 1, "age should increment to 1");
+    assert!(
+        events.is_empty(),
+        "no despawn events for an in-flight bullet"
+    );
+}
+
+#[test]
+fn update_bullets_ages_and_despawns() {
+    // Setup: a bullet with max_age_ticks=3 placed at the origin with zero
+    // velocity. After 4 ticks it should expire (age 4 > max 3 → !active +
+    // Despawn event). The active-guard on subsequent ticks means
+    // additional calls are no-ops.
+    let mut b = BulletState::fresh(BulletId(7));
+    b.max_age_ticks = 3;
+
+    let ctx = BulletStepContext::default();
+    let mut events: Vec<BulletEvent> = Vec::new();
+
+    // Ticks 1, 2, 3 — bullet still alive (age incremented but not yet > 3).
+    for tick in 1..=3 {
+        update_bullet(&mut b, &ctx, &mut events);
+        assert!(b.active, "bullet should be active at tick {}", tick);
+    }
+
+    // Tick 4 — age becomes 4, which is > max_age_ticks (3): despawn.
+    update_bullet(&mut b, &ctx, &mut events);
+    assert!(!b.active, "bullet should despawn after max_age_ticks");
+    assert_eq!(
+        events.len(),
+        1,
+        "exactly one Despawn event on lifetime expiry"
+    );
+    assert!(matches!(events[0], BulletEvent::Despawn { bullet_id: 7 }));
+
+    // Tick 5 — bullet already inactive; no further events.
+    update_bullet(&mut b, &ctx, &mut events);
+    assert_eq!(
+        events.len(),
+        1,
+        "no additional events for inactive bullet"
+    );
+}
+
+#[test]
+fn update_bullets_off_screen_despawns() {
+    // Setup: bullet at the right-arena boundary with eastward velocity
+    // and a small arena. One tick should push it outside `arena_width`,
+    // triggering the off-screen branch.
+    let mut b = BulletState::fresh(BulletId(99));
+    b.x = 100.0;
+    b.vx = 5000.0; // Huge velocity to guarantee off-screen in 1 tick.
+
+    let ctx = BulletStepContext {
+        dt: 0.1,
+        arena_width: 200.0,
+        arena_height: 200.0,
+    };
+    let mut events: Vec<BulletEvent> = Vec::new();
+
+    update_bullet(&mut b, &ctx, &mut events);
+
+    assert!(
+        !b.active,
+        "bullet should be deactivated when it leaves the arena"
+    );
+    assert_eq!(events.len(), 1, "exactly one Despawn event for off-screen");
+    assert!(matches!(events[0], BulletEvent::Despawn { bullet_id: 99 }));
+}
+
+#[test]
+fn update_bullets_helix_offset() {
+    // Setup: a bullet drifting east with helix enabled (amplitude=4,
+    // freq=0.3). The y-coordinate should oscillate within the amplitude
+    // band as the bullet advances; after several ticks y must measurably
+    // differ from its starting value (without helix it would stay at 0).
+    let mut b = BulletState::fresh(BulletId(2));
+    b.vx = 10.0;
+    b.helix_amplitude = 4.0;
+    b.helix_freq = 0.3;
+
+    let ctx = BulletStepContext::default();
+    let mut events: Vec<BulletEvent> = Vec::new();
+
+    let starting_y = b.y;
+    // Run enough ticks to see noticeable sine motion. The phase advances
+    // by `helix_freq` each tick; ~10 ticks covers a measurable fraction
+    // of a period.
+    for _ in 0..10 {
+        update_bullet(&mut b, &ctx, &mut events);
+    }
+
+    // y should have moved (helix adds delta-sin each tick).
+    assert!(
+        (b.y - starting_y).abs() > 1e-6,
+        "helix should produce non-zero y deviation; y={}, start={}",
+        b.y,
+        starting_y
+    );
+    // y must stay within the amplitude band (the helix adds the **delta**
+    // of the sine each frame, so the cumulative offset bounds by the
+    // amplitude itself — plus a small float tolerance).
+    assert!(
+        (b.y - starting_y).abs() <= b.helix_amplitude + 0.01,
+        "helix y drifted outside amplitude band: y={}, start={}, amp={}",
+        b.y,
+        starting_y,
+        b.helix_amplitude
+    );
+    assert!(b.active, "bullet should still be active mid-helix");
+    assert!(events.is_empty(), "no despawn while in-flight");
+}

--- a/server/tests/state_bullets.rs
+++ b/server/tests/state_bullets.rs
@@ -1,0 +1,180 @@
+//! `GameState.bullets` collection plumbing tests.
+//!
+//! Verifies the sim-internal bullet collection added to `GameState` and the
+//! `build_bullets` view-builder in `room::collision` that consumes it.
+//! Distinct from `parity_bullet.rs` (which pins the per-bullet step physics)
+//! and `collision_drain.rs` (which covers the event-dispatch path).
+//!
+//! Scope:
+//!   1. `GameState::new()` produces an empty `bullets` Vec.
+//!   2. Bullets can be pushed and the `len` reflects the push.
+//!   3. `drain` populates `CollisionBullet`s from `state.bullets` and the
+//!      bullet-vs-asteroid pair fires when geometry overlaps.
+//!   4. Inactive bullets are pruned by the drain's despawn pass.
+
+use rainboids_server::protocol::{AsteroidId, AsteroidState, GameEvent};
+use rainboids_server::room::collision::{drain, CollisionSideState};
+use rainboids_server::sim::state::{BulletId, BulletState, GameState};
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+fn make_state() -> GameState {
+    GameState::new()
+}
+
+fn make_asteroid(id: u64, x: f32, y: f32) -> AsteroidState {
+    AsteroidState {
+        id: AsteroidId(id),
+        size: 1,
+        x,
+        y,
+    }
+}
+
+fn make_bullet(id: u32, x: f32, y: f32) -> BulletState {
+    let mut b = BulletState::fresh(BulletId(id));
+    b.x = x;
+    b.y = y;
+    b.damage = 4.0;
+    b
+}
+
+// ─── 1. GameState::new() yields an empty bullets Vec ────────────────
+
+#[test]
+fn gamestate_bullets_field_default_empty() {
+    let state = GameState::new();
+    assert!(
+        state.bullets.is_empty(),
+        "fresh GameState should have no bullets; got {} entries",
+        state.bullets.len()
+    );
+}
+
+// ─── 2. Pushing bullets works and length reflects the push ──────────
+
+#[test]
+fn gamestate_can_add_bullets() {
+    let mut state = make_state();
+    assert_eq!(state.bullets.len(), 0);
+
+    state.bullets.push(make_bullet(1, 100.0, 100.0));
+    assert_eq!(state.bullets.len(), 1);
+
+    state.bullets.push(make_bullet(2, 200.0, 100.0));
+    state.bullets.push(make_bullet(3, 300.0, 100.0));
+    assert_eq!(state.bullets.len(), 3);
+
+    // Bullets should retain the data we passed in.
+    assert_eq!(state.bullets[0].id, BulletId(1));
+    assert_eq!(state.bullets[0].x, 100.0);
+    assert_eq!(state.bullets[2].id, BulletId(3));
+    assert_eq!(state.bullets[2].x, 300.0);
+}
+
+// ─── 3. drain fires bullet-vs-asteroid when geometry overlaps ───────
+
+/// Place a bullet and an asteroid at the same coordinates so the
+/// circle-circle pair always intersects (bullet radius 4 + asteroid
+/// radius 30 = 34; centers 0 px apart ⇒ overlap of 34 px). The drain
+/// should:
+///   - Build a non-empty `CollisionBullet` view from `state.bullets`.
+///   - Call `detect_bullet_asteroid_hits` → emit `BulletHitAsteroid`.
+///   - Damage the asteroid (HP ↓ by `bullet.damage`).
+///   - Mark the (non-piercing) bullet inactive in `state.bullets`.
+///   - Prune the dead bullet via `despawn_dead_bullets`.
+///   - Emit a `BulletDespawn` wire event.
+///
+/// Before this PR `build_bullets` returned an empty Vec → no hit ever
+/// fired. This test pins the bullet-collision integration.
+#[test]
+fn drain_fires_bullet_asteroid_collision_with_populated_bullets() {
+    let mut state = make_state();
+
+    // Asteroid at (100, 100) with HP=10 — alive but easy to hit.
+    state.asteroids.push(make_asteroid(101, 100.0, 100.0));
+    let mut side = CollisionSideState::new();
+    side.asteroid_hp.insert(101, 10.0);
+
+    // Bullet overlapping the asteroid with damage=4.
+    state.bullets.push(make_bullet(42, 100.0, 100.0));
+
+    let mut wire_events: Vec<GameEvent> = Vec::new();
+    drain(&mut state, &mut side, &mut wire_events);
+
+    // Asteroid HP should have dropped by `bullet.damage` (4.0).
+    let hp = side.get_asteroid_hp(101);
+    assert!(
+        (hp - 6.0).abs() < 1e-6,
+        "asteroid HP should drop from 10 to 6 after bullet hit (damage=4); got {}",
+        hp
+    );
+
+    // Bullet should be pruned by the despawn pass (non-piercing → dies on hit).
+    assert!(
+        state.bullets.is_empty(),
+        "non-piercing bullet should be despawned and pruned after hit; remaining: {:?}",
+        state.bullets.iter().map(|b| b.id).collect::<Vec<_>>()
+    );
+
+    // Exactly one BulletDespawn wire event should have been emitted.
+    let bullet_despawns = wire_events
+        .iter()
+        .filter(|e| matches!(e, GameEvent::BulletDespawn { .. }))
+        .count();
+    assert_eq!(
+        bullet_despawns, 1,
+        "expected exactly 1 BulletDespawn wire event for the consumed bullet"
+    );
+}
+
+// ─── 4. Inactive bullets get pruned by drain ────────────────────────
+
+#[test]
+fn drain_prunes_inactive_bullets() {
+    let mut state = make_state();
+    // Pre-emptively mark a bullet as inactive (simulating a prior tick's
+    // off-screen / lifetime expiry). The drain's despawn pass should
+    // prune it even when no collision-vs-anything fires.
+    let mut dead = make_bullet(5, 100.0, 100.0);
+    dead.active = false;
+    state.bullets.push(dead);
+
+    // Also include a live bullet to confirm the prune is selective.
+    state.bullets.push(make_bullet(6, 500.0, 500.0));
+
+    assert_eq!(state.bullets.len(), 2);
+
+    let mut side = CollisionSideState::new();
+    let mut wire_events: Vec<GameEvent> = Vec::new();
+
+    drain(&mut state, &mut side, &mut wire_events);
+
+    assert_eq!(state.bullets.len(), 1, "only the inactive bullet should be pruned");
+    assert_eq!(
+        state.bullets[0].id,
+        BulletId(6),
+        "the surviving bullet should be the active one"
+    );
+}
+
+// ─── 5. Empty bullets Vec is still a clean no-op (regression guard) ─
+
+#[test]
+fn drain_with_empty_bullets_is_noop() {
+    // Sanity guard: removing the bullet collection plumbing must not break
+    // the existing "MVD ship-only no-op" behavior — the drain still
+    // succeeds with an empty `state.bullets` and produces no extra events.
+    let mut state = make_state();
+    let mut side = CollisionSideState::new();
+    let mut wire_events: Vec<GameEvent> = Vec::new();
+
+    drain(&mut state, &mut side, &mut wire_events);
+
+    assert!(state.bullets.is_empty());
+    assert!(
+        wire_events.is_empty(),
+        "empty-bullets drain should produce no wire events; got {:?}",
+        wire_events
+    );
+}


### PR DESCRIPTION
## Summary
**Major server-side enabler.** Adds bullets to GameState so the room actor's collision drain (PR #66/#70) can finally fire for bullet ↔ asteroid and bullet ↔ enemy collisions. Previously \`build_bullets\` returned \`Vec::new()\` and those collision passes were guaranteed no-ops.

## What's new

### server/src/sim/state.rs
- \`BulletId(pub u32)\` newtype — sim-internal; narrowed to match \`CollisionBullet.id\`, avoiding per-tick conversion in hot path
- \`BulletState\` — { id, x, y, vx, vy, angle, radius, damage, pierce_count, homing, helix_amplitude/freq, age_ticks/max_age_ticks, active } with \`fresh(BulletId)\` constructor
- \`GameState.bullets: Vec<BulletState>\` field

### server/src/sim/bullet.rs
- \`BulletStepContext { dt=0.05, arena_width=4000, arena_height=4000 }\`
- \`update_bullet(bullet, ctx, events)\` — v1 step: active-guard → position → helix → age++ → lifetime → arena bounds
- \`update_bullets(bullets, ctx, events)\` — slice loop
- **Existing PlayerBullet/EnemyBullet parity code untouched** — full parity port stays available; v1 step distinct for owner-aware routing follow-up

### server/src/room/collision.rs
- \`build_bullets\` now reads from \`state.bullets\` (joins with \`bullet_pierced_*\` side-state for the CollisionBullet view)
- \`deactivate_bullet\` helper called from \`BulletHitAsteroid\` + \`BulletHitEnemy\` arms in \`apply_event\` (drains bullet despawn)
- \`despawn_dead_bullets\` pass added to drain (also prunes side-tables)
- Added \`LightningArcHitEnemy\` apply_event arm (master had it after #78 merged; subagent's diff was based on an earlier state)

## Tests
- **+10 net new tests**: 5 in parity_bullet.rs (BulletState constructor, update_bullets position/age/off-screen/helix) + 5 in NEW state_bullets.rs
- **Key integration test**: \`drain_fires_bullet_asteroid_collision_with_populated_bullets\` — bullet overlapping asteroid → damage applied + bullet despawned + BulletDespawn wire event emitted. Before this PR, build_bullets returned empty and this test would have produced zero events.
- 134 → **149 Rust tests passing**, 0 failures, 1 pre-existing ignored
- Clean build, zero warnings

## Follow-ups (next PRs)
1. Wire \`Player.fire\`-side production code to push BulletState into GameState.bullets (simulate_tick stub today only test fixtures populate)
2. Bullet snapshot delivery — wire BulletState into snapshot.rs payload so client renders server-side bullets
3. Pierce-count tracking back from CollisionBullet to BulletState after pierce hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)