### PR TITLE
feat/mobile: scaffold haptic feedback + first-run tutorial + screen wake lock

### DIFF
--- a/js/modules/platform/haptic.js
+++ b/js/modules/platform/haptic.js
@@ -1,0 +1,93 @@
+// Haptic feedback — thin wrapper around the Web Vibration API for mobile
+// gameplay events (hits, kills, level-ups, game-over). Phase 1 ships the
+// module + tests only; gameplay integration lands in a follow-up PR.
+//
+// Design notes:
+// - We always gate on isMobile() first. Desktop browsers may technically
+//   implement navigator.vibrate (Chrome on Linux historically did), but we
+//   don't want shake-the-laptop feedback on a desktop session.
+// - We treat the Vibration API as best-effort. iOS Safari has never
+//   implemented it, and some Android WebViews will throw on certain
+//   pattern shapes (negative values, oversized arrays). All API calls go
+//   through a try/catch so a thrown error becomes a `false` return.
+// - vibrate(0) is the documented way to cancel an ongoing vibration; we
+//   expose that as cancelVibrate() for readability at call sites.
+
+import { isMobile } from './platform-detect.js';
+
+/**
+ * Predefined haptic patterns matching common game events. Callers pass
+ * these directly to vibrate(); see the constants for the intended use.
+ *
+ * Durations are in milliseconds. Arrays follow the Web Vibration API
+ * convention of alternating vibrate / pause / vibrate / pause / ...
+ */
+export const HAPTIC = {
+    LIGHT: 10,            // brief tick (UI tap, projectile fire)
+    MEDIUM: 25,           // hit confirmation (enemy struck)
+    HEAVY: 50,            // explosion / kill
+    DOUBLE: [15, 30, 15], // achievement / level up
+    LONG: 100,            // game over
+};
+
+/**
+ * Internal: returns true iff the Vibration API is wired up on this
+ * navigator. We keep this separate from isHapticSupported() because the
+ * latter also enforces the isMobile() gate; this just answers "is the
+ * function callable".
+ */
+function _hasVibrateApi() {
+    return typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function';
+}
+
+/**
+ * Check if haptic feedback is supported on the current platform.
+ * Returns true if isMobile() is true AND navigator.vibrate is a function.
+ *
+ * This does NOT guarantee a subsequent vibrate() call will succeed — iOS
+ * Safari is famously absent from the support matrix, and some Android
+ * builds throw on specific pattern shapes — but it's a useful "should I
+ * even try" hint for callers that want to skip work entirely on desktop.
+ */
+export function isHapticSupported() {
+    if (!isMobile()) return false;
+    return _hasVibrateApi();
+}
+
+/**
+ * Vibrate the device using the Web Vibration API.
+ *
+ * @param {number | number[]} pattern - Either a single duration in
+ *   milliseconds, or an array of alternating vibrate/pause durations.
+ * @returns {boolean} true if navigator.vibrate(pattern) was invoked and
+ *   did not throw; false if we bailed out (desktop, no API, or a thrown
+ *   error from the underlying implementation).
+ *
+ * Note: a `true` return only means we successfully *called* the API. The
+ * spec allows navigator.vibrate to itself return false (e.g. for an empty
+ * pattern); we treat that as "we tried" and still return true, because
+ * the caller's contract is "did I trigger a haptic attempt", not "did
+ * the device physically buzz".
+ */
+export function vibrate(pattern) {
+    if (!isMobile()) return false;
+    if (!_hasVibrateApi()) return false;
+    try {
+        navigator.vibrate(pattern);
+        return true;
+    } catch (_) {
+        return false;
+    }
+}
+
+/**
+ * Cancel any ongoing vibration. Per the Web Vibration API spec, calling
+ * navigator.vibrate(0) (or with an empty array) cancels the active
+ * pattern. We use 0 because it's the most widely supported form.
+ *
+ * @returns {boolean} same semantics as vibrate(): true if the API call
+ *   was made, false if we bailed out or it threw.
+ */
+export function cancelVibrate() {
+    return vibrate(0);
+}

--- a/js/modules/platform/wake-lock.js
+++ b/js/modules/platform/wake-lock.js
@@ -1,0 +1,207 @@
+// Screen wake lock — thin wrapper around the Screen Wake Lock API
+// (navigator.wakeLock) to keep mobile devices from dimming or sleeping
+// during gameplay. Phase 1 ships the module + tests only; gameplay
+// integration (calling requestWakeLock() when a run starts and
+// releaseWakeLock() when the player returns to the menu) lands in a
+// follow-up PR.
+//
+// Design notes:
+// - We gate on isMobile() first. Desktop browsers usually have stable
+//   power policies and we don't want to suppress monitor sleep during a
+//   long pause. Calls from a desktop context no-op and return false.
+// - The Wake Lock API is asynchronous: navigator.wakeLock.request('screen')
+//   returns a Promise that resolves to a sentinel object with .release()
+//   and a 'released' event. Some browsers reject the request (e.g. low
+//   battery, system policy), so every acquisition goes through try/catch.
+// - The browser itself releases wake locks aggressively. The two cases
+//   we care about are:
+//     1. Tab hidden (visibilitychange → 'hidden') — browser releases.
+//     2. User toggles back to the tab — we want to silently re-acquire
+//        if we were holding a lock before the tab was hidden.
+//   We track an internal "should have a lock" flag separately from the
+//   live sentinel so the auto-reacquire handler knows when to fire.
+// - Browser support (as of 2026): Chromium-based browsers and Safari
+//   16.4+ on iOS / macOS implement Screen Wake Lock. Firefox desktop
+//   does NOT (Firefox Android does). All callers must tolerate a `false`
+//   return without further side effects.
+
+import { isMobile } from './platform-detect.js';
+
+// The currently held sentinel object, or null if none. Set when a request
+// succeeds; cleared on release() or on the sentinel's 'released' event
+// (which fires when the browser releases the lock independently of us,
+// e.g. on tab hide).
+let _currentLock = null;
+
+// True iff the caller has expressed intent to hold a lock (the most
+// recent requestWakeLock() succeeded and there has been no matching
+// releaseWakeLock() call). This is independent of _currentLock — when
+// the browser auto-releases on tab hide, _currentLock goes null but
+// _shouldHoldLock stays true so the visibilitychange handler knows to
+// re-request.
+let _shouldHoldLock = false;
+
+/**
+ * Internal: returns true iff the Screen Wake Lock API is wired up on
+ * this navigator. Kept separate from isWakeLockSupported() so the latter
+ * can stay a pure "should I even try" hint without becoming a place
+ * where additional gates accumulate over time.
+ */
+function _hasWakeLockApi() {
+    if (typeof navigator === 'undefined') return false;
+    if (!navigator.wakeLock) return false;
+    return typeof navigator.wakeLock.request === 'function';
+}
+
+/**
+ * Check if the Screen Wake Lock API is available on this platform,
+ * independent of isMobile(). Useful for diagnostics and for callers
+ * that want to advertise capability before any user gesture.
+ *
+ * Note: capability !== "the next request will succeed". Browsers can
+ * still reject under load, low-battery, or policy reasons. This is a
+ * pre-check, not a guarantee.
+ */
+export function isWakeLockSupported() {
+    return _hasWakeLockApi();
+}
+
+/**
+ * Returns true iff a wake lock is currently held (i.e. we have a live
+ * sentinel that the browser has not released). This tracks the actual
+ * lock state, not the intent flag — if the tab is hidden and the browser
+ * auto-releases, this returns false even though we'll try to reacquire
+ * on visibility return.
+ */
+export function isWakeLockHeld() {
+    return _currentLock !== null;
+}
+
+/**
+ * Request a screen wake lock to prevent the device from dimming / sleeping.
+ *
+ * Behavior:
+ * - No-ops on desktop (isMobile() false) → returns false.
+ * - No-ops if navigator.wakeLock is unavailable → returns false.
+ * - On a successful acquisition, stores the sentinel internally and
+ *   returns true.
+ * - Idempotent: if a lock is already held, returns true without
+ *   re-requesting (the existing sentinel stays live).
+ * - If navigator.wakeLock.request() rejects or throws (some browsers
+ *   throw on low battery), returns false and leaves internal state
+ *   untouched.
+ *
+ * @returns {Promise<boolean>} true if a lock is now held, false otherwise.
+ */
+export async function requestWakeLock() {
+    if (!isMobile()) return false;
+    if (!_hasWakeLockApi()) return false;
+    // Idempotent: if we already hold a lock, the caller's intent is met.
+    // Re-record the "should hold" flag in case it was cleared by a
+    // previous release; this keeps the auto-reacquire path consistent.
+    if (_currentLock !== null) {
+        _shouldHoldLock = true;
+        return true;
+    }
+    try {
+        const sentinel = await navigator.wakeLock.request('screen');
+        _currentLock = sentinel;
+        _shouldHoldLock = true;
+        // The browser may release the lock on its own (tab hidden, etc.).
+        // When that happens the sentinel fires a 'released' event; we
+        // clear our reference so isWakeLockHeld() reflects reality. We
+        // intentionally do NOT clear _shouldHoldLock here — that's how
+        // the visibility handler knows to reacquire on return.
+        if (sentinel && typeof sentinel.addEventListener === 'function') {
+            sentinel.addEventListener('release', () => {
+                if (_currentLock === sentinel) {
+                    _currentLock = null;
+                }
+            });
+        }
+        return true;
+    } catch (_) {
+        // Acquisition failed; some browsers throw synchronously here
+        // when the request is denied. Leave the intent flag alone so a
+        // later retry from the caller still works.
+        return false;
+    }
+}
+
+/**
+ * Release the current screen wake lock, if any.
+ *
+ * Behavior:
+ * - No-ops if no lock is held → returns false.
+ * - Calls sentinel.release(), clears internal state, and returns true.
+ * - Also clears the "should hold" intent flag so the auto-reacquire
+ *   handler will not refire on the next visibilitychange.
+ * - If sentinel.release() throws (rare; some early implementations
+ *   threw on double-release), state is cleared anyway and we return
+ *   true — the caller's intent is "release", and a thrown release is
+ *   effectively still released.
+ *
+ * @returns {Promise<boolean>} true if a release was attempted, false
+ *   if no lock was held to begin with.
+ */
+export async function releaseWakeLock() {
+    if (_currentLock === null) {
+        // Still clear the intent flag in case it drifted; a no-op
+        // release should leave the world in a consistent "no lock,
+        // no intent" state.
+        _shouldHoldLock = false;
+        return false;
+    }
+    const sentinel = _currentLock;
+    _currentLock = null;
+    _shouldHoldLock = false;
+    try {
+        if (sentinel && typeof sentinel.release === 'function') {
+            await sentinel.release();
+        }
+    } catch (_) {
+        // Ignore; state is already cleared.
+    }
+    return true;
+}
+
+/**
+ * Attach a visibilitychange handler that re-acquires the wake lock when
+ * the document becomes visible again. The browser releases wake locks
+ * automatically when the tab is hidden, so without this handler the
+ * lock would silently die the first time the user task-switches.
+ *
+ * Behavior:
+ * - Only re-requests if _shouldHoldLock is true (i.e. the caller most
+ *   recently expressed intent to hold a lock, and has not since called
+ *   releaseWakeLock()).
+ * - Safe to call once at init; the handler stays installed for the
+ *   document's lifetime.
+ *
+ * @param {{document?: Document}} [opts] - Inject a document for tests.
+ *   Defaults to window.document.
+ */
+export function attachAutoReacquireHandler({ document = (typeof window !== 'undefined' ? window.document : undefined) } = {}) {
+    if (!document || typeof document.addEventListener !== 'function') return;
+    document.addEventListener('visibilitychange', () => {
+        // Only reacquire on return to foreground, and only if the
+        // caller still wants a lock. We don't re-check isMobile() here
+        // because the original request already did, and a desktop
+        // browser wouldn't have set _shouldHoldLock in the first place.
+        if (document.visibilityState !== 'visible') return;
+        if (!_shouldHoldLock) return;
+        if (_currentLock !== null) return; // already reacquired
+        // Fire-and-forget; the promise resolution doesn't matter here.
+        // requestWakeLock() handles its own errors internally.
+        requestWakeLock();
+    });
+}
+
+/**
+ * Test-only: reset the internal state. Used by unit tests to start each
+ * case from a known baseline without ESM module-cache gymnastics.
+ */
+export function _resetForTests() {
+    _currentLock = null;
+    _shouldHoldLock = false;
+}

--- a/js/modules/ui/mobile-tutorial.js
+++ b/js/modules/ui/mobile-tutorial.js
@@ -1,0 +1,297 @@
+// Mobile first-run tutorial overlay.
+//
+// A self-contained, opt-in overlay that briefly teaches a mobile player the
+// three things the mobile mode does differently from a desktop session:
+//   * Tap-to-shoot (target selection by touch)
+//   * Auto-pilot dodging (the ship handles immediate-threat evasion)
+//   * Long-press radial menu (weapon switching)
+//   * Power weapons auto-fire when charged
+//
+// The overlay is built entirely in JS — no CSS file edits, no index.html
+// edits — so it can be added as a self-contained module without touching
+// the rest of the boot flow. The orchestrator (main.js / game-engine.js)
+// is responsible for calling `mountMobileTutorial()` at the right time
+// (typically after the title screen renders). Phase 1: just the function.
+//
+// Persistence: once the user dismisses the overlay we set a localStorage
+// flag so we never show it again. A `resetTutorialSeen()` helper exists
+// for testing and for a future "replay tutorial" feature.
+
+import { isMobile } from '../platform/platform-detect.js';
+
+export const STORAGE_KEY = 'rainboids:mobile-tutorial-seen';
+
+// DOM ids used both for idempotency checks and as test hooks. Keeping
+// them stable means a future integration test can find the overlay
+// without scraping CSS-in-JS class names.
+const OVERLAY_ID = 'mobile-tutorial-overlay';
+const STYLE_ID = 'mobile-tutorial-style';
+const DISMISS_BUTTON_ID = 'mobile-tutorial-dismiss';
+
+// The four instructional items shown on the overlay. Order matches the
+// priority of what a fresh mobile player needs to learn first.
+const TUTORIAL_ITEMS = [
+    { icon: '🎯', text: 'Tap enemies and asteroids to shoot at them' },
+    { icon: '🤖', text: 'Your ship auto-dodges nearby threats' },
+    { icon: '⚡', text: 'Long-press anywhere to change weapons' },
+    { icon: '🔋', text: 'Power weapons auto-fire when charged' },
+];
+
+// CSS injected into <head>. Kept as a single template literal so the
+// styling stays co-located with the markup it targets — easier to audit
+// than scattering inline styles across the DOM-builder. The landscape
+// media query downsizes text + tightens padding so the card fits a
+// short viewport without scrolling.
+const CSS_TEXT = `
+#${OVERLAY_ID} {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    background: rgba(0, 0, 0, 0.85);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    color: #ffffff;
+}
+#${OVERLAY_ID} .mt-card {
+    background: rgba(20, 20, 30, 0.95);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 12px;
+    padding: 20px;
+    max-width: 90vw;
+    max-height: 80vh;
+    overflow-y: auto;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    text-align: left;
+}
+#${OVERLAY_ID} .mt-title {
+    margin: 0 0 16px 0;
+    font-size: 22px;
+    font-weight: 600;
+    text-align: center;
+    letter-spacing: 0.5px;
+}
+#${OVERLAY_ID} .mt-list {
+    list-style: none;
+    margin: 0 0 20px 0;
+    padding: 0;
+}
+#${OVERLAY_ID} .mt-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 18px;
+    line-height: 1.4;
+    padding: 8px 0;
+}
+#${OVERLAY_ID} .mt-icon {
+    font-size: 26px;
+    flex: 0 0 auto;
+    width: 36px;
+    text-align: center;
+}
+#${OVERLAY_ID} .mt-text {
+    flex: 1 1 auto;
+}
+#${OVERLAY_ID} button.mt-dismiss {
+    display: block;
+    width: 100%;
+    min-height: 60px;
+    margin-top: 8px;
+    padding: 14px 24px;
+    background: linear-gradient(180deg, #4a9eff 0%, #2a7edc 100%);
+    color: #ffffff;
+    border: none;
+    border-radius: 10px;
+    font-size: 18px;
+    font-weight: 600;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+}
+#${OVERLAY_ID} button.mt-dismiss:active {
+    background: linear-gradient(180deg, #3a8eef 0%, #1a6ecc 100%);
+}
+@media (orientation: landscape) {
+    #${OVERLAY_ID} .mt-card {
+        padding: 14px 20px;
+        max-height: 90vh;
+    }
+    #${OVERLAY_ID} .mt-title {
+        font-size: 18px;
+        margin-bottom: 10px;
+    }
+    #${OVERLAY_ID} .mt-item {
+        font-size: 15px;
+        padding: 5px 0;
+    }
+    #${OVERLAY_ID} .mt-icon {
+        font-size: 20px;
+        width: 28px;
+    }
+    #${OVERLAY_ID} button.mt-dismiss {
+        min-height: 60px;
+        font-size: 16px;
+        padding: 10px 20px;
+    }
+}
+`;
+
+function injectStyle(doc) {
+    if (doc.getElementById(STYLE_ID)) return;
+    const style = doc.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = CSS_TEXT;
+    doc.head.appendChild(style);
+}
+
+function buildOverlay(doc, onDismiss) {
+    const overlay = doc.createElement('div');
+    overlay.id = OVERLAY_ID;
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-label', 'Mobile controls tutorial');
+
+    const card = doc.createElement('div');
+    card.className = 'mt-card';
+
+    const title = doc.createElement('h2');
+    title.className = 'mt-title';
+    title.textContent = 'Welcome to Rainboids';
+    card.appendChild(title);
+
+    const list = doc.createElement('ul');
+    list.className = 'mt-list';
+    for (const item of TUTORIAL_ITEMS) {
+        const li = doc.createElement('li');
+        li.className = 'mt-item';
+
+        const iconSpan = doc.createElement('span');
+        iconSpan.className = 'mt-icon';
+        iconSpan.setAttribute('aria-hidden', 'true');
+        iconSpan.textContent = item.icon;
+        li.appendChild(iconSpan);
+
+        const textSpan = doc.createElement('span');
+        textSpan.className = 'mt-text';
+        textSpan.textContent = item.text;
+        li.appendChild(textSpan);
+
+        list.appendChild(li);
+    }
+    card.appendChild(list);
+
+    const button = doc.createElement('button');
+    button.id = DISMISS_BUTTON_ID;
+    button.type = 'button';
+    button.className = 'mt-dismiss';
+    button.textContent = 'Got it!';
+    button.addEventListener('click', onDismiss);
+    card.appendChild(button);
+
+    overlay.appendChild(card);
+    return overlay;
+}
+
+function safeGetItem(storage, key) {
+    if (!storage) return null;
+    try { return storage.getItem(key); }
+    catch { return null; }
+}
+
+function safeSetItem(storage, key, value) {
+    if (!storage) return;
+    try { storage.setItem(key, value); }
+    catch { /* localStorage may be disabled — silent no-op */ }
+}
+
+function safeRemoveItem(storage, key) {
+    if (!storage) return;
+    try { storage.removeItem(key); }
+    catch { /* silent no-op */ }
+}
+
+function mountInternal(doc, storage) {
+    // Idempotency: if the overlay is already in the DOM, bail out instead
+    // of stacking duplicates. Callers may legitimately re-trigger a
+    // forceMount during debug.
+    if (doc.getElementById(OVERLAY_ID)) {
+        return { mounted: false, reason: 'already-mounted' };
+    }
+    injectStyle(doc);
+    const overlay = buildOverlay(doc, () => {
+        safeSetItem(storage, STORAGE_KEY, '1');
+        if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+    });
+    doc.body.appendChild(overlay);
+    return { mounted: true };
+}
+
+/**
+ * Mount the mobile tutorial overlay if:
+ *   - isMobile() returns true
+ *   - localStorage does NOT have STORAGE_KEY set
+ *
+ * @param {object} [opts]
+ * @param {Document} [opts.document] - Target document (defaults to window.document).
+ * @param {Storage} [opts.storage] - Storage backend (defaults to window.localStorage).
+ * @returns {{ mounted: boolean, reason?: string }}
+ */
+export function mountMobileTutorial({
+    document: doc = (typeof window !== 'undefined' ? window.document : null),
+    storage = (typeof window !== 'undefined' ? window.localStorage : null),
+} = {}) {
+    if (!isMobile()) {
+        return { mounted: false, reason: 'not-mobile' };
+    }
+    if (safeGetItem(storage, STORAGE_KEY)) {
+        return { mounted: false, reason: 'already-seen' };
+    }
+    if (!doc || !doc.body) {
+        return { mounted: false, reason: 'no-document' };
+    }
+    return mountInternal(doc, storage);
+}
+
+/**
+ * Clear the "seen tutorial" flag (for testing or a future
+ * "show tutorial again" feature).
+ *
+ * @param {object} [opts]
+ * @param {Storage} [opts.storage] - Storage backend (defaults to window.localStorage).
+ */
+export function resetTutorialSeen({
+    storage = (typeof window !== 'undefined' ? window.localStorage : null),
+} = {}) {
+    safeRemoveItem(storage, STORAGE_KEY);
+}
+
+/**
+ * Manually mount the tutorial regardless of the "seen" flag and regardless
+ * of the mobile-detection check. Intended for debug, replay, and tests.
+ *
+ * @param {object} [opts]
+ * @param {Document} [opts.document] - Target document (defaults to window.document).
+ * @param {Storage} [opts.storage] - Storage backend (defaults to window.localStorage).
+ * @returns {{ mounted: boolean, reason?: string }}
+ */
+export function forceMountTutorial({
+    document: doc = (typeof window !== 'undefined' ? window.document : null),
+    storage = (typeof window !== 'undefined' ? window.localStorage : null),
+} = {}) {
+    if (!doc || !doc.body) {
+        return { mounted: false, reason: 'no-document' };
+    }
+    return mountInternal(doc, storage);
+}
+
+// Test-only constants. Exported so the unit suite can locate elements
+// without re-encoding hard-coded id strings.
+export const __TEST_ONLY__ = Object.freeze({
+    OVERLAY_ID,
+    STYLE_ID,
+    DISMISS_BUTTON_ID,
+    TUTORIAL_ITEMS,
+});

--- a/tests/unit/platform/haptic.test.js
+++ b/tests/unit/platform/haptic.test.js
@@ -1,0 +1,165 @@
+/**
+ * tests/unit/platform/haptic.test.js
+ *
+ * Unit tests for js/modules/platform/haptic.js. Runs in Node.js; we
+ * manipulate the global window / navigator shims to simulate mobile vs
+ * desktop and to mock / un-mock navigator.vibrate.
+ *
+ * The platform-detect module caches the `?mobile=` URL override at
+ * import time; we reset it via the exported _resetUrlOverrideForTests
+ * helper so each test can independently force mobile mode on or off.
+ *
+ * We use `allure-jest/node` as the env (see jest.config.js), which
+ * doesn't expose `jest` as a top-level global under experimental-vm-
+ * modules — so we pull it from `@jest/globals` explicitly, matching the
+ * convention used by tests/unit/net/loopback-connection.test.js.
+ */
+
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+beforeEach(async () => {
+    // Reset to a clean mobile baseline (touch + small viewport) so vibrate()
+    // can run by default. Individual tests override for desktop or no-API
+    // scenarios.
+    globalThis.window = {
+        innerWidth: 400,
+        innerHeight: 800,
+        location: { search: '' },
+        matchMedia: () => ({ matches: false }),
+    };
+    globalThis.navigator = {
+        maxTouchPoints: 5,
+        vibrate: jest.fn(() => true),
+    };
+    const mod = await import('../../../js/modules/platform/platform-detect.js');
+    mod._resetUrlOverrideForTests(null);
+});
+
+afterAll(() => {
+    delete globalThis.window;
+    delete globalThis.navigator;
+});
+
+async function loadHaptic() {
+    return import('../../../js/modules/platform/haptic.js');
+}
+
+describe('vibrate', () => {
+    it('calls navigator.vibrate(50) when isMobile + API present', async () => {
+        const mod = await loadHaptic();
+        const result = mod.vibrate(50);
+        expect(result).toBe(true);
+        expect(globalThis.navigator.vibrate).toHaveBeenCalledTimes(1);
+        expect(globalThis.navigator.vibrate).toHaveBeenCalledWith(50);
+    });
+
+    it('calls navigator.vibrate with an array pattern', async () => {
+        const mod = await loadHaptic();
+        const result = mod.vibrate([10, 20, 10]);
+        expect(result).toBe(true);
+        expect(globalThis.navigator.vibrate).toHaveBeenCalledTimes(1);
+        expect(globalThis.navigator.vibrate).toHaveBeenCalledWith([10, 20, 10]);
+    });
+
+    it('returns false when isMobile() is false (desktop)', async () => {
+        // Force desktop: no touch + large viewport.
+        globalThis.navigator.maxTouchPoints = 0;
+        globalThis.window.innerWidth = 1920;
+        globalThis.window.innerHeight = 1080;
+        const platform = await import('../../../js/modules/platform/platform-detect.js');
+        platform._resetUrlOverrideForTests(null);
+
+        const mod = await loadHaptic();
+        const result = mod.vibrate(50);
+        expect(result).toBe(false);
+        expect(globalThis.navigator.vibrate).not.toHaveBeenCalled();
+    });
+
+    it('returns false when navigator.vibrate is undefined (iOS Safari)', async () => {
+        delete globalThis.navigator.vibrate;
+        const mod = await loadHaptic();
+        const result = mod.vibrate(50);
+        expect(result).toBe(false);
+    });
+
+    it('returns false when navigator.vibrate throws', async () => {
+        globalThis.navigator.vibrate = jest.fn(() => {
+            throw new TypeError('Invalid pattern');
+        });
+        const mod = await loadHaptic();
+        const result = mod.vibrate([-1]);
+        expect(result).toBe(false);
+        expect(globalThis.navigator.vibrate).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('isHapticSupported', () => {
+    it('returns true when isMobile + API present', async () => {
+        const mod = await loadHaptic();
+        expect(mod.isHapticSupported()).toBe(true);
+    });
+
+    it('returns false when not on mobile', async () => {
+        globalThis.navigator.maxTouchPoints = 0;
+        globalThis.window.innerWidth = 1920;
+        globalThis.window.innerHeight = 1080;
+        const platform = await import('../../../js/modules/platform/platform-detect.js');
+        platform._resetUrlOverrideForTests(null);
+
+        const mod = await loadHaptic();
+        expect(mod.isHapticSupported()).toBe(false);
+    });
+
+    it('returns false when API is missing even on mobile', async () => {
+        delete globalThis.navigator.vibrate;
+        const mod = await loadHaptic();
+        expect(mod.isHapticSupported()).toBe(false);
+    });
+});
+
+describe('cancelVibrate', () => {
+    it('calls navigator.vibrate(0)', async () => {
+        const mod = await loadHaptic();
+        const result = mod.cancelVibrate();
+        expect(result).toBe(true);
+        expect(globalThis.navigator.vibrate).toHaveBeenCalledTimes(1);
+        expect(globalThis.navigator.vibrate).toHaveBeenCalledWith(0);
+    });
+});
+
+describe('HAPTIC presets', () => {
+    it('HAPTIC.LIGHT is a small positive number', async () => {
+        const mod = await loadHaptic();
+        expect(typeof mod.HAPTIC.LIGHT).toBe('number');
+        expect(mod.HAPTIC.LIGHT).toBeGreaterThan(0);
+        expect(mod.HAPTIC.LIGHT).toBeLessThan(50);
+    });
+
+    it('HAPTIC.DOUBLE is an array of numbers', async () => {
+        const mod = await loadHaptic();
+        expect(Array.isArray(mod.HAPTIC.DOUBLE)).toBe(true);
+        expect(mod.HAPTIC.DOUBLE.length).toBeGreaterThan(1);
+        for (const n of mod.HAPTIC.DOUBLE) {
+            expect(typeof n).toBe('number');
+            expect(n).toBeGreaterThan(0);
+        }
+    });
+});
+
+describe('URL override interop', () => {
+    it('?mobile=1 forces isMobile() true so vibrate() works on a desktop shim', async () => {
+        // Strip touch + use a desktop viewport — without the override,
+        // isMobile() would return false and vibrate() would no-op.
+        globalThis.navigator.maxTouchPoints = 0;
+        globalThis.window.innerWidth = 1920;
+        globalThis.window.innerHeight = 1080;
+        globalThis.window.location.search = '?mobile=1';
+        const platform = await import('../../../js/modules/platform/platform-detect.js');
+        platform._resetUrlOverrideForTests(); // re-read from current search
+
+        const mod = await loadHaptic();
+        const result = mod.vibrate(mod.HAPTIC.MEDIUM);
+        expect(result).toBe(true);
+        expect(globalThis.navigator.vibrate).toHaveBeenCalledWith(mod.HAPTIC.MEDIUM);
+    });
+});

--- a/tests/unit/platform/wake-lock.test.js
+++ b/tests/unit/platform/wake-lock.test.js
@@ -1,0 +1,298 @@
+/**
+ * tests/unit/platform/wake-lock.test.js
+ *
+ * Unit tests for js/modules/platform/wake-lock.js. Runs in Node.js; we
+ * manipulate the global window / navigator / document shims to simulate
+ * mobile vs desktop, mock navigator.wakeLock, and drive visibilitychange
+ * events for the auto-reacquire path.
+ *
+ * The platform-detect module caches the `?mobile=` URL override at
+ * import time; we reset it via the exported _resetUrlOverrideForTests
+ * helper so each test starts from a clean mobile baseline. We also
+ * call wake-lock's exported _resetForTests() so the module-scoped
+ * sentinel and intent flag don't leak between cases.
+ *
+ * We use `allure-jest/node` as the env (see jest.config.js), which
+ * doesn't expose `jest` as a top-level global under experimental-vm-
+ * modules — so we pull it from `@jest/globals` explicitly, matching the
+ * convention used by tests/unit/platform/haptic.test.js.
+ */
+
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+/**
+ * Build a fresh sentinel mock per acquisition. Each one has its own
+ * release() spy and an addEventListener that records the 'release'
+ * handler so tests can fire the browser-released event manually.
+ */
+function makeSentinel() {
+    const listeners = {};
+    return {
+        released: false,
+        release: jest.fn(function () {
+            this.released = true;
+            // Fire the registered 'release' event listeners synchronously
+            // — matches how a real implementation cleans up after a
+            // direct sentinel.release() call.
+            if (listeners.release) {
+                for (const fn of listeners.release) fn();
+            }
+            return Promise.resolve();
+        }),
+        addEventListener: jest.fn(function (event, fn) {
+            if (!listeners[event]) listeners[event] = [];
+            listeners[event].push(fn);
+        }),
+        // Test-only: trigger the 'released' event as if the browser
+        // released the lock independently (e.g. on tab hide).
+        _fireRelease() {
+            if (listeners.release) {
+                for (const fn of listeners.release) fn();
+            }
+        },
+    };
+}
+
+beforeEach(async () => {
+    // Mobile baseline: touch device with a small viewport so isMobile()
+    // returns true unless a test explicitly forces desktop.
+    globalThis.window = {
+        innerWidth: 400,
+        innerHeight: 800,
+        location: { search: '' },
+        matchMedia: () => ({ matches: false }),
+    };
+    globalThis.navigator = {
+        maxTouchPoints: 5,
+        wakeLock: {
+            request: jest.fn(async (_type) => makeSentinel()),
+        },
+    };
+    // Document mock with a tiny event-bus so we can fire visibilitychange.
+    const docListeners = {};
+    globalThis.document = {
+        visibilityState: 'visible',
+        addEventListener: jest.fn((event, fn) => {
+            if (!docListeners[event]) docListeners[event] = [];
+            docListeners[event].push(fn);
+        }),
+        removeEventListener: jest.fn(),
+        _fire(event) {
+            if (docListeners[event]) {
+                for (const fn of docListeners[event]) fn();
+            }
+        },
+    };
+    // Expose document on window too so the default-arg `window.document`
+    // in attachAutoReacquireHandler resolves cleanly.
+    globalThis.window.document = globalThis.document;
+
+    const platform = await import('../../../js/modules/platform/platform-detect.js');
+    platform._resetUrlOverrideForTests(null);
+    const wakeLock = await import('../../../js/modules/platform/wake-lock.js');
+    wakeLock._resetForTests();
+});
+
+afterAll(() => {
+    delete globalThis.window;
+    delete globalThis.navigator;
+    delete globalThis.document;
+});
+
+async function loadWakeLock() {
+    return import('../../../js/modules/platform/wake-lock.js');
+}
+
+describe('requestWakeLock', () => {
+    it('returns false on desktop (isMobile false)', async () => {
+        globalThis.navigator.maxTouchPoints = 0;
+        globalThis.window.innerWidth = 1920;
+        globalThis.window.innerHeight = 1080;
+        const platform = await import('../../../js/modules/platform/platform-detect.js');
+        platform._resetUrlOverrideForTests(null);
+
+        const mod = await loadWakeLock();
+        const result = await mod.requestWakeLock();
+        expect(result).toBe(false);
+        expect(globalThis.navigator.wakeLock.request).not.toHaveBeenCalled();
+        expect(mod.isWakeLockHeld()).toBe(false);
+    });
+
+    it('returns false when navigator.wakeLock is missing', async () => {
+        delete globalThis.navigator.wakeLock;
+        const mod = await loadWakeLock();
+        const result = await mod.requestWakeLock();
+        expect(result).toBe(false);
+        expect(mod.isWakeLockHeld()).toBe(false);
+    });
+
+    it('returns true when mobile + API present + acquisition succeeds', async () => {
+        const mod = await loadWakeLock();
+        const result = await mod.requestWakeLock();
+        expect(result).toBe(true);
+        expect(globalThis.navigator.wakeLock.request).toHaveBeenCalledTimes(1);
+        expect(globalThis.navigator.wakeLock.request).toHaveBeenCalledWith('screen');
+        expect(mod.isWakeLockHeld()).toBe(true);
+    });
+
+    it('returns false when navigator.wakeLock.request() throws', async () => {
+        globalThis.navigator.wakeLock.request = jest.fn(async () => {
+            throw new Error('NotAllowedError: low battery');
+        });
+        const mod = await loadWakeLock();
+        const result = await mod.requestWakeLock();
+        expect(result).toBe(false);
+        expect(mod.isWakeLockHeld()).toBe(false);
+    });
+
+    it('is idempotent: second call returns true without re-acquiring', async () => {
+        const mod = await loadWakeLock();
+        const r1 = await mod.requestWakeLock();
+        const r2 = await mod.requestWakeLock();
+        expect(r1).toBe(true);
+        expect(r2).toBe(true);
+        // The underlying API should only have been called once; the
+        // second request must reuse the existing sentinel.
+        expect(globalThis.navigator.wakeLock.request).toHaveBeenCalledTimes(1);
+        expect(mod.isWakeLockHeld()).toBe(true);
+    });
+});
+
+describe('releaseWakeLock', () => {
+    it('calls sentinel.release() and clears held state', async () => {
+        // Capture the sentinel that the request returns so we can
+        // assert on its release() spy after the fact.
+        let acquired;
+        globalThis.navigator.wakeLock.request = jest.fn(async () => {
+            acquired = makeSentinel();
+            return acquired;
+        });
+        const mod = await loadWakeLock();
+        await mod.requestWakeLock();
+        expect(mod.isWakeLockHeld()).toBe(true);
+
+        const result = await mod.releaseWakeLock();
+        expect(result).toBe(true);
+        expect(acquired.release).toHaveBeenCalledTimes(1);
+        expect(mod.isWakeLockHeld()).toBe(false);
+    });
+
+    it('returns false when no lock is held', async () => {
+        const mod = await loadWakeLock();
+        const result = await mod.releaseWakeLock();
+        expect(result).toBe(false);
+    });
+});
+
+describe('isWakeLockHeld', () => {
+    it('returns false initially', async () => {
+        const mod = await loadWakeLock();
+        expect(mod.isWakeLockHeld()).toBe(false);
+    });
+
+    it('returns true after a successful request', async () => {
+        const mod = await loadWakeLock();
+        await mod.requestWakeLock();
+        expect(mod.isWakeLockHeld()).toBe(true);
+    });
+});
+
+describe('isWakeLockSupported', () => {
+    it('returns true when navigator.wakeLock.request is present', async () => {
+        const mod = await loadWakeLock();
+        expect(mod.isWakeLockSupported()).toBe(true);
+    });
+
+    it('returns false when navigator.wakeLock is missing', async () => {
+        delete globalThis.navigator.wakeLock;
+        const mod = await loadWakeLock();
+        expect(mod.isWakeLockSupported()).toBe(false);
+    });
+
+    it('is independent of isMobile (returns true on a desktop shim with API present)', async () => {
+        // Force desktop in platform-detect, but keep navigator.wakeLock
+        // populated. The support check is a pure capability test and
+        // must not gate on isMobile().
+        globalThis.navigator.maxTouchPoints = 0;
+        globalThis.window.innerWidth = 1920;
+        globalThis.window.innerHeight = 1080;
+        const platform = await import('../../../js/modules/platform/platform-detect.js');
+        platform._resetUrlOverrideForTests(null);
+
+        const mod = await loadWakeLock();
+        expect(mod.isWakeLockSupported()).toBe(true);
+    });
+});
+
+describe('attachAutoReacquireHandler', () => {
+    it('adds a visibilitychange listener to the document', async () => {
+        const mod = await loadWakeLock();
+        mod.attachAutoReacquireHandler();
+        expect(globalThis.document.addEventListener).toHaveBeenCalledWith(
+            'visibilitychange',
+            expect.any(Function)
+        );
+    });
+
+    it('re-requests when visibility returns to visible and a lock was previously held', async () => {
+        const mod = await loadWakeLock();
+        mod.attachAutoReacquireHandler();
+
+        // First: acquire a lock, then simulate the browser auto-releasing
+        // it (as happens when the tab is hidden). The 'release' event on
+        // the sentinel clears _currentLock but leaves _shouldHoldLock set,
+        // which is exactly the state the auto-reacquire handler expects.
+        await mod.requestWakeLock();
+        expect(mod.isWakeLockHeld()).toBe(true);
+        const requestCallsBefore = globalThis.navigator.wakeLock.request.mock.calls.length;
+
+        // Grab the most recent sentinel and trigger its 'release' event
+        // to mimic browser-side auto-release on tab hide.
+        const lastReturnedSentinel = await globalThis.navigator.wakeLock.request.mock.results[0].value;
+        lastReturnedSentinel._fireRelease();
+        expect(mod.isWakeLockHeld()).toBe(false);
+
+        // Now fire visibilitychange with state === 'visible'. The handler
+        // should re-request because _shouldHoldLock is still true.
+        globalThis.document.visibilityState = 'visible';
+        globalThis.document._fire('visibilitychange');
+        // requestWakeLock is async; wait a microtask for it to resolve.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(globalThis.navigator.wakeLock.request.mock.calls.length).toBeGreaterThan(requestCallsBefore);
+        expect(mod.isWakeLockHeld()).toBe(true);
+    });
+
+    it('does not re-request when visibility becomes hidden', async () => {
+        const mod = await loadWakeLock();
+        mod.attachAutoReacquireHandler();
+
+        await mod.requestWakeLock();
+        const lastReturnedSentinel = await globalThis.navigator.wakeLock.request.mock.results[0].value;
+        lastReturnedSentinel._fireRelease();
+        const requestCallsBefore = globalThis.navigator.wakeLock.request.mock.calls.length;
+
+        globalThis.document.visibilityState = 'hidden';
+        globalThis.document._fire('visibilitychange');
+        await Promise.resolve();
+
+        expect(globalThis.navigator.wakeLock.request.mock.calls.length).toBe(requestCallsBefore);
+    });
+
+    it('does not re-request after releaseWakeLock() has cleared the intent', async () => {
+        const mod = await loadWakeLock();
+        mod.attachAutoReacquireHandler();
+
+        await mod.requestWakeLock();
+        await mod.releaseWakeLock();
+        const requestCallsBefore = globalThis.navigator.wakeLock.request.mock.calls.length;
+
+        globalThis.document.visibilityState = 'visible';
+        globalThis.document._fire('visibilitychange');
+        await Promise.resolve();
+
+        expect(globalThis.navigator.wakeLock.request.mock.calls.length).toBe(requestCallsBefore);
+        expect(mod.isWakeLockHeld()).toBe(false);
+    });
+});

--- a/tests/unit/ui/mobile-tutorial.test.js
+++ b/tests/unit/ui/mobile-tutorial.test.js
@@ -1,0 +1,195 @@
+/**
+ * @jest-environment allure-jest/jsdom
+ */
+
+/**
+ * tests/unit/ui/mobile-tutorial.test.js — unit tests for the mobile
+ * first-run tutorial overlay (js/modules/ui/mobile-tutorial.js).
+ *
+ * The overlay is built entirely via DOM creation + an injected <style>
+ * tag, so these tests run under jsdom (via the `allure-jest/jsdom`
+ * environment) to exercise real createElement / appendChild /
+ * getElementById behavior.
+ *
+ * `isMobile()` from `js/modules/platform/platform-detect.js` is not
+ * stubbed via jest.mock — ESM exports are read-only under the
+ * experimental VM modules loader. Instead, we use the URL-override
+ * hook (`_resetUrlOverrideForTests`) to flip the mobile/desktop state.
+ * This is the same pattern the mobile-auto-fire test suite uses.
+ *
+ * jsdom-provided localStorage is wiped between tests for isolation.
+ */
+
+import {
+    mountMobileTutorial,
+    resetTutorialSeen,
+    forceMountTutorial,
+    STORAGE_KEY,
+    __TEST_ONLY__,
+} from '../../../js/modules/ui/mobile-tutorial.js';
+import { _resetUrlOverrideForTests } from '../../../js/modules/platform/platform-detect.js';
+
+const { OVERLAY_ID, STYLE_ID, DISMISS_BUTTON_ID, TUTORIAL_ITEMS } = __TEST_ONLY__;
+
+// Force mobile / desktop by flipping the `?mobile=` URL override that
+// platform-detect.js caches at module load. `true` = always mobile,
+// `false` = always desktop, `null` = re-read from window.location.
+function setMobile(force) {
+    _resetUrlOverrideForTests(force);
+}
+
+beforeEach(() => {
+    // Clean DOM between tests so id-based lookups don't cross-pollinate.
+    document.body.innerHTML = '';
+    document.head.innerHTML = '';
+    window.localStorage.clear();
+    setMobile(true); // default: pretend we're on a mobile device
+});
+
+afterAll(() => {
+    setMobile(null);
+});
+
+describe('mountMobileTutorial — gating', () => {
+    it('returns { mounted: false, reason: "not-mobile" } when isMobile is false', () => {
+        setMobile(false);
+        const result = mountMobileTutorial();
+        expect(result).toEqual({ mounted: false, reason: 'not-mobile' });
+        expect(document.getElementById(OVERLAY_ID)).toBeNull();
+    });
+
+    it('returns { mounted: false, reason: "already-seen" } when storage flag is set', () => {
+        window.localStorage.setItem(STORAGE_KEY, '1');
+        const result = mountMobileTutorial();
+        expect(result).toEqual({ mounted: false, reason: 'already-seen' });
+        expect(document.getElementById(OVERLAY_ID)).toBeNull();
+    });
+
+    it('returns { mounted: true } when mobile + no flag', () => {
+        const result = mountMobileTutorial();
+        expect(result).toEqual({ mounted: true });
+    });
+});
+
+describe('mountMobileTutorial — DOM construction', () => {
+    it('mounts an overlay element into the document', () => {
+        mountMobileTutorial();
+        const overlay = document.getElementById(OVERLAY_ID);
+        expect(overlay).not.toBeNull();
+        expect(overlay.parentNode).toBe(document.body);
+    });
+
+    it('injects a <style> element into document.head', () => {
+        mountMobileTutorial();
+        const style = document.getElementById(STYLE_ID);
+        expect(style).not.toBeNull();
+        expect(style.tagName.toLowerCase()).toBe('style');
+        expect(style.parentNode).toBe(document.head);
+        // sanity: rule references the overlay id
+        expect(style.textContent).toContain(`#${OVERLAY_ID}`);
+    });
+
+    it('renders exactly 4 instructional items', () => {
+        mountMobileTutorial();
+        const items = document.querySelectorAll(`#${OVERLAY_ID} .mt-item`);
+        expect(items.length).toBe(4);
+        // Exported list is the source of truth.
+        expect(TUTORIAL_ITEMS).toHaveLength(4);
+        for (let i = 0; i < TUTORIAL_ITEMS.length; i++) {
+            const li = items[i];
+            expect(li.textContent).toContain(TUTORIAL_ITEMS[i].icon);
+            expect(li.textContent).toContain(TUTORIAL_ITEMS[i].text);
+        }
+    });
+
+    it('renders a dismiss button with touch-target ≥ 44px height', () => {
+        mountMobileTutorial();
+        const button = document.getElementById(DISMISS_BUTTON_ID);
+        expect(button).not.toBeNull();
+        expect(button.tagName.toLowerCase()).toBe('button');
+        expect(button.textContent).toBe('Got it!');
+        // The CSS rule for `.mt-dismiss` sets min-height: 60px (well above
+        // the 44px Apple HIG / Material accessibility floor). Verify by
+        // scraping the injected stylesheet — jsdom does not compute
+        // layout, so we assert the rule text instead of getBoundingClientRect.
+        const css = document.getElementById(STYLE_ID).textContent;
+        const match = css.match(/button\.mt-dismiss\s*\{[^}]*min-height:\s*(\d+)px/);
+        expect(match).not.toBeNull();
+        const minHeightPx = parseInt(match[1], 10);
+        expect(minHeightPx).toBeGreaterThanOrEqual(44);
+    });
+
+    it('ships distinct portrait + landscape font-size rules for readable text', () => {
+        mountMobileTutorial();
+        const css = document.getElementById(STYLE_ID).textContent;
+        // Portrait (default) .mt-item font-size = 18px (per spec).
+        const portraitMatch = css.match(/#mobile-tutorial-overlay \.mt-item\s*\{[^}]*font-size:\s*(\d+)px/);
+        expect(portraitMatch).not.toBeNull();
+        const portraitPx = parseInt(portraitMatch[1], 10);
+        expect(portraitPx).toBe(18);
+        // Landscape override exists with a smaller font-size.
+        expect(css).toMatch(/@media \(orientation: landscape\)/);
+        const landscapeBlock = css.split('@media (orientation: landscape)')[1];
+        expect(landscapeBlock).toBeDefined();
+        const landscapeMatch = landscapeBlock.match(/\.mt-item\s*\{[^}]*font-size:\s*(\d+)px/);
+        expect(landscapeMatch).not.toBeNull();
+        const landscapePx = parseInt(landscapeMatch[1], 10);
+        expect(landscapePx).toBeLessThan(portraitPx);
+    });
+});
+
+describe('mountMobileTutorial — dismissal', () => {
+    it('clicking the dismiss button removes the overlay and sets the storage flag', () => {
+        mountMobileTutorial();
+        const button = document.getElementById(DISMISS_BUTTON_ID);
+        expect(document.getElementById(OVERLAY_ID)).not.toBeNull();
+        button.click();
+        expect(document.getElementById(OVERLAY_ID)).toBeNull();
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe('1');
+    });
+
+    it('after dismissal, a subsequent mount call returns "already-seen"', () => {
+        mountMobileTutorial();
+        document.getElementById(DISMISS_BUTTON_ID).click();
+        const second = mountMobileTutorial();
+        expect(second).toEqual({ mounted: false, reason: 'already-seen' });
+    });
+});
+
+describe('resetTutorialSeen', () => {
+    it('clears the storage flag so the tutorial can be shown again', () => {
+        window.localStorage.setItem(STORAGE_KEY, '1');
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe('1');
+        resetTutorialSeen();
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+        // Mount should now succeed again.
+        const result = mountMobileTutorial();
+        expect(result).toEqual({ mounted: true });
+    });
+});
+
+describe('forceMountTutorial', () => {
+    it('mounts even when the storage flag is set', () => {
+        window.localStorage.setItem(STORAGE_KEY, '1');
+        const result = forceMountTutorial();
+        expect(result).toEqual({ mounted: true });
+        expect(document.getElementById(OVERLAY_ID)).not.toBeNull();
+    });
+
+    it('two consecutive calls do not duplicate-mount (idempotent)', () => {
+        const first = forceMountTutorial();
+        expect(first).toEqual({ mounted: true });
+        const second = forceMountTutorial();
+        expect(second).toEqual({ mounted: false, reason: 'already-mounted' });
+        // Exactly one overlay node, exactly one style node.
+        expect(document.querySelectorAll(`#${OVERLAY_ID}`).length).toBe(1);
+        expect(document.querySelectorAll(`#${STYLE_ID}`).length).toBe(1);
+    });
+
+    it('mounts even when isMobile is false (debug / replay path)', () => {
+        setMobile(false);
+        const result = forceMountTutorial();
+        expect(result).toEqual({ mounted: true });
+        expect(document.getElementById(OVERLAY_ID)).not.toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
Three NEW mobile UX modules, all **Phase 1 scaffold** — modules + tests only, no integration in player/game-engine yet. Dead code today; follow-up PR will wire them into specific gameplay events.

**No version bump** — per CLAUDE.md, scaffolding with no runtime effect doesn't warrant one. Bumping happens when integration lands.

## Modules

### \`js/modules/platform/haptic.js\` (NEW, 93 lines)
- \`vibrate(pattern)\` — gated by \`isMobile()\` + \`navigator.vibrate\` API
- \`isHapticSupported()\`, \`cancelVibrate()\`
- \`HAPTIC\` constants: \`LIGHT=10\`, \`MEDIUM=25\`, \`HEAVY=50\`, \`DOUBLE=[15,30,15]\`, \`LONG=100\`
- Try/catch wraps API calls (iOS Safari has no API; some Androids throw)

### \`js/modules/platform/wake-lock.js\` (NEW, 207 lines)
- \`requestWakeLock()\` / \`releaseWakeLock()\` — async; mobile + API gated; idempotent
- \`isWakeLockHeld()\` / \`isWakeLockSupported()\` — sync inspection
- \`attachAutoReacquireHandler()\` — visibilitychange listener re-requests when tab returns visible (browsers auto-release on tab hide)

### \`js/modules/ui/mobile-tutorial.js\` (NEW, 297 lines)
- \`mountMobileTutorial({document, storage})\` → \`{mounted, reason}\`
- Gated on \`isMobile()\` + localStorage flag
- Full-screen overlay, 4 instructional items (tap-to-shoot, auto-dodge, long-press radial, auto-fire)
- Dismiss button sets \`'rainboids:mobile-tutorial-seen'\`
- CSS injected programmatically into \`document.head\` (no \`styles.css\` edit)
- \`resetTutorialSeen()\` / \`forceMountTutorial()\` for debug/replay

## Future integration (next PR)
- Player hit → \`vibrate(HAPTIC.MEDIUM)\`; enemy killed → \`HAPTIC.HEAVY\`; game over → \`HAPTIC.LONG\`
- Gameplay starts → \`requestWakeLock()\`; game over → \`releaseWakeLock()\`
- \`main.js\` after title screen renders → \`mountMobileTutorial()\` on first mobile load

## Test plan
- [x] +42 new tests (12 haptic, 14 tutorial, 16 wake-lock)
- [x] Full unit suite 858/858 across 34 suites, no regressions
- [x] All modules import-only from existing platform-detect.js
- [x] No \`styles.css\` / \`index.html\` / \`main.js\` / game-engine edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)